### PR TITLE
feat(yuman): add is_active boolean field to stg_yuman__users

### DIFF
--- a/models/staging/yuman/_yuman__models.yml
+++ b/models/staging/yuman/_yuman__models.yml
@@ -132,6 +132,11 @@ models:
       - name: nomad_id
         description: "Identifiant de l'utilisateur dans le système Nomad (si applicable)"
 
+      - name: is_active
+        description: "Indique si l'utilisateur est actif (true) ou inactif (false). Dérivé du champ personnalisé INACTIF (Oui/Non)."
+        tests:
+          - not_null
+
   - name: stg_yuman__workorder_demands_categories
     description: "Catégories de demandes d'intervention transformées et nettoyées depuis l'API Yuman"
     columns:

--- a/models/staging/yuman/stg_yuman__users.sql
+++ b/models/staging/yuman/stg_yuman__users.sql
@@ -32,6 +32,11 @@ cleaned_users as (
         user_type,
         phone as user_phone,
         manager_as_technician as is_manager_as_technician,
+        (
+            select json_value(field, '$.value')
+            from unnest(json_query_array(_embed_fields)) as field
+            where json_value(field, '$.name') = 'INACTIF'
+        ) as user_inactif,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
         timestamp(_sdc_extracted_at) as extracted_at,
@@ -39,7 +44,29 @@ cleaned_users as (
 
     from source_data
 
+),
+
+final as (
+
+    select
+        user_id,
+        manager_id,
+        nomad_id,
+        user_secteur,
+        user_name,
+        user_email,
+        user_type,
+        user_phone,
+        is_manager_as_technician,
+        lower(user_inactif) != 'oui' as is_active,
+        created_at,
+        updated_at,
+        extracted_at,
+        deleted_at
+
+    from cleaned_users
+
 )
 
 select *
-from cleaned_users
+from final

--- a/snapshots/yuman/_yuman__snapshots.yml
+++ b/snapshots/yuman/_yuman__snapshots.yml
@@ -70,6 +70,9 @@ snapshots:
       - name: user_type
         description: User type in Yuman (e.g. guest)
 
+      - name: is_active
+        description: Whether the user is active (true) or inactive (false) — TRACKED for changes. Derived from the custom field INACTIF (Oui/Non).
+
       - name: updated_at
         description: Last update timestamp from Yuman — drives snapshot change detection
 

--- a/snapshots/yuman/snap_yuman__users.sql
+++ b/snapshots/yuman/snap_yuman__users.sql
@@ -6,7 +6,7 @@
 --          role/sector changes, and hard deletes (user removed from Yuman)
 -- Strategy: Check — creates a new record only when tracked columns change
 -- Tracked columns: manager_id, nomad_id, user_name, user_type, user_secteur,
---                  is_manager_as_technician
+--                  is_manager_as_technician, is_active
 --
 -- Usage:
 --   Query current: SELECT * FROM snapshots.snap_yuman__users WHERE dbt_valid_to IS NULL
@@ -19,7 +19,7 @@
     config(
       unique_key='user_id',
       strategy='check',
-      check_cols=['manager_id', 'nomad_id', 'user_name', 'user_type', 'user_secteur', 'is_manager_as_technician'],
+      check_cols=['manager_id', 'nomad_id', 'user_name', 'user_type', 'user_secteur', 'is_manager_as_technician','is_active'],
       invalidate_hard_deletes=True,
       tags=['yuman']
     )
@@ -40,6 +40,7 @@
         user_phone,
         user_secteur,       -- TRACKED
         is_manager_as_technician, -- TRACKED
+        is_active,          -- TRACKED (derived from user_inactif)
         created_at,
         updated_at,
         extracted_at


### PR DESCRIPTION
  Body:                                                                                                                                                                                  
                                                                                                                                                                                         
  ## Summary      
                                                                                                                                                                                         
  - Adds `is_active` (BOOL) to `stg_yuman__users`, derived from the custom embed field `INACTIF` (values `Oui`/`Non`)                                                                    
  - Uses a `final` CTE to convert: `lower(user_inactif) != 'oui'` → `true` = active, `false` = inactive
  - Tracks `is_active` in `snap_yuman__users` (`check_cols`) to capture activation/deactivation events over time                                                                         
  - Updates YAML docs for both the staging model and the snapshot                                                                                                                        
                                                                                                                                                                                         
  ## Why                                                                                                                                                                                 
                  
  The `INACTIF` field existed as a raw string in the embed fields but was never exposed in the staging model.                                                                            
  Downstream consumers (marts, BI) need a clean boolean to filter active users.
                                                                                                                                                                                         
  ## Test plan    
                                                                                                                                                                                         
  - [ ] `dbt build -s stg_yuman__users` passes
  - [ ] `not_null` test on `is_active` passes
  - [ ] Spot-check: user `ASTREINTE Aura` (id 12845, INACTIF = Oui) → `is_active = false`