### PR TITLE
feat(oracle_neshu): keep inactive contracts in dim_contract

### DIFF
--- a/models/marts/oracle_neshu/dim_oracle_neshu__contract.sql
+++ b/models/marts/oracle_neshu/dim_oracle_neshu__contract.sql
@@ -105,9 +105,8 @@ from (
         *,
         ROW_NUMBER() over (
             partition by company_id
-            order by current_end_date desc, original_start_date desc, contract_id asc
+            order by is_active desc, current_end_date desc, original_start_date desc, contract_id asc
         ) as rn
     from aggreated_contract
-    where is_active = true
 ) as subq
 where rn = 1


### PR DESCRIPTION
## Summary
- Drop the `is_active = true` filter in `dim_oracle_neshu__contract` so inactive contracts are also exposed (Business needs them for historical reporting).
- Add `is_active desc` as the primary key of the `ROW_NUMBER()` ordering, so companies with both an active and an inactive contract still surface the active one.
- Grain unchanged: 1 row per `company_id`.

## Impact (validated on dev)
| Metric | Before | After |
|---|---|---|
| Rows | 171 | 226 |
| Active contracts kept | 171 | 171 |
| Inactive contracts kept | 0 | 55 |

## Test plan
- [x] `dbt build -s dim_oracle_neshu__contract` on dev — validated by author
- [x] Row count + uniqueness on `company_id` checked against `prod_staging`
- [ ] Power BI consumers warned that `is_active` is now meaningful (not always true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)