### PR TITLE
docs(marts-refacto): Phase 0 inventory + BU naming convention

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -29,6 +29,34 @@ Le double underscore `__` separe la source de l'entite.
 > va dans un dossier BU (`marts/technique/`) et non dans un dossier source (`marts/oracle_neshu/`).
 > Le prefixe du nom reflete la BU, pas la source. Voir `docs/scheduling_and_tagging_decisions.md`.
 
+### Nommage des marts — convention by BU (refacto en cours)
+
+> **Statut :** convention cible documentee. Application planifiee lors du refacto
+> `marts/` by BU — voir `docs/migration-marts/`. Tant que la migration n'est pas
+> faite, les anciens noms `fct_<source>__...` restent en place.
+
+Apres refacto, les marts sont organises par **BU/domaine** (folder = BU), pas par source.
+Le nom du modele reflete la BU et l'entite metier, pas l'implementation source.
+
+| Element | Regle |
+|---------|-------|
+| Prefixe | `dim_` (dimension) ou `fct_` (fait) |
+| Cle BU/domaine | nom exact du folder : `neshu`, `lcdp`, `technique`, `commerce`, `finance`, `services_generaux`, `supply_chain` |
+| Separateur | `__` entre BU et entite |
+| Entite | singulier, snake_case, nom metier (pas le nom source, pas le nom du rapport BI) |
+| Suffixe de grain | uniquement si agrege au-dessus du grain naturel (`_quinzaine`, `_mensuel`) |
+| Suffixe de source | uniquement en cas de collision dans le meme folder (ex. `fct_supply_chain__stock_neshu` vs `fct_supply_chain__stock_yuman`) |
+| Nom du rapport BI | jamais dans le nom du mart — va dans l'`exposure` |
+
+Exemples (avant → apres) :
+
+| Avant | Apres | Pourquoi |
+|-------|-------|----------|
+| `fct_oracle_neshu__conso_business_review` | `fct_neshu__consommation` | source droppee, nom de rapport BI deplace vers exposure |
+| `fct_mssql_sage__pnl_bu_kpis` | `fct_finance__pnl_bu` | `_kpis` implicite dans un fait |
+| `dim_yuman__materials` | `dim_technique__material` | singulier, pas de source |
+| `fct_oracle_neshu__chargement_par_quinzaine` | `fct_neshu__chargement_quinzaine` | suffixe de grain conserve |
+
 ### Fichiers YAML
 
 Chaque source a deux fichiers YAML dans son dossier staging :

