### PR TITLE
feat(mssql_sage): expose do_domaine/do_type on f_docligne and clean up staging

### DIFF
--- a/docs/architecture/mssql_sage.md
+++ b/docs/architecture/mssql_sage.md
@@ -162,6 +162,8 @@ erDiagram
     stg_mssql_sage__f_docligne {
         int dl_no PK
         int cbco_no FK
+        int do_domaine
+        int do_type
         string ct_num FK
         timestamp do_date
         float dl_montant_ht
@@ -195,7 +197,7 @@ erDiagram
 |---|---|---|
 | `stg_mssql_sage__f_comptet` | Comptes clients Nunshen. Source raw stockée **en JSON** (colonne `data`). | 12 156 |
 | `stg_mssql_sage__f_collaborateur` | Commerciaux Nunshen. Source raw stockée **en JSON**. | 166 |
-| `stg_mssql_sage__f_docligne` | Lignes de vente Nunshen. Source raw stockée **en JSON**. Partitionné sur `do_date`. **Incremental** (filtre `updated_at` + 7 jours de marge). | 326 910 |
+| `stg_mssql_sage__f_docligne` | Lignes de documents Sage (ventes + achats + stock). Filtrer `do_domaine = 0` pour les ventes pures. Source raw stockée **en JSON**. Partitionné sur `do_date`. **Incremental** (filtre `updated_at` + 7 jours de marge). | 326 910 |
 
 ---
 
@@ -236,7 +238,8 @@ select
 from stg_mssql_sage__f_docligne d
 left join stg_mssql_sage__f_comptet      cl   on cl.ct_num = d.ct_num
 left join stg_mssql_sage__f_collaborateur coll on coll.co_no = d.cbco_no
-where d.do_date >= '2026-01-01'
+where d.do_domaine = 0          -- 0 = ventes (exclut stock interne et achats)
+  and d.do_date >= '2026-01-01'
 ```
 
 **P&L direct depuis le mart (cas Power BI) :**
@@ -310,7 +313,7 @@ de chaque domaine :
 | Relation | Taux de match | Interprétation |
 |---|---|---|
 | `f_ecriturea.ec_no → f_ecriturec.ec_no` | testé en staging (100 % attendu) | Toute écriture analytique vient d'une écriture comptable |
-| `f_docligne.ct_num → f_comptet.ct_num` | 70 % (228 173 / 326 910) | 30 % des ventes pointent vers `ct_num = '1'` (cf. plus bas) |
+| `f_docligne.ct_num → f_comptet.ct_num` (domaine 0) | 100 % attendu | Voir gotcha ci-dessous : sans filtrage `do_domaine = 0`, 30 % d'orphelins illusoires |
 | `f_comptet.co_no → f_collaborateur.co_no` | 65 % (7 849 / 12 156) | 35 % des comptes clients n'ont pas de commercial attribué |
 
 Les jointures sur ces FK doivent systématiquement être en `LEFT JOIN`,
@@ -360,15 +363,31 @@ Conséquence : sur 2024 et pour les BU non budgétées, toutes les colonnes
 `budget`, `budget_ytd`, `ecart_vs_budget*` du mart sont `NULL`. À enrichir
 avec la DAF si Power BI doit afficher des écarts sur ces périmètres.
 
-### `ct_num = '1'` côté `f_docligne` : compte client générique
-~30 % des lignes de `f_docligne` (~98 k) n'ont pas de match dans
-`f_comptet`. Échantillonnage des plus récentes : **toutes ont `ct_num = '1'`**,
-qui correspond vraisemblablement à un **compte tiers générique** côté Sage
-(type "vente au comptoir" ou "divers"). Ce n'est probablement pas un défaut
-de qualité, mais à confirmer fonctionnellement.
+### `f_docligne` mélange ventes, achats et mouvements de stock
+`f_docligne` agrège **trois types de documents Sage** que le pipeline expose
+désormais explicitement via les colonnes `do_domaine` et `do_type` :
 
-→ Recommandation : si besoin Power BI de marquer ces ventes, ajouter une
-colonne `is_generic_customer` au staging plutôt que de filtrer.
+| `do_domaine` | Lignes (~) | Total HT | Sens |
+|---|---|---|---|
+| `0` | 224 901 | 10,2 M€ | **Ventes** (CT_Num = client Nunshen, jointure à `f_comptet` valide) |
+| `1` | 3 272 | 3,2 M€ | Achats / autre flux marginal |
+| `2` | **98 737** | 27,0 M€ | **Stock interne** (CT_Num = code d'entrepôt numérique, **pas** un client) |
+
+Les 98 737 lignes en `do_domaine = 2` sont les responsables des « 30 % de
+ventes orphelines » historiquement observés. Le `CT_Num` y prend des valeurs
+chiffrées (`1`, `2`, `3`, `7`, `8`…) qui sont en réalité des identifiants
+de dépôts Sage, pas des clients. Le `do_type` y vaut typiquement 20, 21,
+23, 24 ou 26 (entrée / sortie / transfert / ajustement / fabrication).
+
+**Conséquences pour les analystes** :
+- Pour un **P&L commercial Nunshen** : filtrer `do_domaine = 0` côté mart.
+- Pour une **analyse logistique** (rotation, mouvements inter-dépôts) :
+  filtrer `do_domaine = 2`.
+- Pour **ne pas casser** les jointures `ct_num → f_comptet` historiques :
+  toujours filtrer explicitement le domaine — ne pas joindre tel quel.
+
+Le staging ne filtre **pas** par domaine — il expose les trois pour
+permettre toutes les analyses en aval.
 
 ### Champs Sage non documentés
 Le YAML source recense plusieurs champs marqués « non documenté Sage » sur

--- a/docs/architecture/mssql_sage.md
+++ b/docs/architecture/mssql_sage.md
@@ -197,7 +197,7 @@ erDiagram
 |---|---|---|
 | `stg_mssql_sage__f_comptet` | Comptes clients Nunshen. Source raw stockée **en JSON** (colonne `data`). | 12 156 |
 | `stg_mssql_sage__f_collaborateur` | Commerciaux Nunshen. Source raw stockée **en JSON**. | 166 |
-| `stg_mssql_sage__f_docligne` | Lignes de documents Sage (ventes + achats + stock). Filtrer `do_domaine = 0` pour les ventes pures. Source raw stockée **en JSON**. Partitionné sur `do_date`. **Incremental** (filtre `updated_at` + 7 jours de marge). | 326 910 |
+| `stg_mssql_sage__f_docligne` | Lignes de documents Sage (ventes + achats + stock). Filtrer `do_domaine = 0` pour les ventes pures. Source raw stockée **en JSON**. Partitionné sur `do_date`. Matérialisé en `table` (full refresh). | 326 910 |
 
 ---
 

--- a/models/staging/mssql_sage/_mssql_sage__models.yml
+++ b/models/staging/mssql_sage/_mssql_sage__models.yml
@@ -192,8 +192,26 @@ models:
               arguments:
                 to: ref('stg_mssql_sage__f_collaborateur')
                 field: co_no
+      - name: do_domaine
+        description: >
+          Domaine du document Sage. Valeurs observées :
+          0 = Ventes (~225 k lignes, CT_Num pointe vers f_comptet),
+          1 = Achats / autre flux (~3 k lignes),
+          2 = Stock interne (~99 k lignes, CT_Num est un code dépôt
+          numérique et ne pointe PAS vers f_comptet).
+          Filtrer sur do_domaine = 0 pour ne garder que les ventes Nunshen.
+      - name: do_type
+        description: >
+          Type de document Sage à l'intérieur d'un domaine. Pour
+          do_domaine = 0 (ventes) : facture / avoir / livraison /
+          devis selon la valeur. Pour do_domaine = 2 (stock) : entrée,
+          sortie, transfert, etc.
       - name: ct_num
-        description: "Code du compte client associé"
+        description: >
+          Code du compte client associé pour les ventes (do_domaine = 0).
+          Pour do_domaine = 2 (stock interne), ct_num est un code
+          d'entrepôt / dépôt numérique et ne correspond PAS à un client
+          de f_comptet.
       - name: do_piece
         description: "Pièce associée à la ventes"
       - name: dl_design

--- a/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
@@ -1,13 +1,12 @@
 {{
     config(
         materialized='table',
-        unique_key='dl_no',
         partition_by={
             "field": "do_date",
             "data_type": "timestamp",
             "granularity": "day"
         },
-        description='Table des ventes Nunshen nettoyée et transformée depuis la table source dbo_f_docligne de MSSQL Sage'
+        description='Table des documents Sage Nunshen (ventes, achats, stock) nettoyée et transformée depuis dbo_f_docligne. Filtrer do_domaine = 0 pour ne garder que les ventes.'
     )
 }}
 
@@ -50,15 +49,3 @@ cleaned_data as (
 
 select *
 from cleaned_data
-
-
-{% if is_incremental() %}
-where
-    (
-        updated_at > (
-            select max(updated_at)
-            from {{ this }}
-        )
-        or updated_at >= timestamp_sub(current_timestamp(), interval 7 day)
-    )
-{% endif %}

--- a/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
@@ -22,6 +22,11 @@ cleaned_data as (
         cast(json_value(data, '$.DL_No') as int64) as dl_no, -- PK
         cast(json_value(data, '$.cbCO_No') as int64) as cbco_no, -- FK pour table collaborateur
 
+        -- Domaine et type Sage (filtrage métier en aval)
+        -- DO_Domaine : 0 = Ventes, 1 = Achats/autre, 2 = Stock interne
+        cast(json_value(data, '$.DO_Domaine') as int64) as do_domaine,
+        cast(json_value(data, '$.DO_Type') as int64) as do_type,
+
         -- Champs principaux
         json_value(data, '$.CT_Num') as ct_num,
         json_value(data, '$.DO_Piece') as do_piece,


### PR DESCRIPTION
## Summary
- **Expose `do_domaine` and `do_type`** on `stg_mssql_sage__f_docligne`. The raw `dbo_f_docligne` table mixes three Sage document domains and the staging only exposed `ct_num` so far, making 99 k stock-movement rows look like orphan sales.
- **Drop the dead `is_incremental()` block** and the unused `unique_key='dl_no'` from the staging config. The model was already `materialized='table'`, so the incremental code never executed.
- **Update docs and YAML** to reflect both changes (and fix the architecture doc which mistakenly described this model as incremental).

## Diagnostic (run via MCP on `prod_raw.dbo_f_docligne`)
| `do_domaine` | Rows | `ct_num` matches `f_comptet` | Interpretation |
|---|---|---|---|
| 0 | 224 901 (69 %) | 100 % | **Sales** — Nunshen customers |
| 1 | 3 272 (1 %) | 100 % | Purchases / other |
| 2 | 98 737 (30 %) | 0 % | **Internal stock movements** — `ct_num` is a warehouse code, not a customer |

The 30 % « orphan sales » historically observed are entirely explained by `do_domaine = 2`. Downstream marts can now filter `do_domaine = 0` explicitly instead of relying on a broken join.

## Test plan
- [x] `dbt parse` passes locally with `dbt_venv`
- [x] `sqlfluff lint` clean after dropping dead block
- [ ] CI `dbt build --exclude resource_type:snapshot` on dev should pass
- [ ] Verify the new `do_domaine` and `do_type` columns appear in `prod_staging.stg_mssql_sage__f_docligne` after the first prod build
- [ ] **Follow-up (out of scope of this PR)** : decide with the DA / finance team whether to add `where do_domaine = 0` to the existing Nunshen sales marts, or leave it to each consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)