### PR TITLE
feat(yuman): add storehouse-to-user relationship and clean up contacts YAML

### DIFF
--- a/docs/architecture/yuman.md
+++ b/docs/architecture/yuman.md
@@ -1,6 +1,6 @@
 # Architecture — Yuman
 
-> Dernière mise à jour : 2026-05-18
+> Dernière mise à jour : 2026-05-19
 
 ---
 
@@ -181,7 +181,9 @@ erDiagram
     }
 
     stg_yuman__storehouses {
-        int storehouses_id PK
+        int storehouses_id PK_FK
+        string storehouses_name
+        string storehouses_address
     }
 
     %% Hiérarchie client / site / matériel
@@ -218,6 +220,9 @@ erDiagram
 
     %% Purchase orders
     stg_yuman__products ||--o{ stg_yuman__purchase_orders : "product_id"
+
+    %% Storehouse = entrepôt mobile d'un user (technicien/manager)
+    stg_yuman__users ||--o| stg_yuman__storehouses : "user_id = storehouses_id"
 ```
 
 ---
@@ -237,7 +242,7 @@ erDiagram
 | `stg_yuman__products` | Catalogue des produits / pièces détachées | 4 000 |
 | `stg_yuman__workorders_categories` | Catégories d'intervention | 64 |
 | `stg_yuman__workorder_demands_categories` | Catégories de demandes d'intervention | 57 |
-| `stg_yuman__storehouses` | Entrepôts | 45 |
+| `stg_yuman__storehouses` | Entrepôts mobiles. `storehouses_id` correspond au `user_id` du technicien ou manager propriétaire (41/45). Exceptions : 4 ateliers physiques (Rungis/Lyon, Lyon, Strasbourg, Bordeaux) sans user associé | 45 |
 
 ### Facts — les événements
 
@@ -369,6 +374,24 @@ Ces deux modèles staging "explosent" un JSON array de la source :
 - `workorder_products` : 1 ligne = 1 produit utilisé sur 1 workorder, issu
   de `_embed_products` dans `yuman_workorders`. Cela évite d'avoir à
   re-parser le JSON dans chaque mart consommateur.
+
+### `storehouses_id` est identique au `user_id` du propriétaire
+Un storehouse Yuman représente l'entrepôt mobile (stock embarqué) d'un
+technicien ou d'un manager. La règle métier — non documentée par Yuman mais
+vérifiée empiriquement — est que `storehouses_id = user_id`. Sur 45
+storehouses : 38 matchent un technicien, 3 matchent un manager, et 4 sont des
+**ateliers physiques** sans user associé :
+
+| storehouses_id | Nom |
+|---|---|
+| 1891 | 06 - ATELIER RUNGIS DEPOT *(adresse Dardilly/69 — incohérence libellé)* |
+| 311335 | 07 - ATELIER LYON DEPOT |
+| 311336 | 09 - ATELIER STRASBOURG DEPOT |
+| 311337 | 08 - ATELIER BORDEAUX DEPOT |
+
+Un test `relationships` (severity = `warn`) entre `stg_yuman__storehouses.storehouses_id`
+et `stg_yuman__users.user_id` est en place dans `_yuman__models.yml` pour
+détecter toute dérive future (sortie de plus de 4 orphelins → alerte).
 
 ### Le rattachement technicien → agence passe par un mapping nom/prénom
 Yuman ne porte pas l'agence du technicien. Le mapping est fourni par un seed

--- a/models/staging/yuman/_yuman__models.yml
+++ b/models/staging/yuman/_yuman__models.yml
@@ -27,20 +27,6 @@ models:
         tests:
           - unique
           - not_null
-#      - name: client_id
-#        description: "Référence vers le client rattaché"
-#        tests:
-#          - relationships:
-#              arguments:
-#                 to: ref('stg_yuman__clients')
-#                 field: client_id
-#       - name: site_id
-#         description: "Référence vers le site rattaché"
-#         tests:
-#           - relationships:
-#               arguments:
-#                 to: ref('stg_yuman__sites')
-#                 field: site_id
       - name: category_id
         description: "Identifiant de la catégorie du contact"
       - name: contact_name
@@ -412,10 +398,24 @@ models:
         description: "Date de dernière mise à jour de l'association produit-workorder dans Yuman"
 
   - name: stg_yuman__storehouses
-    description: "Storehouses clean depuis la table source yuman_storehouses"
+    description: >
+      Storehouses clean depuis la table source yuman_storehouses.
+      Règle métier : storehouses_id correspond au user_id du technicien ou
+      manager propriétaire de l'entrepôt mobile. Exception : les ateliers
+      physiques (Rungis/Lyon, Lyon, Strasbourg, Bordeaux) n'ont pas de user
+      associé — 4 enregistrements concernés.
     columns:
       - name: storehouses_id
-        description: "Identifiant unique du storehouses (clé primaire)"
+        description: >
+          Identifiant unique du storehouse. Correspond au user_id du technicien
+          ou manager propriétaire de l'entrepôt mobile. NULL match attendu pour
+          les ateliers physiques.
         tests:
           - unique
           - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_yuman__users')
+                field: user_id
+              config:
+                severity: warn

--- a/models/staging/yuman/_yuman__sources.yml
+++ b/models/staging/yuman/_yuman__sources.yml
@@ -96,10 +96,6 @@ sources:
               - unique
               - not_null
             description: "Identifiant unique du contact"
-          - name: client_id
-            description: "Identifiant du client rattaché"
-          - name: site_id
-            description: "Identifiant du site rattaché"
           - name: category_id
             description: "Identifiant de la catégorie du contact"
           - name: name


### PR DESCRIPTION
## Summary
- **Storehouse ↔ User relationship** — adds a `relationships` test (`severity: warn`) on `stg_yuman__storehouses.storehouses_id → stg_yuman__users.user_id`. The business rule is that a storehouse is the mobile stock of a technician or manager: 41/45 storehouses match a user; 4 are physical workshops with no associated user (Rungis/Lyon, Lyon, Strasbourg, Bordeaux).
- **Contacts YAML cleanup** — removes `client_id` and `site_id` from the source YAML (they no longer exist in `prod_raw.yuman_contacts`, verified via INFORMATION_SCHEMA) and deletes the corresponding commented-out blocks in `_yuman__models.yml`.
- **Doc update** — `docs/architecture/yuman.md` updated with the new relationship in the ERD and a dedicated "Points d'attention" entry listing the 4 orphan workshops.

## Test plan
- [x] `dbt parse` passes (validated locally with `dbt_venv`)
- [x] `dbt test --select stg_yuman__storehouses --target dev` returns exactly `WARN 4` — the 4 expected orphan workshops
- [ ] Review the updated mermaid ER diagram on GitHub
- [ ] Cross-check the 4 listed orphans against the functional owner's knowledge (in particular: `storehouses_id=1891` labelled "RUNGIS" but located in Dardilly — possible inconsistency to raise with Yuman owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)