### PR TITLE
refacto(marts): Phase 1 scaffolding — empty BU/domain folders

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -126,6 +126,23 @@ models:
       commerce:
         +tags: ['marts', 'commerce']
 
+      # New BU/domain subkeys for the marts refacto by BU.
+      # See docs/migration-marts/. Empty until Phase 2 populates them.
+      neshu:
+        +tags: ['marts', 'neshu']
+
+      lcdp:
+        +tags: ['marts', 'lcdp']
+
+      finance:
+        +tags: ['marts', 'finance']
+
+      services_generaux:
+        +tags: ['marts', 'services_generaux']
+
+      supply_chain:
+        +tags: ['marts', 'supply_chain']
+
 seeds:
   dbt_warehouse:
     +schema: reference

--- a/models/marts/finance/_finance__marts_models.yml
+++ b/models/marts/finance/_finance__marts_models.yml
@@ -1,0 +1,6 @@
+version: 2
+
+# Placeholder — populated during Phase 2 of marts refacto by BU.
+# See docs/migration-marts/inventory.md for the list of marts targeting this folder.
+
+models: []

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -1,0 +1,6 @@
+version: 2
+
+# Placeholder — populated during Phase 2 of marts refacto by BU.
+# See docs/migration-marts/inventory.md for the list of marts targeting this folder.
+
+models: []

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1,0 +1,6 @@
+version: 2
+
+# Placeholder — populated during Phase 2 of marts refacto by BU.
+# See docs/migration-marts/inventory.md for the list of marts targeting this folder.
+
+models: []

--- a/models/marts/services_generaux/_services_generaux__marts_models.yml
+++ b/models/marts/services_generaux/_services_generaux__marts_models.yml
@@ -1,0 +1,6 @@
+version: 2
+
+# Placeholder — populated during Phase 2 of marts refacto by BU.
+# See docs/migration-marts/inventory.md for the list of marts targeting this folder.
+
+models: []

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -1,0 +1,6 @@
+version: 2
+
+# Placeholder — populated during Phase 2 of marts refacto by BU.
+# See docs/migration-marts/inventory.md for the list of marts targeting this folder.
+
+models: []


### PR DESCRIPTION
## Summary
Phase 1 of the marts refacto by BU (see `docs/migration-marts/README.md` §6 Phase 1). Additive only — **no model moves, no behavior change.**

- 5 empty folders created: `marts/{neshu,lcdp,finance,services_generaux,supply_chain}/`
- Each with a placeholder `_<folder>__marts_models.yml` (empty `models: []`)
- 5 new subkeys added in `dbt_project.yml > marts:` with their `+tags`

## Notes
- `dbt parse` emits 5 expected warnings about unused config paths — they will disappear progressively as Phase 2 PRs populate each folder.
- Workflow YAMLs (`/mnt/data/workflows`) + Terraform blocks (`/mnt/data/infra`) are tracked in a separate PR on those repos — schedulers will be created with `paused = true` until the corresponding BU's Phase 2 PR is merged.

## Test plan
- [x] `dbt parse` succeeds (warnings only, no errors)
- [x] 5 new folders + 5 YAMLs visible at `models/marts/`
- [x] `dbt_project.yml > marts:` updated with new subkeys
- [ ] CI green (`dbt build --exclude resource_type:snapshot` on dev)

🤖 Generated with [Claude Code](https://claude.com/claude-code)