### PR TITLE
fix(yuman): classify is_active across all INACTIF locales

### DIFF
--- a/models/staging/yuman/stg_yuman__users.sql
+++ b/models/staging/yuman/stg_yuman__users.sql
@@ -58,7 +58,7 @@ final as (
         user_type,
         user_phone,
         is_manager_as_technician,
-        lower(user_inactif) != 'oui' as is_active,
+        lower(user_inactif) not in ('oui', 'sì', 'si', 'yes', 'true') as is_active,
         created_at,
         updated_at,
         extracted_at,


### PR DESCRIPTION
## Summary
- Yuman's `_embed_fields.INACTIF` value is returned in the user's UI locale (`Oui`/`Non` FR, `Yes`/`No` EN, `Sì`/`No` IT), not as a normalized boolean.
- `stg_yuman__users` only matched `'oui'`, so Italian users flagged inactive with `Sì` (e.g. **BAYARMAA MARGAD**) appeared as active downstream.
- Fix: classify `is_active = false` for any of `oui`, `sì`, `si`, `yes`, `true` (case-insensitive).

## Diagnostic (current distribution)
| Value | Locale | Meaning | Count |
|---|---|---|---|
| `Non` | FR | active | 36 |
| `No` | EN/IT | active | 26 |
| `Sì` | IT | inactive | 18 |
| `Oui` | FR | inactive | 14 |

## Test plan
- [ ] `dbt build -s stg_yuman__users` on dev
- [ ] Confirm BAYARMAA MARGAD now has `is_active = false` in `dev_staging.stg_yuman__users`
- [ ] Spot-check a few `Oui`, `Sì`, `Non`, `No` users match business expectations
- [ ] Verify downstream marts that consume `is_active` reflect the corrected flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)