### PR TITLE
  feat(snapshot): track specific columns in snap_yuman__users                                                                                                                               

### DIFF
--- a/models/staging/yuman/stg_yuman__users.sql
+++ b/models/staging/yuman/stg_yuman__users.sql
@@ -22,6 +22,11 @@ cleaned_users as (
             from unnest(json_query_array(_embed_fields)) as field
             where json_value(field, '$.name') = 'ID NOMAD'
         ) as nomad_id,
+        (
+            select json_value(field, '$.value')
+            from unnest(json_query_array(_embed_fields)) as field
+            where json_value(field, '$.name') = 'SECTEUR'
+        ) as user_secteur,
         name as user_name,
         email as user_email,
         user_type,

--- a/snapshots/yuman/snap_yuman__users.sql
+++ b/snapshots/yuman/snap_yuman__users.sql
@@ -3,9 +3,10 @@
 -- ==============================================================================
 -- Source: stg_yuman__users
 -- Purpose: Track historical changes of Yuman app users — captures reassignments,
---          email changes, and hard deletes (user removed from Yuman)
--- Strategy: Timestamp — creates a new record whenever updated_at changes
--- Tracked columns: all (via updated_at bump from Yuman)
+--          role/sector changes, and hard deletes (user removed from Yuman)
+-- Strategy: Check — creates a new record only when tracked columns change
+-- Tracked columns: manager_id, nomad_id, user_name, user_type, user_secteur,
+--                  is_manager_as_technician
 --
 -- Usage:
 --   Query current: SELECT * FROM snapshots.snap_yuman__users WHERE dbt_valid_to IS NULL
@@ -17,8 +18,8 @@
 {{
     config(
       unique_key='user_id',
-      strategy='timestamp',
-      updated_at='updated_at',
+      strategy='check',
+      check_cols=['manager_id', 'nomad_id', 'user_name', 'user_type', 'user_secteur', 'is_manager_as_technician'],
       invalidate_hard_deletes=True,
       tags=['yuman']
     )
@@ -31,13 +32,14 @@
 
     select
         user_id,
-        manager_id,
-        nomad_id,           -- TRACKED via updated_at
-        user_name,          -- TRACKED via updated_at
-        user_email,         -- TRACKED via updated_at
-        user_type,
+        manager_id,         -- TRACKED
+        nomad_id,           -- TRACKED
+        user_name,          -- TRACKED
+        user_email,
+        user_type,          -- TRACKED
         user_phone,
-        is_manager_as_technician,
+        user_secteur,       -- TRACKED
+        is_manager_as_technician, -- TRACKED
         created_at,
         updated_at,
         extracted_at


### PR DESCRIPTION
  What                                                                                                                                                                                    
                                                                                                                                                                                            
  - Added user_secteur field to stg_yuman__users (extracted from _embed_fields JSON under key SECTEUR)                                                                                      
  - Switched snap_yuman__users from strategy='timestamp' to strategy='check' to avoid noisy SCD2 records
                                                                                                                                                                                            
  Why             
                                                                                                                                                                                            
  The timestamp strategy was triggering a new snapshot record on every updated_at bump, even when none of the meaningful business columns changed. With strategy='check', a new historical  
  record is only created when one of the tracked columns actually changes.
                                                                                                                                                                                            
  Tracked columns                                                                                                                                                                           
   
  manager_id · nomad_id · user_name · user_type · user_secteur · is_manager_as_technician                                                                                                   
                  
  Notes                                                                                                                                                                                     
                  
  - Snapshot table was manually dropped in BigQuery and rebuilt from scratch (dbt snapshot --target prod) — no historical data loss (snapshot was created the day before)                   
  - All staging columns are still selected in the snapshot; only the tracked columns above trigger new SCD2 records