### PR TITLE
fix(oracle_neshu): filter null company_id in dim_contract

### DIFF
--- a/models/marts/oracle_neshu/dim_oracle_neshu__contract.sql
+++ b/models/marts/oracle_neshu/dim_oracle_neshu__contract.sql
@@ -28,6 +28,7 @@ with contract_labels as (
         on lhc.idlabel = l.idlabel
     left join {{ ref('stg_oracle_neshu__label_family') }} as lf
         on l.idlabel_family = lf.idlabel_family
+    where c.idcompany_peer is not null
 ),
 
 aggregated_labels as (


### PR DESCRIPTION
## Summary
- Filter out contracts where `idcompany_peer` is NULL in `dim_oracle_neshu__contract`
- Applied in the first CTE (`contract_labels`) to avoid propagating useless rows through the label pivot and `ROW_NUMBER()` window

## Test plan
- [ ] `dbt build -s +dim_oracle_neshu__contract` on dev
- [ ] Check row count vs previous run (expected: fewer rows, none with null `company_id`)
- [ ] Validate downstream marts referencing `dim_oracle_neshu__contract`

🤖 Generated with [Claude Code](https://claude.com/claude-code)