### PR TITLE
feat(staging): Zoho Desk staging layer

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -64,6 +64,10 @@ models:
       gac:
         +tags: ['staging', 'gac']
 
+      zoho_desk:
+        +tags: ['staging', 'zoho_desk']
+        +materialized: table
+
     intermediate:
       +schema: intermediate
       +tags: ['intermediate']

--- a/docs/architecture/zoho_desk.md
+++ b/docs/architecture/zoho_desk.md
@@ -1,0 +1,229 @@
+# Architecture — Zoho Desk
+
+> Dernière mise à jour : 2026-04-20
+
+---
+
+## Vue d'ensemble
+
+Zoho Desk est le logiciel de support client utilisé pour gérer les tickets entrants
+(email, téléphone, chat, formulaire web). Ce pipeline extrait les données de l'API
+Zoho Desk (EU region) et les rend disponibles dans BigQuery pour l'analyse.
+
+---
+
+## Flux de données
+
+```
+┌─────────────────┐     dlt (Python)     ┌──────────────────────┐
+│   API Zoho Desk │ ──────────────────►  │  prod_raw (BigQuery)  │
+│   EU region     │   extraction full    │  zoho_desk_*          │
+└─────────────────┘   write_disposition  └──────────┬───────────┘
+                        = merge/replace             │
+                                                    │ dbt staging
+                                                    ▼
+                                       ┌──────────────────────────┐
+                                       │  staging (BigQuery)       │
+                                       │  stg_zoho_desk__*         │
+                                       │  matérialisé en TABLE     │
+                                       └──────────────────────────┘
+```
+
+**Ce que fait chaque couche :**
+
+| Couche | Rôle | Localisation |
+|---|---|---|
+| `prod_raw` | Données brutes telles que reçues de l'API — aucune transformation | `evs-datastack-prod.prod_raw` |
+| `staging` | Nettoyage, renommage des PKs, cast des types, documentation | `evs-datastack-prod.staging` |
+| `marts` *(à venir)* | Métriques et dimensions BI-ready | `evs-datastack-prod.marts` |
+
+---
+
+## Modèle de données
+
+### Diagramme des relations
+
+```mermaid
+erDiagram
+
+    stg_zoho_desk__departments {
+        string department_id PK
+        string name
+        boolean is_enabled
+    }
+
+    stg_zoho_desk__agents {
+        string agent_id PK
+        string _dlt_id
+        string email_id
+        string status
+    }
+
+    stg_zoho_desk__accounts {
+        string account_id PK
+        string account_name
+    }
+
+    stg_zoho_desk__contacts {
+        string contact_id PK
+        string email
+        string account_id FK
+    }
+
+    stg_zoho_desk__agent_departments {
+        string _dlt_id PK
+        string _dlt_parent_id FK
+        string department_id FK
+    }
+
+    stg_zoho_desk__tickets {
+        string ticket_id PK
+        string department_id FK
+        string assignee_id FK
+        string contact_id FK
+        string account_id FK
+        string status
+        timestamp created_time
+        timestamp closed_time
+    }
+
+    stg_zoho_desk__ticket_details {
+        string ticket_id PK
+        boolean is_over_due
+        boolean is_escalated
+        string sla_id
+    }
+
+    stg_zoho_desk__ticket_history {
+        string _dlt_id PK
+        string _zoho_desk_associated_tickets_id FK
+        string event_name
+        timestamp event_time
+    }
+
+    stg_zoho_desk__ticket_history_event_info {
+        string _dlt_id PK
+        string _dlt_parent_id FK
+        string property_name
+        string property_value__previous_value
+        string property_value__updated_value
+    }
+
+    %% Dimensions → Tickets
+    stg_zoho_desk__tickets }o--|| stg_zoho_desk__departments : "department_id"
+    stg_zoho_desk__tickets }o--|| stg_zoho_desk__agents : "assignee_id → agent_id"
+    stg_zoho_desk__tickets }o--|| stg_zoho_desk__contacts : "contact_id"
+    stg_zoho_desk__tickets }o--|| stg_zoho_desk__accounts : "account_id"
+
+    %% Contact → Account
+    stg_zoho_desk__contacts }o--|| stg_zoho_desk__accounts : "account_id"
+
+    %% Tickets → enrichissements 1:1
+    stg_zoho_desk__tickets ||--|| stg_zoho_desk__ticket_details : "ticket_id"
+
+    %% Tickets → historique 1:N
+    stg_zoho_desk__tickets ||--o{ stg_zoho_desk__ticket_history : "ticket_id"
+
+    %% Historique → détail événement 1:N
+    stg_zoho_desk__ticket_history ||--o{ stg_zoho_desk__ticket_history_event_info : "_dlt_id"
+
+    %% Agent → départements (bridge)
+    stg_zoho_desk__agents ||--o{ stg_zoho_desk__agent_departments : "_dlt_id"
+    stg_zoho_desk__departments ||--o{ stg_zoho_desk__agent_departments : "department_id"
+```
+
+---
+
+## Rôle de chaque table
+
+### Dimensions — les référentiels
+
+| Table | Ce qu'elle contient | Lignes (~) |
+|---|---|---|
+| `stg_zoho_desk__accounts` | Entreprises clientes | 251 |
+| `stg_zoho_desk__contacts` | Personnes physiques (clients) liées à un compte | 3 362 |
+| `stg_zoho_desk__agents` | Membres de l'équipe support | 5 |
+| `stg_zoho_desk__departments` | Groupes organisationnels (ex : Service Client, Facturation) | 4 |
+| `stg_zoho_desk__agent_departments` | Table pont agent ↔ département (un agent peut appartenir à plusieurs départements) | 11 |
+
+### Facts — les événements
+
+| Table | Ce qu'elle contient | Lignes (~) |
+|---|---|---|
+| `stg_zoho_desk__tickets` | **Table centrale** — un ticket par ligne, avec tous ses attributs courants | 20 678 |
+| `stg_zoho_desk__ticket_details` | Enrichissement 1:1 : flags SLA, champs custom (`cf_*`), résolution | 20 678 |
+| `stg_zoho_desk__ticket_history` | Journal d'audit : un événement par ligne (création, changement de statut, etc.) | 259 677 |
+| `stg_zoho_desk__ticket_history_event_info` | Détail de chaque événement : champ modifié, valeur avant, valeur après | 823 452 |
+
+---
+
+## Jointures clés
+
+### Cas d'usage typiques
+
+**Ticket avec ses dimensions :**
+```sql
+select
+    t.ticket_id,
+    t.ticket_number,
+    t.status,
+    t.created_time,
+    d.name          as department,
+    a.name          as agent_name,
+    c.email         as contact_email,
+    acc.account_name
+from stg_zoho_desk__tickets        t
+left join stg_zoho_desk__departments   d   on d.department_id = t.department_id
+left join stg_zoho_desk__agents        a   on a.agent_id      = t.assignee_id
+left join stg_zoho_desk__contacts      c   on c.contact_id    = t.contact_id
+left join stg_zoho_desk__accounts      acc on acc.account_id  = t.account_id
+```
+
+**Tickets fermés en un mois donné** *(via l'historique — ne pas utiliser `closed_time`)* :
+```sql
+select
+    t.ticket_id,
+    h.event_time as closed_at
+from stg_zoho_desk__ticket_history           h
+join stg_zoho_desk__tickets                  t  on t.ticket_id = h._zoho_desk_associated_tickets_id
+join stg_zoho_desk__ticket_history_event_info ei on ei._dlt_parent_id = h._dlt_id
+where ei.property_name                 = 'Status'
+  and ei.property_value__updated_value = 'Closed'
+  and date_trunc(h.event_time, month)  = '2026-03-01'
+```
+
+**Départements d'un agent :**
+```sql
+select
+    a.agent_id,
+    a.name    as agent_name,
+    d.name    as department_name
+from stg_zoho_desk__agents             a
+join stg_zoho_desk__agent_departments  ad on ad._dlt_parent_id = a._dlt_id
+join stg_zoho_desk__departments        d  on d.department_id   = ad.department_id
+```
+
+---
+
+## Points d'attention
+
+### `closed_time` ne suffit pas pour les métriques temporelles
+`closed_time` sur `stg_zoho_desk__tickets` ne contient que **la fermeture la plus récente**
+et est `NULL` si le ticket a été rouvert. Pour compter les tickets fermés par mois,
+utiliser `stg_zoho_desk__ticket_history` filtré sur `property_name = 'Status'`
+et `property_value__updated_value = 'Closed'`.
+
+### La jointure agent ↔ département passe par `_dlt_id`, pas `agent_id`
+`stg_zoho_desk__agent_departments` est une sous-table générée par dlt à partir
+d'un tableau JSON. La jointure vers l'agent se fait via la clé interne dlt :
+`agent_departments._dlt_parent_id = agents._dlt_id` — **pas** via `agent_id`.
+
+### `ticket_details._zoho_desk_tickets_id` renommé en `ticket_id`
+Dans la source brute, la FK de `ticket_details` se nomme `_zoho_desk_tickets_id`
+(et non `_zoho_desk_associated_tickets_id` comme on pourrait s'y attendre).
+C'est un effet de bord du nommage interne du pipeline dlt.
+Dans le staging, cette colonne est renommée en `ticket_id` pour la cohérence.
+
+### Les champs custom `cf_*` sont tous en `STRING`
+Même les champs qui contiennent des dates ou des booléens — c'est ainsi que
+l'API Zoho les retourne. Caster dans les modèles marts si nécessaire.

--- a/models/staging/zoho_desk/_zoho_desk__models.yml
+++ b/models/staging/zoho_desk/_zoho_desk__models.yml
@@ -138,9 +138,9 @@ models:
               arguments:
                 to: ref('stg_zoho_desk__agents')
                 field: _dlt_id
-      - name: value
+      - name: department_id
         description: >
-          ID du département auquel appartient cet agent.
+          ID du département auquel appartient cet agent (renommé depuis value).
           FK vers stg_zoho_desk__departments.department_id.
         tests:
           - relationships:

--- a/models/staging/zoho_desk/_zoho_desk__models.yml
+++ b/models/staging/zoho_desk/_zoho_desk__models.yml
@@ -1,0 +1,579 @@
+version: 2
+
+# ─────────────────────────────────────────────────────────────────────────────
+# STAGING MODELS : Zoho Desk
+#
+# Convention de nommage des colonnes dans ce layer :
+#   - La colonne `id` de chaque table source est renommée en {entity}_id
+#     pour éviter les ambiguïtés dans les jointures en aval.
+#   - Toutes les autres colonnes gardent leur nom source exact (pas de
+#     renommage des FKs, des colonnes dlt internes, des cf_*, etc.).
+#
+# Convention de test :
+#   - unique + not_null sur toutes les PKs
+#   - not_null sur les FKs obligatoires (mode REQUIRED dans BigQuery)
+#   - relationships pour valider l'intégrité référentielle entre staging models
+#
+# Jointures entre modèles :
+#   stg_tickets ──M:1──► stg_departments       (via department_id)
+#   stg_tickets ──M:1──► stg_agents            (via assignee_id → agent_id)
+#   stg_tickets ──M:1──► stg_contacts          (via contact_id)
+#   stg_tickets ──M:1──► stg_accounts          (via account_id)
+#   stg_contacts ─M:1──► stg_accounts          (via account_id)
+#   stg_ticket_details ─1:1──► stg_tickets     (via _zoho_desk_tickets_id → ticket_id)
+#   stg_ticket_history ─M:1──► stg_tickets     (via _zoho_desk_associated_tickets_id → ticket_id)
+#   stg_ticket_history_event_info ─M:1──► stg_ticket_history  (via _dlt_parent_id → _dlt_id)
+#   stg_agent_departments ─M:1──► stg_agents   (via _dlt_parent_id → _dlt_id)
+#   stg_agent_departments ─M:1──► stg_departments (via value → department_id)
+# ─────────────────────────────────────────────────────────────────────────────
+
+models:
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # DIMENSIONS
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - name: stg_zoho_desk__accounts
+    description: >
+      Comptes Zoho Desk nettoyés = entreprises clientes.
+      Source : prod_raw.zoho_desk_accounts
+      Transformation : id renommé en account_id.
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: account_id
+        description: "PK — identifiant unique du compte (renommé depuis id)"
+        tests:
+          - unique
+          - not_null
+      - name: account_name
+        description: "Nom de l'entreprise cliente"
+      - name: created_time
+        description: "Date de création du compte (TIMESTAMP)"
+      - name: web_url
+        description: "URL de la fiche compte dans Zoho Desk"
+      - name: customer_happiness__bad_percentage
+        description: "% d'évaluations CSAT négatives"
+      - name: customer_happiness__ok_percentage
+        description: "% d'évaluations CSAT neutres"
+      - name: customer_happiness__good_percentage
+        description: "% d'évaluations CSAT positives"
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__agents
+    description: >
+      Agents Zoho Desk nettoyés = membres de l'équipe support.
+      Source : prod_raw.zoho_desk_agents
+      Transformation : id renommé en agent_id.
+      Note : _dlt_id est conservé dans ce modèle car il sert de clé de jointure
+      vers stg_zoho_desk__agent_departments (jointure dlt interne, pas un ID Zoho).
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: agent_id
+        description: "PK — identifiant unique de l'agent (renommé depuis id)"
+        tests:
+          - unique
+          - not_null
+      - name: first_name
+        description: "Prénom de l'agent"
+      - name: last_name
+        description: "Nom de famille de l'agent"
+      - name: name
+        description: "Nom complet de l'agent (concaténé par Zoho)"
+      - name: email_id
+        description: "Adresse e-mail de l'agent"
+      - name: status
+        description: "Statut : ACTIVE ou DISABLED"
+      - name: role_id
+        description: "ID du rôle Zoho"
+      - name: profile_id
+        description: "ID du profil de permissions Zoho"
+      - name: role_permission_type
+        description: "Type de permission (ex : AGENT, ADMINISTRATOR)"
+      - name: time_zone
+        description: "Fuseau horaire de l'agent"
+      - name: lang_code
+        description: "Code langue de l'interface (ex : fr, en)"
+      - name: is_confirmed
+        description: "BOOLEAN — compte e-mail confirmé"
+      - name: is_zia_agent
+        description: "BOOLEAN — agent IA Zoho Zia (bot)"
+      - name: _dlt_id
+        description: >
+          Clé interne dlt — exposée ici car c'est la clé de jointure vers
+          stg_zoho_desk__agent_departments._dlt_parent_id.
+          Ce n'est pas un ID Zoho. Ne pas utiliser dans les rapports BI.
+        tests:
+          - unique
+          - not_null
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__agent_departments
+    description: >
+      Table pont agent ↔ département — dénormalisée depuis le tableau JSON
+      associated_department_ids de l'API Zoho (11 lignes).
+      Source : prod_raw.zoho_desk_agents__associated_department_ids
+      Transformation : aucune (pas de colonne id à renommer dans cette table).
+      Jointures :
+        → agent      : _dlt_parent_id = stg_zoho_desk__agents._dlt_id  (clé dlt interne)
+        → département : value = stg_zoho_desk__departments.department_id (ID Zoho métier)
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: _dlt_id
+        description: "PK interne dlt de cette ligne"
+        tests:
+          - unique
+          - not_null
+      - name: _dlt_parent_id
+        description: >
+          FK interne dlt vers stg_zoho_desk__agents._dlt_id.
+          ATTENTION : jointure sur _dlt_id (clé dlt), pas sur agent_id (ID Zoho).
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__agents')
+                field: _dlt_id
+      - name: value
+        description: >
+          ID du département auquel appartient cet agent.
+          FK vers stg_zoho_desk__departments.department_id.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__departments')
+                field: department_id
+      - name: _dlt_list_idx
+        description: "Position (0-based) de cet élément dans le tableau JSON d'origine"
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__contacts
+    description: >
+      Contacts Zoho Desk nettoyés = personnes physiques (clients) qui ouvrent des tickets.
+      Source : prod_raw.zoho_desk_contacts
+      Transformation : id renommé en contact_id.
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: contact_id
+        description: "PK — identifiant unique du contact (renommé depuis id)"
+        tests:
+          - unique
+          - not_null
+      - name: first_name
+        description: "Prénom du contact"
+      - name: last_name
+        description: "Nom de famille du contact"
+      - name: email
+        description: "Adresse e-mail du contact"
+      - name: phone
+        description: "Numéro de téléphone du contact"
+      - name: account_id
+        description: "FK vers stg_zoho_desk__accounts.account_id — entreprise du contact"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__accounts')
+                field: account_id
+      - name: owner_id
+        description: "ID de l'agent Zoho responsable de ce contact"
+      - name: created_time
+        description: "Date de création du contact (TIMESTAMP)"
+      - name: is_anonymous
+        description: "BOOLEAN — contact anonyme"
+      - name: is_end_user
+        description: "BOOLEAN — utilisateur final (vs agent interne)"
+      - name: is_spam
+        description: "BOOLEAN — contact marqué comme spam"
+      - name: customer_happiness__bad_percentage
+        description: "% d'évaluations CSAT négatives"
+      - name: customer_happiness__ok_percentage
+        description: "% d'évaluations CSAT neutres"
+      - name: customer_happiness__good_percentage
+        description: "% d'évaluations CSAT positives"
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__departments
+    description: >
+      Départements Zoho Desk nettoyés = groupes organisationnels recevant les tickets.
+      Source : prod_raw.zoho_desk_departments
+      Transformation : id renommé en department_id.
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: department_id
+        description: "PK — identifiant unique du département (renommé depuis id)"
+        tests:
+          - unique
+          - not_null
+      - name: name
+        description: "Nom du département (ex : Service Client, Facturation)"
+      - name: description
+        description: "Description libre du département"
+      - name: sanitized_name
+        description: "Nom slugifié (minuscules, sans accents)"
+      - name: name_in_customer_portal
+        description: "Nom affiché dans le portail libre-service client"
+      - name: created_time
+        description: "Date de création du département (TIMESTAMP)"
+      - name: is_enabled
+        description: "BOOLEAN — département actif"
+      - name: is_default
+        description: "BOOLEAN — département sélectionné par défaut à la création d'un ticket"
+      - name: is_visible_in_customer_portal
+        description: "BOOLEAN — visible dans le portail client"
+
+  # ═══════════════════════════════════════════════════════════════════════════
+  # FACTS
+  # ═══════════════════════════════════════════════════════════════════════════
+
+  - name: stg_zoho_desk__tickets
+    description: >
+      Tickets Zoho Desk nettoyés — table centrale de toute l'analyse.
+      Source : prod_raw.zoho_desk_associated_tickets
+      Transformation : id renommé en ticket_id.
+      Pour les métriques temporelles (tickets fermés/rouverts par mois),
+      utiliser stg_zoho_desk__ticket_history — ne pas utiliser closed_time
+      qui ne reflète que la fermeture la plus récente.
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: ticket_id
+        description: "PK — identifiant unique du ticket (renommé depuis id)"
+        tests:
+          - unique
+          - not_null
+      - name: ticket_number
+        description: "Numéro de ticket lisible dans l'interface Zoho (ex : #1234)"
+      - name: subject
+        description: "Objet/sujet du ticket"
+      - name: status
+        description: "Statut courant du ticket (ex : Open, Closed, On Hold)"
+      - name: status_type
+        description: "Catégorie du statut : open, closed, on_hold"
+      - name: priority
+        description: "Priorité : Low, Medium, High, Urgent"
+      - name: channel
+        description: "Canal d'entrée : Email, Phone, Chat, Web, etc."
+      - name: channel_code
+        description: "Code interne Zoho du canal"
+      - name: category
+        description: "Catégorie métier (premier niveau)"
+      - name: sub_category
+        description: "Sous-catégorie métier (deuxième niveau)"
+      - name: language
+        description: "Langue détectée du ticket"
+      - name: department_id
+        description: "FK vers stg_zoho_desk__departments.department_id"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__departments')
+                field: department_id
+      - name: assignee_id
+        description: "FK vers stg_zoho_desk__agents.agent_id — agent actuellement assigné"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__agents')
+                field: agent_id
+      - name: contact_id
+        description: "FK vers stg_zoho_desk__contacts.contact_id — contact ayant ouvert le ticket"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__contacts')
+                field: contact_id
+      - name: account_id
+        description: "FK vers stg_zoho_desk__accounts.account_id — entreprise du contact"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__accounts')
+                field: account_id
+      - name: team_id
+        description: "ID de l'équipe assignée (si applicable)"
+      - name: product_id
+        description: "ID du produit associé (si applicable)"
+      - name: layout_id
+        description: "ID du layout de formulaire Zoho"
+      - name: created_time
+        description: "Date/heure de création du ticket (TIMESTAMP)"
+      - name: closed_time
+        description: >
+          Date/heure de fermeture courante (TIMESTAMP). NULL si jamais fermé ou rouvert.
+          Pour les métriques temporelles, utiliser stg_zoho_desk__ticket_history.
+      - name: due_date
+        description: "Échéance SLA de résolution (TIMESTAMP)"
+      - name: response_due_date
+        description: "Échéance SLA de première réponse (TIMESTAMP)"
+      - name: onhold_time
+        description: "Date/heure de mise en attente (TIMESTAMP)"
+      - name: customer_response_time
+        description: "Date/heure de la dernière réponse client (TIMESTAMP)"
+      - name: comment_count
+        description: "Nombre de commentaires internes (STRING)"
+      - name: thread_count
+        description: "Nombre de threads e-mail/chat (STRING)"
+      - name: is_archived
+        description: "BOOLEAN — ticket archivé"
+      - name: is_spam
+        description: "BOOLEAN — ticket marqué comme spam"
+      - name: sentiment
+        description: "Sentiment détecté par Zoho Zia : Positive, Negative, Neutral"
+      - name: source__type
+        description: "Type de source du ticket"
+      - name: last_thread__direction
+        description: "Direction du dernier thread : inbound / outbound"
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__ticket_details
+    description: >
+      Enrichissement 1:1 par ticket : flags SLA, champs custom (cf_*), résolution, layout.
+      Source : prod_raw.zoho_desk_ticket_details
+      Transformation : _zoho_desk_tickets_id renommé en ticket_id.
+      NOTE sur le nom de la colonne source : la FK se nomme _zoho_desk_tickets_id
+      (et non _zoho_desk_associated_tickets_id) car le transformer dlt était défini
+      avec data_from=tickets. Dans le staging, on renomme en ticket_id pour la cohérence.
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: ticket_id
+        description: >
+          PK et FK — identifiant du ticket associé (renommé depuis _zoho_desk_tickets_id).
+          Jointure : stg_zoho_desk__tickets.ticket_id
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__tickets')
+                field: ticket_id
+      - name: sla_id
+        description: "ID du contrat SLA appliqué"
+      - name: is_over_due
+        description: "BOOLEAN — dépassement de l'échéance SLA de résolution"
+      - name: is_response_overdue
+        description: "BOOLEAN — dépassement de l'échéance SLA de première réponse"
+      - name: is_escalated
+        description: "BOOLEAN — ticket escaladé"
+      - name: resolution
+        description: "Texte de résolution saisi par l'agent à la fermeture"
+      - name: layout_name
+        description: "Nom du layout de formulaire (ex : Default Layout, Formulaire Facturation)"
+      - name: contract_id
+        description: "ID du contrat de service associé"
+      - name: created_by
+        description: "ID de l'agent ou système ayant créé le ticket"
+      - name: modified_by
+        description: "ID de l'agent ayant effectué la dernière modification"
+      - name: follower_count
+        description: "Nombre d'agents abonnés à ce ticket"
+      - name: task_count
+        description: "Nombre de tâches liées"
+      # ── Champs custom principaux ─────────────────────────────────────────
+      # Tous de type STRING dans BigQuery. Caster si nécessaire dans les marts.
+      - name: cf_statut_client
+        description: "Custom field : statut du client"
+      - name: cf_nature_des_demandes
+        description: "Custom field : nature de la demande"
+      - name: cf_type
+        description: "Custom field : type de demande"
+      - name: cf_type_de_remboursement
+        description: "Custom field : type de remboursement"
+      - name: cf_votre_demande_concerne
+        description: "Custom field : objet de la demande (formulaire portail client)"
+      - name: cf_demande_intervention
+        description: "Custom field : demande d'intervention terrain"
+      - name: cf_technique
+        description: "Custom field : demande technique"
+      - name: cf_s_equipements
+        description: "Custom field : équipements concernés"
+      - name: cf_machines
+        description: "Custom field : machines concernées"
+      - name: cf_suivi_intervention
+        description: "Custom field : référence de suivi d'intervention"
+      - name: cf_s_facturation
+        description: "Custom field : facturation"
+      - name: cf_s_remboursement
+        description: "Custom field : remboursement"
+      - name: cf_s_commercial
+        description: "Custom field : commercial"
+      - name: cf_s_reappro
+        description: "Custom field : réapprovisionnement"
+      - name: cf_rupture
+        description: "Custom field : rupture de stock"
+      - name: cf_boissons_chaudes
+        description: "Custom field : boissons chaudes"
+      - name: cf_snack
+        description: "Custom field : snacks"
+      - name: cf_consommables
+        description: "Custom field : consommables"
+      - name: cf_s_gestion_des_cartes_privatives
+        description: "Custom field : gestion cartes privatives"
+      - name: cf_s_gestion_des_planogrammes
+        description: "Custom field : gestion planogrammes"
+      - name: cf_s_recyclage
+        description: "Custom field : recyclage"
+      - name: cf_s_systeme_de_paiement
+        description: "Custom field : système de paiement"
+      - name: cf_collecte
+        description: "Custom field : collecte"
+      - name: cf_badges
+        description: "Custom field : badges"
+      - name: cf_inscription
+        description: "Custom field : inscription"
+      - name: cf_creation_d_un_site
+        description: "Custom field : demande création d'un site"
+      - name: cf_modification_d_un_site
+        description: "Custom field : demande modification d'un site"
+      - name: cf_nom_de_l_entreprise
+        description: "Custom field : nom de l'entreprise (formulaire web)"
+      - name: cf_secteur_d_activite
+        description: "Custom field : secteur d'activité (formulaire web)"
+      - name: cf_civilite
+        description: "Custom field : civilité du demandeur (formulaire web)"
+      - name: cf_nom
+        description: "Custom field : nom du demandeur (formulaire web)"
+      - name: cf_prenom
+        description: "Custom field : prénom du demandeur (formulaire web)"
+      - name: cf_numero_de_telephone
+        description: "Custom field : téléphone (formulaire web)"
+      - name: cf_date_de_l_animation
+        description: "Custom field : date de l'animation"
+      - name: cf_champ_machine_formulaire
+        description: "Custom field : machine saisie dans le formulaire web"
+      - name: cf_previous_status
+        description: "Custom field : statut précédent avant l'état courant"
+      - name: cf_close_ticket_notification_sent
+        description: "Custom field : notification de fermeture envoyée (oui/non)"
+      - name: cf_contrat_avenant
+        description: "Custom field : contrat ou avenant concerné"
+      - name: cf_correction
+        description: "Custom field : correction demandée"
+      - name: cf_modification
+        description: "Custom field : modification demandée"
+      - name: cf_s_remontees_personnel_neshu
+        description: "Custom field : remontées personnel NESHU"
+      - name: cf_s_commande_directes
+        description: "Custom field : commandes directes"
+      - name: cf_tranche_effectiv
+        description: "Custom field : tranche d'effectif"
+      - name: cf_fiche_de_renseignement
+        description: "Custom field : fiche de renseignement"
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__ticket_history
+    description: >
+      Journal d'audit par ticket nettoyé — source de vérité pour les métriques temporelles.
+      Source : prod_raw.zoho_desk_ticket_history
+      Transformation : aucune (pas de colonne id à renommer — la PK est _dlt_id).
+      Le détail des champs modifiés est dans stg_zoho_desk__ticket_history_event_info
+      (jointure : _dlt_parent_id = _dlt_id de ce modèle).
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: _dlt_id
+        description: >
+          PK interne dlt de cet événement.
+          Utilisé comme clé de jointure vers
+          stg_zoho_desk__ticket_history_event_info._dlt_parent_id.
+        tests:
+          - unique
+          - not_null
+      - name: _zoho_desk_associated_tickets_id
+        description: "FK vers stg_zoho_desk__tickets.ticket_id — ticket concerné par cet événement"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__tickets')
+                field: ticket_id
+      - name: event_name
+        description: >
+          Type d'événement. Exemples :
+          TicketCreated, StatusChanged, CommentAdded,
+          AssigneeChanged, PriorityChanged, DepartmentChanged, TicketClosed.
+      - name: event_time
+        description: "Date/heure exacte de l'événement (TIMESTAMP) — colonne principale pour les métriques temporelles"
+      - name: source
+        description: "Source déclenchant l'événement : UI, API, EMAIL, SYSTEM"
+      - name: actor__id
+        description: "ID Zoho de l'acteur (agent, contact ou système)"
+      - name: actor__name
+        description: "Nom lisible de l'acteur"
+      - name: actor__type
+        description: "Type de l'acteur : AGENT, CONTACT, SYSTEM"
+
+  # ─────────────────────────────────────────────────────────────────────────
+
+  - name: stg_zoho_desk__ticket_history_event_info
+    description: >
+      Détail des champs modifiés lors d'un événement de ticket_history.
+      Source : prod_raw.zoho_desk_ticket_history__event_info
+      Transformation : aucune (pas de colonne id à renommer — la PK est _dlt_id).
+      Jointure vers ticket_history : _dlt_parent_id = stg_zoho_desk__ticket_history._dlt_id
+      Usage typique :
+        Filtrer sur property_name = 'Status' pour les transitions de statut.
+        Filtrer sur property_name = 'Assignee' pour les changements d'assigné.
+        Les valeurs avant/après sont dans property_value__previous_value /
+        property_value__updated_value (scalaires) ou dans les colonnes __id/__name/__type
+        (quand la valeur est un objet Zoho comme un agent ou département).
+    config:
+      tags: ['zoho_desk', 'staging']
+    columns:
+      - name: _dlt_id
+        description: "PK interne dlt de cette ligne"
+        tests:
+          - unique
+          - not_null
+      - name: _dlt_parent_id
+        description: "FK interne dlt vers stg_zoho_desk__ticket_history._dlt_id"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_zoho_desk__ticket_history')
+                field: _dlt_id
+      - name: _dlt_list_idx
+        description: "Position (0-based) de cet élément dans le tableau JSON d'origine"
+      - name: property_name
+        description: >
+          Nom du champ modifié — filtre principal.
+          Valeurs fréquentes : 'Status', 'Assignee', 'Priority', 'Department', 'Category'.
+      - name: property_type
+        description: "Type Zoho du champ (STRING, BOOLEAN, LOOKUP, etc.)"
+      - name: system_property
+        description: "BOOLEAN — true = champ système Zoho, false = champ custom (cf_*)"
+      - name: property_value
+        description: >
+          Valeur du champ (scalaire simple, sans before/after).
+          NULL quand la modification est représentée en before/after.
+      - name: property_value__id
+        description: "ID de l'objet quand la valeur est un objet sans before/after"
+      - name: property_value__name
+        description: "Nom de l'objet quand la valeur est un objet sans before/after"
+      - name: property_value__previous_value
+        description: >
+          Valeur AVANT modification (scalaire).
+          Exemple : 'Open' pour property_name = 'Status'.
+      - name: property_value__previous_value__id
+        description: "ID de la valeur AVANT quand c'est un objet (ex : ID de l'agent précédent)"
+      - name: property_value__previous_value__name
+        description: "Nom de la valeur AVANT quand c'est un objet"
+      - name: property_value__updated_value
+        description: >
+          Valeur APRÈS modification (scalaire).
+          Exemple : 'Closed' pour property_name = 'Status'.
+      - name: property_value__updated_value__id
+        description: "ID de la valeur APRÈS quand c'est un objet (ex : ID du nouvel agent assigné)"
+      - name: property_value__updated_value__name
+        description: "Nom de la valeur APRÈS quand c'est un objet"

--- a/models/staging/zoho_desk/_zoho_desk__sources.yml
+++ b/models/staging/zoho_desk/_zoho_desk__sources.yml
@@ -1,0 +1,598 @@
+version: 2
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SOURCE : Zoho Desk (prod_raw)
+#
+# Données brutes extraites de l'API Zoho Desk (EU region) via dlt.
+# Chaque table = un endpoint Zoho Desk. Les colonnes préfixées `_dlt_` sont
+# internes à dlt — ne pas les utiliser en BI sauf quand une jointure dlt
+# est explicitement documentée (sous-tables __associated_department_ids,
+# __event_info, etc.).
+#
+# Freshness : _dlt_load_id est une STRING (unix timestamp en texte),
+# pas un TIMESTAMP — freshness dbt non applicable sur cette source.
+# ─────────────────────────────────────────────────────────────────────────────
+
+sources:
+  - name: zoho_desk
+    description: >
+      Données brutes extraites de l'API Zoho Desk (EU region) via dlt (data load tool).
+      Dataset BigQuery : evs-datastack-prod.prod_raw.
+    schema: prod_raw
+    config:
+      tags: ['zoho_desk', 'source']
+
+    tables:
+
+      # ═══════════════════════════════════════════════════════════════════════
+      # DIMENSIONS
+      # ═══════════════════════════════════════════════════════════════════════
+
+      - name: zoho_desk_accounts
+        description: >
+          Comptes Zoho Desk = entreprises clientes (251 lignes).
+          Un compte regroupe plusieurs contacts (personnes physiques).
+          Les tickets et contacts y sont rattachés via account_id.
+        columns:
+          - name: id
+            description: "PK — identifiant unique du compte. Renommé account_id dans le staging."
+            tests: [unique, not_null]
+          - name: account_name
+            description: "Nom de l'entreprise cliente"
+          - name: created_time
+            description: "Date de création du compte (TIMESTAMP)"
+          - name: web_url
+            description: "URL de la fiche compte dans l'interface Zoho Desk"
+          - name: customer_happiness__bad_percentage
+            description: "% d'évaluations CSAT négatives sur ce compte"
+          - name: customer_happiness__ok_percentage
+            description: "% d'évaluations CSAT neutres sur ce compte"
+          - name: customer_happiness__good_percentage
+            description: "% d'évaluations CSAT positives sur ce compte"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt qui a chargé cette ligne (STRING)"
+          - name: _dlt_id
+            description: "Clé interne dlt unique par ligne (utilisée pour les jointures aux éventuelles sous-tables dlt)"
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_agents
+        description: >
+          Agents Zoho Desk = membres de l'équipe support (5 lignes).
+          Les tickets y sont rattachés via assignee_id.
+          Les départements de chaque agent sont dans la sous-table
+          zoho_desk_agents__associated_department_ids
+          (jointure dlt interne : _dlt_id → _dlt_parent_id).
+        columns:
+          - name: id
+            description: "PK — identifiant unique de l'agent. Renommé agent_id dans le staging."
+            tests: [unique, not_null]
+          - name: first_name
+            description: "Prénom de l'agent"
+          - name: last_name
+            description: "Nom de famille de l'agent"
+          - name: name
+            description: "Nom complet de l'agent (first_name + last_name concaténés par Zoho)"
+          - name: email_id
+            description: "Adresse e-mail professionnelle de l'agent"
+          - name: status
+            description: "Statut du compte agent : ACTIVE ou DISABLED"
+          - name: role_id
+            description: "ID du rôle Zoho attribué à l'agent"
+          - name: profile_id
+            description: "ID du profil de permissions Zoho (contrôle les droits d'accès)"
+          - name: role_permission_type
+            description: "Type de permission du rôle (ex : AGENT, ADMINISTRATOR)"
+          - name: phone
+            description: "Numéro de téléphone fixe de l'agent"
+          - name: mobile
+            description: "Numéro de téléphone mobile de l'agent"
+          - name: time_zone
+            description: "Fuseau horaire de l'agent"
+          - name: lang_code
+            description: "Code langue de l'interface Zoho pour cet agent (ex : fr, en)"
+          - name: country_code
+            description: "Code pays de l'agent"
+          - name: about_info
+            description: "Bio / description libre de l'agent"
+          - name: extn
+            description: "Extension téléphonique interne"
+          - name: photo_url
+            description: "URL de la photo de profil"
+          - name: is_confirmed
+            description: "BOOLEAN — compte e-mail confirmé par l'agent"
+          - name: is_zia_agent
+            description: "BOOLEAN — indique si c'est un agent IA Zoho Zia (bot)"
+          - name: zuid
+            description: "Identifiant Zoho universel cross-produits (ex : Zoho CRM, Zoho Mail)"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt (STRING)"
+          - name: _dlt_id
+            description: >
+              Clé interne dlt unique par ligne.
+              IMPORTANT : cette colonne est exposée dans le staging car elle sert
+              de clé de jointure vers zoho_desk_agents__associated_department_ids._dlt_parent_id.
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_agents__associated_department_ids
+        description: >
+          Sous-table dlt — départements auxquels appartient chaque agent (11 lignes).
+          dlt dénormalise les tableaux JSON en tables séparées.
+          Cette table n'a pas de PK métier.
+          Jointure vers l'agent  : _dlt_parent_id = zoho_desk_agents._dlt_id
+          Jointure vers le département : value = zoho_desk_departments.id
+          ATTENTION : la jointure vers l'agent ne passe pas par agents.id mais
+          par agents._dlt_id (clé interne dlt, pas un ID Zoho).
+        columns:
+          - name: value
+            description: "ID du département (FK vers zoho_desk_departments.id)"
+          - name: _dlt_parent_id
+            description: "FK interne dlt vers zoho_desk_agents._dlt_id. Pas un ID Zoho — jointure uniquement via _dlt_id."
+            tests: [not_null]
+          - name: _dlt_root_id
+            description: "Référence à la ligne racine dans la hiérarchie dlt (ici identique à _dlt_parent_id)"
+          - name: _dlt_list_idx
+            description: "Position (0-based) de cet élément dans le tableau JSON d'origine"
+          - name: _dlt_id
+            description: "Clé interne dlt unique pour cette ligne"
+            tests: [unique, not_null]
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_contacts
+        description: >
+          Contacts Zoho Desk = personnes physiques (clients) qui ouvrent des tickets (3 362 lignes).
+          Un contact est rattaché à un compte via account_id.
+          Les tickets y sont liés via contact_id.
+        columns:
+          - name: id
+            description: "PK — identifiant unique du contact. Renommé contact_id dans le staging."
+            tests: [unique, not_null]
+          - name: first_name
+            description: "Prénom du contact"
+          - name: last_name
+            description: "Nom de famille du contact"
+          - name: email
+            description: "Adresse e-mail du contact"
+          - name: phone
+            description: "Numéro de téléphone du contact"
+          - name: account_id
+            description: "FK vers zoho_desk_accounts.id — entreprise à laquelle appartient ce contact"
+          - name: account_count
+            description: "Nombre de comptes associés à ce contact"
+          - name: owner_id
+            description: "ID de l'agent Zoho responsable de ce contact"
+          - name: created_time
+            description: "Date de création du contact dans Zoho Desk (TIMESTAMP)"
+          - name: is_anonymous
+            description: "BOOLEAN — contact anonyme (pas de nom connu)"
+          - name: is_end_user
+            description: "BOOLEAN — contact est un utilisateur final (vs agent interne)"
+          - name: is_spam
+            description: "BOOLEAN — contact marqué comme spam"
+          - name: web_url
+            description: "URL de la fiche contact dans l'interface Zoho Desk"
+          - name: customer_happiness__bad_percentage
+            description: "% d'évaluations CSAT négatives de ce contact"
+          - name: customer_happiness__ok_percentage
+            description: "% d'évaluations CSAT neutres de ce contact"
+          - name: customer_happiness__good_percentage
+            description: "% d'évaluations CSAT positives de ce contact"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt (STRING)"
+          - name: _dlt_id
+            description: "Clé interne dlt unique par ligne"
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_departments
+        description: >
+          Départements Zoho Desk = groupes organisationnels recevant les tickets (4 lignes).
+          Exemples : Service Client, Facturation, Technique.
+          Tickets et agents y sont rattachés via department_id.
+        columns:
+          - name: id
+            description: "PK — identifiant unique du département. Renommé department_id dans le staging."
+            tests: [unique, not_null]
+          - name: name
+            description: "Nom du département (ex : Service Client)"
+          - name: description
+            description: "Description libre du département"
+          - name: sanitized_name
+            description: "Nom slugifié : minuscules, accents supprimés, espaces remplacés par tirets"
+          - name: name_in_customer_portal
+            description: "Nom affiché dans le portail libre-service client"
+          - name: created_time
+            description: "Date de création du département (TIMESTAMP)"
+          - name: creator_id
+            description: "ID de l'agent Zoho qui a créé ce département"
+          - name: chat_status
+            description: "Statut du canal chat en direct pour ce département (ONLINE / OFFLINE)"
+          - name: is_enabled
+            description: "BOOLEAN — département actif et recevant des tickets"
+          - name: is_default
+            description: "BOOLEAN — département sélectionné par défaut à la création d'un ticket"
+          - name: is_assign_to_team_enabled
+            description: "BOOLEAN — affectation aux équipes activée pour ce département"
+          - name: is_visible_in_customer_portal
+            description: "BOOLEAN — visible dans le portail libre-service client"
+          - name: has_logo
+            description: "BOOLEAN — un logo personnalisé est défini pour ce département"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt (STRING)"
+          - name: _dlt_id
+            description: "Clé interne dlt unique par ligne"
+
+      # ═══════════════════════════════════════════════════════════════════════
+      # FACTS
+      # ═══════════════════════════════════════════════════════════════════════
+
+      - name: zoho_desk_associated_tickets
+        description: >
+          Table principale des tickets (20 678 lignes) — table centrale de toute l'analyse.
+          Extraite via /associatedTickets qui contourne la limite de pagination de
+          /tickets (~3 600 lignes max). write_disposition=merge : les runs s'accumulent.
+          Chaque ligne = un ticket.
+          Enrichissements disponibles :
+            - Métriques SLA       → zoho_desk_ticket_metrics (1:1, jointure sur id)
+            - Custom fields/flags → zoho_desk_ticket_details (1:1, jointure sur id)
+            - Historique événements → zoho_desk_ticket_history (1:N, jointure sur id)
+        columns:
+          - name: id
+            description: "PK — identifiant unique du ticket. Renommé ticket_id dans le staging."
+            tests: [unique, not_null]
+          - name: ticket_number
+            description: "Numéro de ticket lisible affiché dans l'interface Zoho (ex : #1234)"
+          - name: subject
+            description: "Objet/sujet du ticket saisi à la création"
+          - name: status
+            description: "Statut courant du ticket (ex : Open, Closed, On Hold, In Progress)"
+          - name: status_type
+            description: "Catégorie fonctionnelle du statut : open, closed, on_hold"
+          - name: priority
+            description: "Priorité du ticket : Low, Medium, High, Urgent"
+          - name: channel
+            description: "Canal d'entrée du ticket : Email, Phone, Chat, Web, etc."
+          - name: channel_code
+            description: "Code interne Zoho du canal"
+          - name: category
+            description: "Catégorie métier du ticket (premier niveau de classification)"
+          - name: sub_category
+            description: "Sous-catégorie métier du ticket (deuxième niveau de classification)"
+          - name: language
+            description: "Langue détectée du ticket"
+          - name: department_id
+            description: "FK vers zoho_desk_departments.id — département recevant le ticket"
+          - name: assignee_id
+            description: "FK vers zoho_desk_agents.id — agent actuellement assigné au ticket"
+          - name: contact_id
+            description: "FK vers zoho_desk_contacts.id — contact ayant ouvert le ticket"
+          - name: account_id
+            description: "FK vers zoho_desk_accounts.id — entreprise du contact"
+          - name: team_id
+            description: "ID de l'équipe Zoho assignée au ticket (si applicable)"
+          - name: product_id
+            description: "ID du produit Zoho associé au ticket (si applicable)"
+          - name: layout_id
+            description: "ID du layout de formulaire Zoho utilisé pour ce ticket"
+          - name: email
+            description: "Adresse e-mail du demandeur au moment de la création"
+          - name: phone
+            description: "Numéro de téléphone du demandeur"
+          - name: created_time
+            description: "Date/heure de création du ticket (TIMESTAMP)"
+          - name: closed_time
+            description: >
+              Date/heure de fermeture courante du ticket (TIMESTAMP).
+              NULL si le ticket n'a jamais été fermé ou s'il a été rouvert.
+              ATTENTION : n'utiliser cette colonne que pour l'état courant.
+              Pour les métriques temporelles (tickets fermés en mois X, rouverts),
+              utiliser zoho_desk_ticket_history avec property_name = 'Status'.
+          - name: due_date
+            description: "Échéance SLA de résolution (TIMESTAMP)"
+          - name: response_due_date
+            description: "Échéance SLA de première réponse (TIMESTAMP)"
+          - name: onhold_time
+            description: "Date/heure de mise en attente (TIMESTAMP)"
+          - name: customer_response_time
+            description: "Date/heure de la dernière réponse du client (TIMESTAMP)"
+          - name: comment_count
+            description: "Nombre de commentaires internes sur le ticket (STRING)"
+          - name: thread_count
+            description: "Nombre de threads e-mail/chat sur le ticket (STRING)"
+          - name: is_archived
+            description: "BOOLEAN — ticket archivé"
+          - name: is_spam
+            description: "BOOLEAN — ticket marqué comme spam"
+          - name: web_url
+            description: "URL directe vers le ticket dans l'interface Zoho Desk"
+          - name: sentiment
+            description: "Sentiment détecté par Zoho Zia (IA) : Positive, Negative, Neutral"
+          - name: relationship_type
+            description: "Type de relation si ticket lié à un autre ticket"
+          - name: on_hold_time
+            description: "Durée cumulée en attente (STRING, format propriétaire Zoho)"
+          - name: last_thread
+            description: "ID du dernier thread sur ce ticket"
+          - name: last_thread__channel
+            description: "Canal du dernier thread"
+          - name: last_thread__direction
+            description: "Direction du dernier thread : inbound (client→agent) / outbound (agent→client)"
+          - name: last_thread__is_draft
+            description: "BOOLEAN — dernier thread est un brouillon non envoyé"
+          - name: last_thread__is_forward
+            description: "BOOLEAN — dernier thread est un transfert (forward)"
+          - name: source__type
+            description: "Type de source du ticket (ex : email, web form)"
+          - name: source__app_name
+            description: "Nom de l'application externe ayant créé le ticket"
+          - name: source__app_photo_url
+            description: "URL de l'icône de l'application source"
+          - name: source__ext_id
+            description: "ID de l'élément dans le système source externe"
+          - name: source__permalink
+            description: "Lien permanent vers l'élément dans le système source"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt (STRING)"
+          - name: _dlt_id
+            description: "Clé interne dlt unique par ligne"
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_ticket_details
+        description: >
+          Enrichissement 1:1 par ticket (20 678 lignes) : flags SLA, champs custom (cf_*),
+          texte de résolution, layout utilisé.
+          Jointure : _zoho_desk_tickets_id = zoho_desk_associated_tickets.id
+          NOTE : la colonne FK est nommée _zoho_desk_tickets_id et non
+          _zoho_desk_associated_tickets_id car le transformer dlt était défini
+          avec data_from=tickets (nom de la ressource dlt, pas du endpoint).
+        columns:
+          - name: _zoho_desk_tickets_id
+            description: >
+              PK et FK — identifiant du ticket associé.
+              Jointure : = zoho_desk_associated_tickets.id
+              Renommé ticket_id dans le staging.
+            tests: [unique, not_null]
+          - name: sla_id
+            description: "ID du contrat SLA appliqué à ce ticket"
+          - name: is_over_due
+            description: "BOOLEAN — ticket en dépassement de l'échéance SLA de résolution"
+          - name: is_response_overdue
+            description: "BOOLEAN — ticket en dépassement de l'échéance SLA de première réponse"
+          - name: is_escalated
+            description: "BOOLEAN — ticket escaladé"
+          - name: resolution
+            description: "Texte de résolution saisi par l'agent à la fermeture du ticket"
+          - name: layout_id
+            description: "ID du layout de formulaire Zoho"
+          - name: layout_name
+            description: "Nom lisible du layout (ex : Default Layout, Formulaire Facturation)"
+          - name: contract_id
+            description: "ID du contrat de service associé au ticket"
+          - name: onhold_time
+            description: "Durée cumulée en attente (STRING)"
+          - name: created_by
+            description: "ID de l'agent ou du système ayant créé le ticket"
+          - name: modified_by
+            description: "ID de l'agent ayant effectué la dernière modification"
+          - name: follower_count
+            description: "Nombre d'abonnés (agents suivant ce ticket)"
+          - name: tag_count
+            description: "Nombre de tags appliqués au ticket"
+          - name: approval_count
+            description: "Nombre d'approbations en attente sur ce ticket"
+          - name: time_entry_count
+            description: "Nombre de saisies de temps (time tracking)"
+          - name: task_count
+            description: "Nombre de tâches liées à ce ticket"
+          # ── Champs custom (cf_*) ─────────────────────────────────────────
+          # Tous les champs custom Zoho sont de type STRING quelle que soit leur
+          # nature réelle (date, booléen, liste) — cast à faire dans le staging
+          # si nécessaire.
+          - name: cf_statut_client
+            description: "Custom field : statut du client (ex : VIP, Standard)"
+          - name: cf_nature_des_demandes
+            description: "Custom field : nature de la demande (classification interne)"
+          - name: cf_previous_status
+            description: "Custom field : statut Zoho précédent (avant l'état courant)"
+          - name: cf_demande_intervention
+            description: "Custom field : demande d'intervention terrain"
+          - name: cf_technique
+            description: "Custom field : indicateur de demande technique"
+          - name: cf_type
+            description: "Custom field : type de demande"
+          - name: cf_type_de_remboursement
+            description: "Custom field : type de remboursement demandé"
+          - name: cf_contrat_avenant
+            description: "Custom field : contrat ou avenant concerné"
+          - name: cf_suivi_intervention
+            description: "Custom field : lien ou référence de suivi d'intervention"
+          - name: cf_votre_demande_concerne
+            description: "Custom field : objet de la demande (formulaire portail client)"
+          - name: cf_correction
+            description: "Custom field : correction demandée"
+          - name: cf_close_ticket_notification_sent
+            description: "Custom field : notification de fermeture envoyée (oui/non)"
+          - name: cf_civilite
+            description: "Custom field : civilité du demandeur (M., Mme) — formulaire web"
+          - name: cf_nom
+            description: "Custom field : nom du demandeur — formulaire web"
+          - name: cf_prenom
+            description: "Custom field : prénom du demandeur — formulaire web"
+          - name: cf_numero_de_telephone
+            description: "Custom field : téléphone — formulaire web"
+          - name: cf_nom_de_l_entreprise
+            description: "Custom field : nom de l'entreprise — formulaire web"
+          - name: cf_secteur_d_activite
+            description: "Custom field : secteur d'activité — formulaire web"
+          - name: cf_tranche_effectiv
+            description: "Custom field : tranche d'effectif de l'entreprise"
+          - name: cf_fiche_de_renseignement
+            description: "Custom field : fiche de renseignement (pièce jointe ou référence)"
+          - name: cf_inscription
+            description: "Custom field : inscription"
+          - name: cf_creation_d_un_site
+            description: "Custom field : demande de création d'un site"
+          - name: cf_modification_d_un_site
+            description: "Custom field : demande de modification d'un site"
+          - name: cf_badges
+            description: "Custom field : badges concernés"
+          - name: cf_rupture
+            description: "Custom field : rupture de stock signalée"
+          - name: cf_boisson_chaude
+            description: "Custom field : boissons chaudes (ancienne colonne, remplacée par cf_boissons_chaudes)"
+          - name: cf_boissons_chaudes
+            description: "Custom field : boissons chaudes"
+          - name: cf_snack
+            description: "Custom field : snacks"
+          - name: cf_consommables
+            description: "Custom field : consommables"
+          - name: cf_s_reappro
+            description: "Custom field : réapprovisionnement"
+          - name: cf_s_facturation
+            description: "Custom field : facturation"
+          - name: cf_s_remboursement
+            description: "Custom field : remboursement"
+          - name: cf_s_commercial
+            description: "Custom field : commercial"
+          - name: cf_s_commande_directes
+            description: "Custom field : commandes directes"
+          - name: cf_s_gestion_des_cartes_privatives
+            description: "Custom field : gestion des cartes privatives"
+          - name: cf_s_gestion_des_planogrammes
+            description: "Custom field : gestion des planogrammes"
+          - name: cf_s_recyclage
+            description: "Custom field : recyclage"
+          - name: cf_s_remontees_personnel_neshu
+            description: "Custom field : remontées personnel NESHU"
+          - name: cf_s_systeme_de_paiement
+            description: "Custom field : système de paiement"
+          - name: cf_collecte
+            description: "Custom field : collecte"
+          - name: cf_modification
+            description: "Custom field : modification demandée"
+          - name: cf_modifications
+            description: "Custom field : modifications (variante colonne, coexiste avec cf_modification)"
+          - name: cf_date_de_l_animation
+            description: "Custom field : date de l'animation"
+          - name: cf_champ_machine_formulaire
+            description: "Custom field : référence machine saisie dans le formulaire web"
+          - name: cf_s_equipements
+            description: "Custom field : équipements concernés"
+          - name: cf_machines
+            description: "Custom field : machines concernées"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt (STRING)"
+          - name: _dlt_id
+            description: "Clé interne dlt unique par ligne"
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_ticket_history
+        description: >
+          Journal d'audit par ticket (259 677 lignes) — une ligne par événement
+          (création du ticket, changement de statut, changement d'assigné,
+          commentaire ajouté, escalade, etc.).
+          C'est la SOURCE DE VÉRITÉ pour toutes les métriques temporelles :
+          tickets fermés en mois X, rouverts, réassignés.
+          NE PAS utiliser closed_time sur associated_tickets pour ces métriques :
+          closed_time ne reflète que la fermeture la plus récente et est NULL
+          si le ticket a été rouvert.
+          Les détails des champs modifiés (valeur avant/après) sont dans
+          zoho_desk_ticket_history__event_info via _dlt_id → _dlt_parent_id.
+        columns:
+          - name: _dlt_id
+            description: >
+              PK interne dlt de cet événement.
+              Utilisé comme clé de jointure vers
+              zoho_desk_ticket_history__event_info._dlt_parent_id.
+            tests: [unique, not_null]
+          - name: _zoho_desk_associated_tickets_id
+            description: "FK vers zoho_desk_associated_tickets.id — ticket concerné par cet événement"
+            tests: [not_null]
+          - name: event_name
+            description: >
+              Type d'événement. Valeurs fréquentes :
+              TicketCreated, StatusChanged, CommentAdded,
+              AssigneeChanged, PriorityChanged, DepartmentChanged, TicketClosed.
+          - name: event_time
+            description: "Date/heure exacte de l'événement (TIMESTAMP)"
+          - name: source
+            description: "Source déclenchant l'événement : UI, API, EMAIL, SYSTEM"
+          - name: actor__id
+            description: "ID Zoho de l'acteur ayant déclenché l'événement (agent, contact ou système)"
+          - name: actor__name
+            description: "Nom lisible de l'acteur"
+          - name: actor__type
+            description: "Type de l'acteur : AGENT, CONTACT, SYSTEM"
+          - name: _dlt_load_id
+            description: "ID interne du run dlt (STRING)"
+
+      # ───────────────────────────────────────────────────────────────────────
+
+      - name: zoho_desk_ticket_history__event_info
+        description: >
+          Sous-table dlt de ticket_history (823 452 lignes) —
+          détail des champs modifiés lors d'un événement.
+          Chaque ligne = un champ modifié dans un événement
+          (ex : Status passé de Open à Closed).
+          Jointure : _dlt_parent_id = zoho_desk_ticket_history._dlt_id
+          Filtrer sur property_name pour isoler un type de changement :
+            'Status'     → transitions de statut (open→closed, closed→open…)
+            'Assignee'   → changements d'assigné
+            'Priority'   → changements de priorité
+            'Department' → changements de département
+            'Category'   → changements de catégorie
+          Quand la valeur modifiée est un objet (ex : agent, département),
+          les colonnes __id / __name / __type décomposent cet objet.
+        columns:
+          - name: _dlt_id
+            description: "Clé interne dlt unique pour cette ligne"
+            tests: [unique, not_null]
+          - name: _dlt_parent_id
+            description: "FK interne dlt vers zoho_desk_ticket_history._dlt_id"
+            tests: [not_null]
+          - name: _dlt_list_idx
+            description: "Position (0-based) de cet élément dans le tableau JSON d'origine"
+          - name: property_name
+            description: >
+              Nom du champ modifié. Exemples :
+              'Status', 'Assignee', 'Priority', 'Department', 'Category'.
+              C'est le filtre principal pour isoler le type d'événement.
+          - name: property_type
+            description: "Type Zoho du champ (STRING, BOOLEAN, LOOKUP, etc.)"
+          - name: system_property
+            description: "BOOLEAN — true = champ système Zoho standard, false = champ custom (cf_*)"
+          - name: property_value
+            description: >
+              Valeur du champ quand elle est scalaire simple (pas de before/after).
+              NULL si la modification est représentée en before/after
+              (property_value__previous_value / property_value__updated_value).
+          - name: property_value__id
+            description: "ID de l'objet quand la valeur est un objet unique sans before/after"
+          - name: property_value__name
+            description: "Nom de l'objet quand la valeur est un objet unique sans before/after"
+          - name: property_value__type
+            description: "Type de l'objet quand la valeur est un objet unique sans before/after"
+          - name: property_value__previous_value
+            description: >
+              Valeur AVANT modification (scalaire).
+              Exemple pour property_name='Status' : 'Open'
+          - name: property_value__previous_value__id
+            description: "ID de la valeur AVANT quand c'est un objet (ex : ID de l'agent précédent)"
+          - name: property_value__previous_value__name
+            description: "Nom de la valeur AVANT quand c'est un objet (ex : nom de l'agent précédent)"
+          - name: property_value__previous_value__type
+            description: "Type de la valeur AVANT"
+          - name: property_value__updated_value
+            description: >
+              Valeur APRÈS modification (scalaire).
+              Exemple pour property_name='Status' : 'Closed'
+          - name: property_value__updated_value__id
+            description: "ID de la valeur APRÈS quand c'est un objet (ex : ID du nouvel agent assigné)"
+          - name: property_value__updated_value__name
+            description: "Nom de la valeur APRÈS quand c'est un objet (ex : nom du nouvel agent)"
+          - name: property_value__updated_value__type
+            description: "Type de la valeur APRÈS"

--- a/models/staging/zoho_desk/stg_zoho_desk__accounts.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__accounts.sql
@@ -12,7 +12,7 @@ with source as (
 renamed as (
     select
         -- primary key
-        id                                    as account_id,
+        id as account_id,
 
         -- attributes
         account_name,
@@ -20,9 +20,9 @@ renamed as (
         web_url,
 
         -- csat scores (STRING in source → FLOAT64)
-        SAFE_CAST(customer_happiness__bad_percentage  AS FLOAT64) as customer_happiness__bad_percentage,
-        SAFE_CAST(customer_happiness__ok_percentage   AS FLOAT64) as customer_happiness__ok_percentage,
-        SAFE_CAST(customer_happiness__good_percentage AS FLOAT64) as customer_happiness__good_percentage
+        safe_cast(customer_happiness__bad_percentage as float64) as customer_happiness__bad_percentage,
+        safe_cast(customer_happiness__ok_percentage as float64) as customer_happiness__ok_percentage,
+        safe_cast(customer_happiness__good_percentage as float64) as customer_happiness__good_percentage
 
     from source
 )

--- a/models/staging/zoho_desk/stg_zoho_desk__accounts.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__accounts.sql
@@ -1,0 +1,30 @@
+{{
+    config(
+        materialized='table',
+        description='Comptes Zoho Desk nettoyés (entreprises clientes). Renomme id en account_id.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_accounts') }}
+),
+
+renamed as (
+    select
+        -- primary key
+        id                                    as account_id,
+
+        -- attributes
+        account_name,
+        created_time,
+        web_url,
+
+        -- csat scores (STRING in source → FLOAT64)
+        SAFE_CAST(customer_happiness__bad_percentage  AS FLOAT64) as customer_happiness__bad_percentage,
+        SAFE_CAST(customer_happiness__ok_percentage   AS FLOAT64) as customer_happiness__ok_percentage,
+        SAFE_CAST(customer_happiness__good_percentage AS FLOAT64) as customer_happiness__good_percentage
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__agent_departments.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__agent_departments.sql
@@ -18,7 +18,7 @@ renamed as (
         _dlt_parent_id,
 
         -- fk to stg_zoho_desk__departments (c'est un ID Zoho métier)
-        value               as department_id,
+        value as department_id,
 
         -- position dans le tableau JSON d'origine (utile pour le debug)
         _dlt_list_idx

--- a/models/staging/zoho_desk/stg_zoho_desk__agent_departments.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__agent_departments.sql
@@ -1,0 +1,29 @@
+{{
+    config(
+        materialized='table',
+        description='Table pont agent ↔ département, dénormalisée depuis le tableau JSON associated_department_ids de API Zoho. Pas de colonne id à renommer dans cette table.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_agents__associated_department_ids') }}
+),
+
+renamed as (
+    select
+        -- dlt internal pk
+        _dlt_id,
+
+        -- fk to stg_zoho_desk__agents (jointure via _dlt_id, pas via agent_id)
+        _dlt_parent_id,
+
+        -- fk to stg_zoho_desk__departments (c'est un ID Zoho métier)
+        value               as department_id,
+
+        -- position dans le tableau JSON d'origine (utile pour le debug)
+        _dlt_list_idx
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__agents.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__agents.sql
@@ -12,7 +12,7 @@ with source as (
 renamed as (
     select
         -- primary key
-        id                          as agent_id,
+        id as agent_id,
 
         -- identity
         first_name,

--- a/models/staging/zoho_desk/stg_zoho_desk__agents.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__agents.sql
@@ -1,0 +1,53 @@
+{{
+    config(
+        materialized='table',
+        description='Agents Zoho Desk nettoyés (membres de l équipe support). Renomme id en agent_id. Expose _dlt_id pour la jointure vers stg_zoho_desk__agent_departments.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_agents') }}
+),
+
+renamed as (
+    select
+        -- primary key
+        id                          as agent_id,
+
+        -- identity
+        first_name,
+        last_name,
+        name,
+        email_id,
+
+        -- role & permissions
+        status,
+        role_id,
+        profile_id,
+        role_permission_type,
+
+        -- contact info
+        phone,
+        mobile,
+
+        -- locale
+        time_zone,
+        lang_code,
+        country_code,
+
+        -- misc
+        about_info,
+        extn,
+        photo_url,
+        is_confirmed,
+        is_zia_agent,
+        zuid,
+
+        -- dlt internal key — kept intentionally for joining to stg_zoho_desk__agent_departments
+        -- jointure : stg_zoho_desk__agent_departments._dlt_parent_id = _dlt_id
+        _dlt_id
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__contacts.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__contacts.sql
@@ -1,0 +1,47 @@
+{{
+    config(
+        materialized='table',
+        description='Contacts Zoho Desk nettoyés (personnes physiques ayant ouvert des tickets). Renomme id en contact_id.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_contacts') }}
+),
+
+renamed as (
+    select
+        -- primary key
+        id                                      as contact_id,
+
+        -- identity
+        first_name,
+        last_name,
+        email,
+        phone,
+
+        -- foreign key
+        account_id,
+
+        -- metadata
+        owner_id,
+        created_time,
+        SAFE_CAST(account_count AS INT64) as account_count,
+
+        -- flags
+        is_anonymous,
+        is_end_user,
+        is_spam,
+
+        -- misc
+        web_url,
+
+        -- csat scores
+        customer_happiness__bad_percentage,
+        customer_happiness__ok_percentage,
+        customer_happiness__good_percentage
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__contacts.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__contacts.sql
@@ -12,7 +12,7 @@ with source as (
 renamed as (
     select
         -- primary key
-        id                                      as contact_id,
+        id as contact_id,
 
         -- identity
         first_name,
@@ -26,7 +26,7 @@ renamed as (
         -- metadata
         owner_id,
         created_time,
-        SAFE_CAST(account_count AS INT64) as account_count,
+        safe_cast(account_count as int64) as account_count,
 
         -- flags
         is_anonymous,

--- a/models/staging/zoho_desk/stg_zoho_desk__departments.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__departments.sql
@@ -12,7 +12,7 @@ with source as (
 renamed as (
     select
         -- primary key
-        id                              as department_id,
+        id as department_id,
 
         -- attributes
         name,

--- a/models/staging/zoho_desk/stg_zoho_desk__departments.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__departments.sql
@@ -1,0 +1,36 @@
+{{
+    config(
+        materialized='table',
+        description='Départements Zoho Desk nettoyés (groupes organisationnels recevant les tickets). Renomme id en department_id.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_departments') }}
+),
+
+renamed as (
+    select
+        -- primary key
+        id                              as department_id,
+
+        -- attributes
+        name,
+        description,
+        sanitized_name,
+        name_in_customer_portal,
+        created_time,
+        creator_id,
+        chat_status,
+
+        -- flags
+        is_enabled,
+        is_default,
+        is_assign_to_team_enabled,
+        is_visible_in_customer_portal,
+        has_logo
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_details.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_details.sql
@@ -1,0 +1,96 @@
+{{
+    config(
+        materialized='table',
+        description='Enrichissement 1:1 par ticket : flags SLA, champs custom (cf_*), résolution, layout. Renomme _zoho_desk_tickets_id en ticket_id.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_ticket_details') }}
+),
+
+renamed as (
+    select
+        -- primary key + foreign key to stg_zoho_desk__tickets
+        -- (colonne source nommée _zoho_desk_tickets_id car le transformer dlt
+        --  utilisait la ressource `tickets` comme parent)
+        _zoho_desk_tickets_id                               as ticket_id,
+
+        -- sla (indicateurs et flags regroupés par domaine)
+        sla_id,
+        is_over_due,
+        is_response_overdue,
+        is_escalated,
+
+        -- layout
+        layout_id,
+        layout_name,
+
+        -- resolution
+        resolution,
+        contract_id,
+
+        -- engagement counts (STRING in source → INT64)
+        SAFE_CAST(follower_count    AS INT64)                as follower_count,
+        SAFE_CAST(tag_count         AS INT64)                as tag_count,
+        SAFE_CAST(approval_count    AS INT64)                as approval_count,
+        SAFE_CAST(time_entry_count  AS INT64)                as time_entry_count,
+        SAFE_CAST(task_count        AS INT64)                as task_count,
+
+        -- custom fields (tous STRING — caster dans les marts si nécessaire)
+        cf_statut_client,
+        cf_nature_des_demandes,
+        cf_type,
+        cf_type_de_remboursement,
+        cf_votre_demande_concerne,
+        cf_demande_intervention,
+        cf_technique,
+        cf_s_equipements,
+        cf_machines,
+        cf_suivi_intervention,
+        cf_s_facturation,
+        cf_s_remboursement,
+        cf_s_commercial,
+        cf_s_reappro,
+        cf_rupture,
+        cf_boissons_chaudes,
+        cf_snack,
+        cf_consommables,
+        cf_s_gestion_des_cartes_privatives,
+        cf_s_gestion_des_planogrammes,
+        cf_s_recyclage,
+        cf_s_systeme_de_paiement,
+        cf_collecte,
+        cf_badges,
+        cf_inscription,
+        cf_creation_d_un_site,
+        cf_modification_d_un_site,
+        cf_nom_de_l_entreprise,
+        cf_secteur_d_activite,
+        cf_civilite,
+        cf_nom,
+        cf_prenom,
+        cf_numero_de_telephone,
+        cf_date_de_l_animation,
+        cf_champ_machine_formulaire,
+        cf_previous_status,
+        cf_close_ticket_notification_sent,
+        cf_contrat_avenant,
+        cf_correction,
+        cf_modification,
+        cf_s_remontees_personnel_neshu,
+        cf_s_commande_directes,
+        cf_tranche_effectiv,
+        cf_fiche_de_renseignement,
+        cf_boisson_chaude,
+        cf_modifications,
+
+        -- metadata
+        created_by,
+        modified_by,
+        onhold_time
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_details.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_details.sql
@@ -14,7 +14,7 @@ renamed as (
         -- primary key + foreign key to stg_zoho_desk__tickets
         -- (colonne source nommée _zoho_desk_tickets_id car le transformer dlt
         --  utilisait la ressource `tickets` comme parent)
-        _zoho_desk_tickets_id                               as ticket_id,
+        _zoho_desk_tickets_id as ticket_id,
 
         -- sla (indicateurs et flags regroupés par domaine)
         sla_id,
@@ -31,11 +31,11 @@ renamed as (
         contract_id,
 
         -- engagement counts (STRING in source → INT64)
-        SAFE_CAST(follower_count    AS INT64)                as follower_count,
-        SAFE_CAST(tag_count         AS INT64)                as tag_count,
-        SAFE_CAST(approval_count    AS INT64)                as approval_count,
-        SAFE_CAST(time_entry_count  AS INT64)                as time_entry_count,
-        SAFE_CAST(task_count        AS INT64)                as task_count,
+        safe_cast(follower_count as int64) as follower_count,
+        safe_cast(tag_count as int64) as tag_count,
+        safe_cast(approval_count as int64) as approval_count,
+        safe_cast(time_entry_count as int64) as time_entry_count,
+        safe_cast(task_count as int64) as task_count,
 
         -- custom fields (tous STRING — caster dans les marts si nécessaire)
         cf_statut_client,

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_history.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_history.sql
@@ -11,7 +11,7 @@ with source as (
 
 renamed as (
     select
-        -- primary key (dlt internal — exposé pour jointure vers stg_zoho_desk__ticket_history_event_info._dlt_parent_id)
+        -- primary key (dlt internal) — jointure vers ticket_history_event_info._dlt_parent_id
         _dlt_id,
 
         -- foreign key

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_history.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_history.sql
@@ -1,0 +1,35 @@
+{{
+    config(
+        materialized='table',
+        description='Journal d audit par ticket — une ligne par événement (création, changement de statut, assigné, etc.). Source de vérité pour les métriques temporelles. Pas de colonne id à renommer : la PK est _dlt_id (clé interne dlt).'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_ticket_history') }}
+),
+
+renamed as (
+    select
+        -- primary key (dlt internal — exposé pour jointure vers stg_zoho_desk__ticket_history_event_info._dlt_parent_id)
+        _dlt_id,
+
+        -- foreign key
+        _zoho_desk_associated_tickets_id,
+
+        -- event (event_name et event_time restent ensemble — ils définissent l'événement)
+        event_name,
+        event_time,
+
+        -- source
+        source,
+
+        -- actor
+        actor__id,
+        actor__name,
+        actor__type
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_history_event_info.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_history_event_info.sql
@@ -1,0 +1,53 @@
+{{
+    config(
+        materialized='table',
+        description='Détail des champs modifiés par événement de ticket_history — une ligne par champ modifié. Jointure : _dlt_parent_id = stg_zoho_desk__ticket_history._dlt_id. Filtrer sur property_name pour isoler un type de changement (Status, Assignee, Priority, etc.).'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_ticket_history__event_info') }}
+),
+
+renamed as (
+    select
+        -- primary key (dlt internal)
+        _dlt_id,
+
+        -- foreign key to stg_zoho_desk__ticket_history (dlt internal)
+        _dlt_parent_id,
+
+        -- property metadata
+        property_name,
+        property_type,
+        system_property,
+
+        -- scalar value (quand la valeur n'est pas un before/after — ex : première assignation)
+        property_value,
+        property_value__id,
+        property_value__name,
+        property_value__type,
+
+        -- valeur AVANT modification
+        -- scalaire : property_value__previous_value (ex : 'Open')
+        -- objet    : property_value__previous_value__id / __name / __type (ex : agent précédent)
+        property_value__previous_value,
+        property_value__previous_value__id,
+        property_value__previous_value__name,
+        property_value__previous_value__type,
+
+        -- valeur APRÈS modification
+        -- scalaire : property_value__updated_value (ex : 'Closed')
+        -- objet    : property_value__updated_value__id / __name / __type (ex : nouvel agent)
+        property_value__updated_value,
+        property_value__updated_value__id,
+        property_value__updated_value__name,
+        property_value__updated_value__type,
+
+        -- metadata
+        _dlt_list_idx
+
+    from source
+)
+
+select * from renamed

--- a/models/staging/zoho_desk/stg_zoho_desk__tickets.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__tickets.sql
@@ -12,7 +12,7 @@ with source as (
 renamed as (
     select
         -- primary key
-        id                                                          as ticket_id,
+        id as ticket_id,
 
         -- foreign keys
         department_id,
@@ -74,8 +74,8 @@ renamed as (
         customer_response_time,
 
         -- counts (STRING in source → INT64)
-        SAFE_CAST(comment_count AS INT64)                           as comment_count,
-        SAFE_CAST(thread_count  AS INT64)                           as thread_count,
+        safe_cast(comment_count as int64) as comment_count,
+        safe_cast(thread_count as int64) as thread_count,
 
         -- metadata
         web_url

--- a/models/staging/zoho_desk/stg_zoho_desk__tickets.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__tickets.sql
@@ -1,0 +1,86 @@
+{{
+    config(
+        materialized='table',
+        description='Tickets Zoho Desk nettoyés — table centrale de toute lanalyse. Source : zoho_desk_associated_tickets. Renomme id en ticket_id.'
+    )
+}}
+
+with source as (
+    select * from {{ source('zoho_desk', 'zoho_desk_associated_tickets') }}
+),
+
+renamed as (
+    select
+        -- primary key
+        id                                                          as ticket_id,
+
+        -- foreign keys
+        department_id,
+        assignee_id,
+        contact_id,
+        account_id,
+        team_id,
+        product_id,
+        layout_id,
+
+        -- ticket identity
+        ticket_number,
+        subject,
+        language,
+
+        -- status & classification (flags restent dans leur domaine)
+        status,
+        status_type,
+        priority,
+        category,
+        sub_category,
+        is_archived,
+        is_spam,
+
+        -- channel
+        channel,
+        channel_code,
+
+        -- contact info at ticket creation
+        email,
+        phone,
+
+        -- sentiment (Zoho Zia AI)
+        sentiment,
+
+        -- last thread snapshot
+        last_thread,
+        last_thread__channel,
+        last_thread__direction,
+        last_thread__is_draft,
+        last_thread__is_forward,
+
+        -- source info
+        source__type,
+        source__app_name,
+        source__ext_id,
+        source__permalink,
+
+        -- on-hold duration (STRING, format propriétaire Zoho — différent de onhold_time qui est TIMESTAMP)
+        relationship_type,
+        on_hold_time,
+
+        -- dates (all TIMESTAMP in source — no cast needed)
+        created_time,
+        closed_time,
+        due_date,
+        response_due_date,
+        onhold_time,
+        customer_response_time,
+
+        -- counts (STRING in source → INT64)
+        SAFE_CAST(comment_count AS INT64)                           as comment_count,
+        SAFE_CAST(thread_count  AS INT64)                           as thread_count,
+
+        -- metadata
+        web_url
+
+    from source
+)
+
+select * from renamed


### PR DESCRIPTION
## Summary

Ce PR introduit la couche staging complète pour la source **Zoho Desk** (9 modèles), avec documentation des sources, tests d'intégrité référentielle et documentation d'architecture.

- **5 modèles dimension** : accounts, agents, contacts, departments, agent_departments
- **4 modèles fact** : tickets, ticket_details, ticket_history, ticket_history_event_info
- **Documentation** : `_zoho_desk__sources.yml`, `_zoho_desk__models.yml`, `docs/architecture/zoho_desk.md`

## Détail des modèles

| Modèle | Source | Lignes (~) | Particularité |
|---|---|---|---|
| `stg_zoho_desk__accounts` | `zoho_desk_accounts` | 251 | Cast CSAT percentages STRING → FLOAT64 |
| `stg_zoho_desk__agents` | `zoho_desk_agents` | 5 | Expose `_dlt_id` pour jointure agent_departments |
| `stg_zoho_desk__agent_departments` | `zoho_desk_agents__associated_department_ids` | 11 | Table pont agent ↔ département (jointure via `_dlt_id`) |
| `stg_zoho_desk__contacts` | `zoho_desk_contacts` | 3 362 | Cast account_count STRING → INT64 |
| `stg_zoho_desk__departments` | `zoho_desk_departments` | 4 | — |
| `stg_zoho_desk__tickets` | `zoho_desk_associated_tickets` | 20 678 | Cast comment/thread counts STRING → INT64 |
| `stg_zoho_desk__ticket_details` | `zoho_desk_ticket_details` | 20 678 | 1:1 avec tickets — expose 40+ champs custom `cf_*` |
| `stg_zoho_desk__ticket_history` | `zoho_desk_ticket_history` | 259 677 | Source de vérité pour métriques temporelles |
| `stg_zoho_desk__ticket_history_event_info` | `zoho_desk_ticket_history__event_info` | 823 452 | Détail des champs modifiés (avant/après) |

## Conventions appliquées

- Tous les modèles sont `materialized='table'` (configuré au niveau dossier dans `dbt_project.yml`)
- Colonne `id` renommée en `{entity}_id` dans chaque modèle pour cohérence des jointures
- Ordre des colonnes : PK → FKs → attributs métier par domaine → dates → counts → `cf_*` → metadata
- `safe_cast()` utilisé pour tous les casts (retourne NULL plutôt que d'échouer sur une valeur invalide)

## Tests

- `unique` + `not_null` sur toutes les PKs
- `not_null` sur les FKs obligatoires
- `relationships` sur toutes les FKs — validés via `dbt build --select models/staging/zoho_desk` ✅

## Documentation

- `docs/architecture/zoho_desk.md` : flux de données, diagramme Mermaid des relations, exemples de jointures SQL, points d'attention (closed_time, _dlt_id, cf_* types)

## Test plan

- [x] `dbt build --select models/staging/zoho_desk` — tous les tests passent
- [ ] Vérifier les row counts des tables matérialisées dans `staging`
- [ ] Valider les jointures clés dans BigQuery (tickets ↔ departments, history ↔ event_info)

🤖 Generated with [Claude Code](https://claude.com/claude-code)