### PR TITLE
fix: adapt yuman contacts to N-N model and harden parsing

### DIFF
--- a/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
+++ b/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
@@ -12,6 +12,7 @@ with workorder_demands as (
         material_id,
         site_id,
         client_id,
+        contact_id,
         user_id,
         demand_description,
         demand_status,
@@ -114,34 +115,15 @@ tech_agence_mapping as (
     from {{ ref('ref_yuman__tech_agence') }}
 ),
 
-contacts_per_site as (
-    select
-        contact_id,
-        site_id,
-        contact_name,
-        contact_title,
-        contact_phone,
-        contact_mobile,
-        contact_email,
-        row_number() over (
-            partition by site_id
-            order by created_at desc
-        ) as rn
-    from {{ ref('stg_yuman__contacts') }}
-    where site_id is not null
-),
-
 contacts as (
     select
         contact_id,
-        site_id,
         contact_name,
         contact_title,
         contact_phone,
         contact_mobile,
         contact_email
-    from contacts_per_site
-    where rn = 1
+    from {{ ref('stg_yuman__contacts') }}
 )
 
 select
@@ -234,7 +216,7 @@ left join clients as cl
 left join sites as s
     on wd.site_id = s.site_id
 left join contacts as c
-    on wd.site_id = c.site_id
+    on wd.contact_id = c.contact_id
 left join materials as m
     on wd.material_id = m.material_id
 left join materials_categories as mc

--- a/models/staging/nesp_tech/stg_nesp_tech__interventions.sql
+++ b/models/staging/nesp_tech/stg_nesp_tech__interventions.sql
@@ -103,7 +103,13 @@ cleaned_data as (
         case
             when lower(trim(pickup_date)) in ('nat', 'nan') then null
             when pickup_date like '01/01/0001%' then null
-            else timestamp(pickup_date)
+            else coalesce(
+                safe_cast(pickup_date as timestamp),
+                safe.parse_timestamp(
+                    '%d/%m/%Y %H:%M',
+                    regexp_replace(pickup_date, r'^(\d{2}/\d{2}/)00(\d{2})', r'\1' || '20' || r'\2')
+                )
+            )
         end as pickup_date,
         case
             when lower(trim(date_planning_nomadrepair)) in ('nat', 'nan') then null

--- a/models/staging/yuman/_yuman__models.yml
+++ b/models/staging/yuman/_yuman__models.yml
@@ -27,20 +27,20 @@ models:
         tests:
           - unique
           - not_null
-      - name: client_id
-        description: "Référence vers le client rattaché"
-        tests:
-          - relationships:
-              arguments:
-                to: ref('stg_yuman__clients')
-                field: client_id
-      - name: site_id
-        description: "Référence vers le site rattaché"
-        tests:
-          - relationships:
-              arguments:
-                to: ref('stg_yuman__sites')
-                field: site_id
+#      - name: client_id
+#        description: "Référence vers le client rattaché"
+#        tests:
+#          - relationships:
+#              arguments:
+#                 to: ref('stg_yuman__clients')
+#                 field: client_id
+#       - name: site_id
+#         description: "Référence vers le site rattaché"
+#         tests:
+#           - relationships:
+#               arguments:
+#                 to: ref('stg_yuman__sites')
+#                 field: site_id
       - name: category_id
         description: "Identifiant de la catégorie du contact"
       - name: contact_name

--- a/models/staging/yuman/stg_yuman__contacts.sql
+++ b/models/staging/yuman/stg_yuman__contacts.sql
@@ -16,8 +16,6 @@ cleaned as (
 
     select
         id as contact_id,
-        client_id,
-        site_id,
         category_id,
         name as contact_name,
         title as contact_title,


### PR DESCRIPTION
## Summary

- **Yuman contacts (N-N migration)** : `client_id` et `site_id` ont disparu de la réponse de `/v1/contacts` suite à l'évolution du modèle Yuman (relation contact↔client/site passée de 1-N à N-N). Adaptation de `stg_yuman__contacts` (suppression des colonnes + tests `relationships` retirés du YAML) et de l'intermediate `int_yuman__demands_workorders_enriched` (ajout d'un CTE `contacts` et jointure via `wd.contact_id`).
- **nesp_tech interventions** : robustification du parsing de `pickup_date` avec `safe_cast` + `safe.parse_timestamp` en fallback pour gérer les formats legacy de type `01/01/00YY`.

> Note : la reconstruction de la table de pont contact↔site (via `POST /contacts/filter`) fait l'objet d'un pipeline séparé `ingest_yuman_contact_links` dans le repo `extract_load`, hors de ce PR.

## Test plan

- [ ] CI dbt build passe sur dev
- [ ] `dbt build -s +stg_yuman__contacts` OK
- [ ] `dbt build -s +int_yuman__demands_workorders_enriched` OK
- [ ] `dbt build -s +stg_nesp_tech__interventions` OK
- [ ] Vérifier qu'aucun mart en aval ne casse à cause de la perte de `client_id`/`site_id` sur les contacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)