--- a/docs/migration-marts/README.md
+++ b/docs/migration-marts/README.md
@@ -1,0 +1,269 @@
+# Marts refacto by BU — preparation
+
+> Internal doc — design and migration plan for reorganizing `models/marts/` by Business Unit.
+> Status: **preparation, not started**. Last updated: 2026-05-19.
+>
+> **Companion docs:**
+> - [`docs/architecture_review.md`](../architecture_review.md) — current state, source inventory, scheduling table
+> - [`docs/scheduling_and_tagging_decisions.md`](../scheduling_and_tagging_decisions.md) — tag conventions, cross-source patterns
+
+---
+
+## 1. Why we refacto
+
+Current `marts/` mixes two organizing axes:
+- **By source:** `oracle_neshu/`, `yuman/`, `mssql_sage/`, ... → mono-source marts
+- **By domain:** `technique/`, `commerce/` → cross-source marts
+
+This breaks as soon as a new mart belongs to a partner BU but spans sources outside the existing transverse domains. Trigger: May 2026 — cross-source mart for BU Neshu (appro `oracle_neshu` + technique `yuman`) had no natural home.
+
+Better to refacto before we accumulate 5–10 marts in the wrong place.
+
+---
+
+## 2. Core principles
+
+### 2.1 Per source from raw to intermediate, per BU at marts
+
+| Layer | Organization | Changes? |
+|---|---|---|
+| `prod_raw` (BigQuery) | per source | unchanged (out of dbt scope) |
+| `models/staging/` | per source | unchanged |
+| `models/intermediate/` | per source | unchanged — cross-source joins go **directly** into marts, never into intermediate |
+| `models/marts/` | **per BU + transverse domains** | **moved** |
+
+### 2.2 EL stays per source, T moves to BU
+
+Sources are shared across BUs (e.g. `yuman` serves Neshu, LCDP, Technique, Commerce, Supply Chain). Extraction frequency and connector ownership belong to the source, not the BU.
+
+| Layer | Today | After refacto |
+|---|---|---|
+| EL pipelines | `pipeline-<source>` (per source) | **Unchanged** structure, but `dbt build` step inside is **scoped down** to `tag:<source>,path:staging|intermediate` only |
+| T workflows | `transform-technique-daily`, `transform-commerce-daily` (per domain) | **One per mart folder**: `transform-<bu>-daily` and `transform-<domain>-daily` |
+
+### 2.3 Mart placement rule
+
+> *Who is this mart about?*
+>
+> - About a partner (internal client) → `marts/<partner>/` (e.g. `neshu/`, `lcdp/`)
+> - About EVS's own activity, transverse → `marts/<domain>/` (e.g. `commerce/`, `technique/`)
+> - About an EVS support function → `marts/<function>/` (e.g. `finance/`, `supply_chain/`, `services_generaux/`)
+
+A mart that crosses topics for one partner (e.g. Neshu maintenance preventive = Neshu commercial + Neshu technical data) stays in the **partner folder** (`neshu/`). The transverse `technique/` and `commerce/` are reserved for **non-partner-specific** EVS activity.
+
+---
+
+## 3. Target structure
+
+### 3.1 Mart folders (= Power BI workspaces, 1:1)
+
+| Folder | Type | Power BI workspace | Sources commonly used |
+|---|---|---|---|
+| `neshu/` | Partner BU | Neshu | oracle_neshu, yuman, zoho_desk (future) |
+| `lcdp/` | Partner BU | LCDP | oracle_lcdp, yuman, zoho_desk (future) |
+| `commerce/` | EVS transverse | Commerce | nesp_co, nesp_tech, yuman |
+| `technique/` | EVS transverse | Technique | nesp_co, nesp_tech, yuman |
+| `finance/` | EVS function | Finance | mssql_sage |
+| `services_generaux/` | EVS function | Services Généraux | gac |
+| `supply_chain/` | EVS function | Supply Chain | yuman_gcs, oracle_neshu_gcs, oracle_neshu |
+
+### 3.2 Adding a future partner BU
+
+Designed to scale. Adding e.g. `partner_xyz/` requires:
+1. New folder `models/marts/partner_xyz/` + `_partner_xyz__marts_models.yml`
+2. New subkey in `dbt_project.yml` under `marts:`
+3. New `transform-partner-xyz-daily.yaml` (copy from template)
+4. Two Terraform resources in `workflows.tf` (workflow + scheduler)
+5. New exposure file `models/exposures/partner_xyz.yml`
+
+~30 min of plumbing per new partner. No refacto of existing folders.
+
+---
+
+## 4. Orchestration: 7 T workflows
+
+### 4.1 EL pipeline scheduling (current state, unchanged)
+
+| Source | EL pipeline | Schedule |
+|---|---|---|
+| oracle_neshu | `pipeline-oracle-neshu` | `0 1 * * *` — daily 01:00 |
+| oracle_lcdp | `pipeline-oracle-lcdp` | `0 1 * * *` — daily 01:00 |
+| yuman | `pipeline-yuman` | `0 1 * * 1-5` — weekdays 01:00 |
+| mssql_sage | `pipeline-mssql-sage` | `0 1 * * 1-5` — weekdays 01:00 |
+| oracle_neshu_gcs | `pipeline-oracle-stock-theorique` | `0 23 * * *` — daily 23:00 |
+| yuman_gcs | `pipeline-sftp-gcs-yuman` | `0 6 * * 1-6` — Mon–Sat 06:00 |
+| nesp_co | `pipeline-nesp-co` | `0 8 * * *` — daily 08:00 |
+| nesp_tech | `pipeline-nesp-tech` | `30 7 * * 1` — Monday 07:30 (weekly) |
+| gac | `pipeline-sftp-evs` | `0 8 * * *` — daily 08:00 |
+
+### 4.2 Target T workflow schedules (+2h margin minimum)
+
+| T workflow | Waits for EL | Schedule |
+|---|---|---|
+| `transform-neshu-daily` | oracle_neshu (01:00), yuman (01:00) | `0 3 * * *` — daily 03:00 |
+| `transform-lcdp-daily` | oracle_lcdp (01:00), yuman (01:00) | `0 3 * * *` — daily 03:00 |
+| `transform-technique-daily` | nesp_co (08:00), nesp_tech (Mon 07:30), yuman (01:00) | `0 10 * * *` — daily 10:00 ⚠️ moved from 03:00 |
+| `transform-commerce-daily` | nesp_co (08:00), nesp_tech (Mon 07:30), yuman (01:00) | `0 10 * * *` — daily 10:00 |
+| `transform-finance-daily` | mssql_sage (01:00 weekdays) | `0 3 * * 1-5` — weekdays 03:00 |
+| `transform-services-generaux-daily` | gac (08:00) | `0 10 * * *` — daily 10:00 |
+| `transform-supply-chain-daily` | oracle_neshu_gcs (23:00 prev day), yuman_gcs (06:00), oracle_neshu (01:00) | `0 8 * * *` — daily 08:00 |
+
+**⚠️ Schedule fix:** `transform-technique-daily` currently runs at 03:00 but its sources `nesp_co` (08:00) and `nesp_tech` (Mon 07:30) finish later. Today this means technique marts use **previous day's** nesp data. Moving to 10:00 fixes this. Same applies to the new `transform-commerce-daily`.
+
+**Note:** `transform-commerce-daily` does **not exist today** — commerce marts are not currently orchestrated by a dedicated workflow. To be created as part of the refacto.
+
+---
+
+## 5. Critical things to watch
+
+### 5.1 `dbt_project.yml` — must be rewritten
+Today: per-source subkeys auto-tag every mart. After refacto: replace with BU/domain subkeys.
+
+```yaml
+# Before
+marts:
+  oracle_neshu:
+    +tags: ['marts', 'oracle_neshu']
+  technique:
+    +tags: ['marts', 'technique']
+
+# After
+marts:
+  neshu:
+    +tags: ['marts', 'neshu']
+  lcdp:
+    +tags: ['marts', 'lcdp']
+  commerce:
+    +tags: ['marts', 'commerce']      # unchanged
+  technique:
+    +tags: ['marts', 'technique']     # unchanged (scope reduced — neshu/lcdp marts move out)
+  finance:
+    +tags: ['marts', 'finance']
+  services_generaux:
+    +tags: ['marts', 'services_generaux']
+  supply_chain:
+    +tags: ['marts', 'supply_chain']
+```
+
+With folder-based tagging, **do not** set `tags=[...]` manually in each mart's `{{ config() }}` — the folder config handles it. Remove redundant model-level tags during migration.
+
+`staging:` and `intermediate:` subkeys stay per source, unchanged.
+
+### 5.2 Model renaming — decouple file rename from BQ table rename
+
+| What | Recommended | How |
+|---|---|---|
+| Rename .sql file | **Yes** — `fct_oracle_neshu__device.sql` → `fct_neshu__device.sql` | `git mv` |
+| Rename BigQuery physical table | **No (phase 1)** — keep BQ name `fct_oracle_neshu__device` | Add `alias='fct_oracle_neshu__device'` in `{{ config() }}` |
+
+This keeps Power BI datasets working without changes during the refacto. Physical rename can be a later separate project, coordinated with each BI dataset owner.
+
+### 5.3 Refs in downstream marts and exposures
+- Every `ref()` to a renamed dbt resource must be updated in the same PR.
+- `models/exposures/*.yml` must reference the new dbt names.
+- Run `dbt ls --select exposure:*` after each batch.
+
+### 5.4 Terraform state
+Renaming `google_workflows_workflow.transform_technique_daily` recreates the resource (delete + create) unless `terraform state mv` is run first.
+
+Since the refacto is **additive** in phase 1 (new workflows alongside old), no rename is needed initially. Cleanup phase removes old resources after all marts have migrated.
+
+### 5.5 Existing `dbt build tag:<source>` in EL pipelines
+Each `pipeline-<source>.yaml` today builds `tag:<source>` post-extraction (staging + intermediate + marts of that source). After refacto, scope down to staging + intermediate only:
+
+```yaml
+env_override:
+  - name: "DBT_TAG_SELECTOR"
+    value: "tag:<source>,path:models/staging models/intermediate"
+```
+
+Apply to every EL pipeline as part of phase 3 cleanup.
+
+### 5.6 `profiles.yml` — not impacted
+Contains GCP project, dataset prefix, keyfile, dev/prod targets. No coupling to mart layout. No action.
+
+---
+
+## 6. Migration plan
+
+### Phase 0 — Inventory (no code changes)
+- [x] Inventory the 32 existing marts → target folder mapping. See [`inventory.md`](./inventory.md). 24 unambiguous, 8 to confirm.
+- [ ] Confirm the 7 BI workspaces match the 7 mart folders.
+- [ ] Identify exposures impact: per Power BI report, which marts feed it.
+
+### Phase 1 — Additive scaffolding (1 PR)
+- [ ] Create empty folders: `neshu/`, `lcdp/`, `finance/`, `services_generaux/`, `supply_chain/`.
+- [ ] Add empty `_<folder>__marts_models.yml` in each.
+- [ ] Add new subkeys in `dbt_project.yml`.
+- [ ] Create 5 new `transform-<x>-daily.yaml` workflow files (copy `transform-technique-daily.yaml` template).
+- [ ] Add 5 Terraform `google_workflows_workflow` + `google_cloud_scheduler_job` blocks. **Schedulers paused** until phase 2 finishes for the corresponding BU.
+- [ ] Merge — no behavioral change.
+
+### Phase 2 — Migrate marts, BU by BU (1 PR per BU/domain)
+
+Order suggestion (smallest first to rehearse the process):
+
+1. `finance/` (likely smallest — only mssql_sage marts)
+2. `services_generaux/` (gac marts)
+3. `supply_chain/` (gcs + neshu)
+4. `lcdp/` (oracle_lcdp marts + any technique mart that's actually LCDP-specific)
+5. `neshu/` (oracle_neshu marts + technique marts that are Neshu-specific, e.g. `fct_technique__neshu_maintenance_preventives`)
+6. `technique/`, `commerce/` — scope reduction (move out partner-specific marts, keep transverse only)
+
+Per-BU checklist:
+- [ ] Branch `feature/marts-refacto-<folder>`
+- [ ] Move .sql files; set `alias='<old_bq_name>'` in each
+- [ ] Rename dbt resources to `<prefix>_<folder>__<entity>` (e.g. `fct_neshu__device`)
+- [ ] Update all `ref()` calls across the repo
+- [ ] Remove explicit `tags=[...]` in model configs (folder config handles it)
+- [ ] Merge YAML test files into `_<folder>__marts_models.yml`
+- [ ] Update `models/exposures/*.yml`
+- [ ] Activate the BU scheduler in Terraform (`paused = false`)
+- [ ] PR + merge
+
+### Phase 3 — Cleanup (1 PR)
+- [ ] Delete empty `marts/oracle_neshu/`, `marts/oracle_lcdp/`, `marts/yuman/`, `marts/mssql_sage/`, `marts/gac/`, `marts/yuman_gcs/`, `marts/oracle_neshu_gcs/`, `marts/nesp_tech/` folders
+- [ ] Remove source-named subkeys from `dbt_project.yml` `marts:` section
+- [ ] Scope down `dbt build` step in each `pipeline-<source>.yaml` to staging+intermediate only
+- [ ] Update `transform-technique-daily` schedule to 10:00 (fix latency bug for nesp data)
+- [ ] Update `README.md`, `CONTRIBUTING.md`, `CONVENTIONS.md`, `CLAUDE.md` to document new layout
+
+### Phase 4 — Validation
+- [ ] `dbt build` in dev → all green
+- [ ] All exposures resolve: `dbt ls --select exposure:*`
+- [ ] Power BI smoke test: 1 dataset per BU refreshes
+- [ ] `dbt source freshness` unchanged
+- [ ] All 7 BU/domain schedulers triggered successfully day 1
+
+---
+
+## 7. Estimated effort (rough, solo DE)
+
+| Phase | Effort |
+|---|---|
+| Phase 0 (inventory) | 0.5 day |
+| Phase 1 (scaffolding) | 0.5 day |
+| Phase 2 (migration, per BU/domain × 6) | 0.5–1 day each → 3–6 days |
+| Phase 3 (cleanup) | 0.5 day |
+| Phase 4 (validation) | 0.5 day |
+| **Total** | **5–8 days** spread over 2–3 weeks |
+
+PR per BU. Validate Power BI between each. Small team → can move fast, incidents recoverable.
+
+---
+
+## 8. Out of scope (intentionally)
+
+- Migrating EL pipelines to BU organization (sources stay per source).
+- Reorganizing `staging/` and `intermediate/` (stay per source).
+- Snapshots (managed by Cloud Workflows, not refactored).
+- Renaming physical BigQuery tables (separate later project).
+- Switching from cron to event-driven workflow triggers (separate initiative — see `docs/architecture_review.md`).
+
+---
+
+## 9. Open questions
+
+- Existing `docs/scheduling_and_tagging_decisions.md` mentions an `cross_post_*` tag pattern explicitly dropped. Confirm no remnant in current code before phase 2.
+- Confirm `gac` workspace name is "Services Généraux" in Power BI (folder `services_generaux/` must match).
+- For partner-specific exposures already in `models/exposures/neshu.yml`, `lcdp.yml`: are they all up to date?

--- a/docs/migration-marts/inventory.md
+++ b/docs/migration-marts/inventory.md
@@ -1,0 +1,134 @@
+# Marts inventory — current → target folder
+
+> Companion of [`README.md`](./README.md) — Phase 0 deliverable.
+> Status: **draft**. Last updated: 2026-05-19.
+>
+> 32 marts (not 23 — memory was stale). 1 to delete, 31 to migrate.
+
+---
+
+## 0. Naming convention for marts
+
+Documented in [`CONVENTIONS.md` § Nommage des marts](../../CONVENTIONS.md#nommage-des-marts--convention-by-bu-refacto-en-cours). Target names in §1 below apply that convention.
+
+**Tradeoff:** the new SQL name diverges from the physical BigQuery table name during the refacto. We rely on `alias='<old_bq_name>'` in `{{ config() }}` (see [`README.md` §5.2](./README.md#52-model-renaming--decouple-file-rename-from-bq-table-rename)) so Power BI datasets keep working. Physical BQ table rename = separate later project coordinated with the Data Analyst.
+
+---
+
+## 1. Mapping by target folder (31 marts after deletions)
+
+Target names follow §0 convention. ⚠️ flags model names worth a second look before migration.
+
+### → `neshu/` (12)
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `oracle_neshu/dim_oracle_neshu__company.sql` | `dim_neshu__company` | exposed by `business_review`, `passage_appro_monitoring`, `reporting_appro` |
+| `oracle_neshu/dim_oracle_neshu__contract.sql` | `dim_neshu__contract` | exposed by `business_review` |
+| `oracle_neshu/dim_oracle_neshu__device.sql` | `dim_neshu__device` | exposed by `business_review` |
+| `oracle_neshu/dim_oracle_neshu__product.sql` | `dim_neshu__product` | |
+| `oracle_neshu/dim_oracle_neshu__resources.sql` | `dim_neshu__resource` | singular |
+| `oracle_neshu/dim_oracle_neshu__vehicule_roadman.sql` | `dim_neshu__vehicule_roadman` | |
+| `oracle_neshu/fct_oracle_neshu__appro.sql` | `fct_neshu__appro` | exposed by `reporting_appro` |
+| `oracle_neshu/fct_oracle_neshu__chargement_par_quinzaine.sql` | `fct_neshu__chargement_quinzaine` | grain suffix |
+| `oracle_neshu/fct_oracle_neshu__chargement_vs_conso.sql` | `fct_neshu__chargement_vs_consommation` | ⚠️ comparison view — could become an intermediate or a derived BI view; keep for now |
+| `oracle_neshu/fct_oracle_neshu__conso_business_review.sql` | `fct_neshu__consommation` | BI name moves to exposure |
+| `oracle_neshu/fct_oracle_neshu__pa_business_review.sql` | `fct_neshu__pa` | ⚠️ confirm what "pa" means (prix d'achat ? plan d'appro ?) — rename more explicit if possible |
+| `technique/fct_technique__neshu_maintenance_preventives.sql` | `fct_neshu__maintenance_preventive` | partner-specific → moves out of `technique/`, exposed by `maintenance_preventives` |
+| `yuman/fct_yuman__workorder_delais_neshu.sql` | `fct_neshu__workorder_delai` | ⚠️ Neshu-specific yuman fact moves to neshu folder |
+
+### → `lcdp/` (3)
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `oracle_lcdp/dim_oracle_lcdp__company.sql` | `dim_lcdp__company` | exposed by `passage_appro_monitoring_lcdp` |
+| `oracle_lcdp/dim_oracle_lcdp__device.sql` | `dim_lcdp__device` | |
+| `oracle_lcdp/dim_oracle_lcdp__product.sql` | `dim_lcdp__product` | |
+
+> No fact today — facts to be built by DA later.
+
+### → `technique/` (9)
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `yuman/dim_yuman__clients.sql` | `dim_technique__client` | singular |
+| `yuman/dim_yuman__sites.sql` | `dim_technique__site` | singular |
+| `yuman/dim_yuman__materials.sql` | `dim_technique__material` | singular |
+| `yuman/dim_yuman__materials_clients.sql` | `dim_technique__material_client` | bridge (kept as dim until grain reviewed) |
+| `yuman/dim_yuman__technicians.sql` | `dim_technique__technician` | singular |
+| `technique/fct_technique__interventions.sql` | `fct_technique__intervention` | singular |
+| `yuman/fct_yuman__workorder_pricing.sql` | `fct_technique__workorder_pricing` | transverse (ad-hoc reporting for intervention pricing) |
+| `nesp_tech/fct_nesp_tech__alerting_conso_pieces_aguila.sql` | `fct_technique__alerting_consommation_piece_aguila` | ⚠️ long name; OK |
+| `nesp_tech/fct_nesp_tech__pieces_detachees_pricing.sql` | `fct_technique__piece_detachee_pricing` | |
+
+### → `commerce/` (1)
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `commerce/fct_commerce__machines_avec_interventions.sql` | `fct_commerce__machine_intervention` | singular, drop `_avec_` connector |
+
+### → `finance/` (1)
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `mssql_sage/fct_mssql_sage__pnl_bu_kpis.sql` | `fct_finance__pnl_bu` | `_kpis` redundant |
+
+### → `services_generaux/` (1)
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `gac/fct_gac__sinistres_sg.sql` | `fct_services_generaux__sinistre` | `_sg` redundant once in folder, singular |
+
+### → `supply_chain/` (3)
+
+Three stock-related facts here. Source suffix kept to disambiguate them (rule §0 last row).
+
+| Current path | Target name | Notes |
+|---|---|---|
+| `oracle_neshu_gcs/fct_oracle_neshu_gcs__stock_products.sql` | `fct_supply_chain__stock_neshu` | source suffix kept (collision risk with yuman stock) |
+| `yuman_gcs/fct_yuman_gcs__stock_articles.sql` | `fct_supply_chain__stock_yuman` | idem |
+| `oracle_neshu/fct_oracle_neshu__supply_flux.sql` | `fct_supply_chain__flux_neshu` | BI consumer is Supply Chain workspace |
+
+### → DELETE (1)
+
+| Current path | Reason |
+|---|---|
+| `yuman/fct_yuman__suivi_partenaires.sql` | not consumed today, confirmed by DE |
+
+---
+
+## 2. Decisions log (2026-05-19)
+
+- Yuman dims and `workorder_pricing` → `technique/` (Yuman is transverse for all non-Nespresso partners).
+- `fct_yuman__suivi_partenaires` → **delete**.
+- `fct_yuman__workorder_delais_neshu` → `neshu/`.
+- `fct_oracle_neshu__supply_flux` → `supply_chain/` (BI in Supply Chain workspace).
+- `gac` BU confirmed: **Services Généraux**.
+- LCDP has no fact today — expected, DA will build them later.
+- Source suffix in mart name only when needed to disambiguate inside a folder (currently only `supply_chain/` stocks).
+- Mart naming convention documented in §0 — to be formalized in `CONVENTIONS.md` during the refacto.
+
+---
+
+## 3. Remaining items to address during Phase 2
+
+1. **Exposures backfill** — DE only declared the 5 exposures for the BI dashboards he built himself. The DA owns BI now and will be the source of truth for which mart feeds which report. **Action:** during each BU PR in Phase 2, ping DA to identify the consumers and declare them as exposures in `models/exposures/<bu>.yml`.
+2. **⚠️ flagged renames** — confirm `fct_neshu__pa`, `fct_neshu__chargement_vs_consommation`, `fct_neshu__maintenance_preventive` (singular vs plural for "preventives") with DA at the time of the BU PR.
+3. **`dim_technique__material_client`** — review grain (looks like a bridge table); confirm dim vs fact classification.
+
+---
+
+## 4. Final count
+
+| Target | Count |
+|---|---|
+| `neshu/` | 13 |
+| `lcdp/` | 3 |
+| `technique/` | 9 |
+| `commerce/` | 1 |
+| `finance/` | 1 |
+| `services_generaux/` | 1 |
+| `supply_chain/` | 3 |
+| **Migrated total** | **31** |
+| Deleted | 1 |
+| **Grand total** | **32** |


### PR DESCRIPTION
## Summary
- Versioned planning docs for the upcoming marts refacto by BU under `docs/migration-marts/`
- `README.md`: design, target structure (7 BU/domain folders = 7 Power BI workspaces), 7 T-workflow schedules with +2h margin, 4-phase additive migration plan
- `inventory.md`: 32 marts mapped to target folder + target name (31 to migrate, 1 to delete: `fct_yuman__suivi_partenaires`)
- `CONVENTIONS.md`: new subsection "Nommage des marts — convention by BU" formalizing the naming rules (singular entity, BU in name, no source, no BI report name, grain/source suffixes only when needed)

No code change. Phases 1 (scaffolding) and 2 (per-BU migration) will follow in separate PRs.

## Test plan
- [x] `docs/migration-marts/README.md` references existing docs (`architecture_review.md`, `scheduling_and_tagging_decisions.md`)
- [x] `inventory.md` links to `CONVENTIONS.md` for naming rules
- [x] All 32 current marts accounted for in `inventory.md` §1 and §4
- [x] No SQL or YAML touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)