### PR TITLE
refacto(marts): migrate services_generaux — sinistres_sg → fct_services_generaux__sinistre

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -114,9 +114,6 @@ models:
       nesp_tech:
         +tags: ['marts', 'nesp_tech']
 
-      gac:
-        +tags: ['marts', 'gac']
-
       technique:
         +tags: ['marts', 'technique']
 
@@ -125,6 +122,9 @@ models:
 
       finance:
         +tags: ['marts', 'finance']
+
+      services_generaux:
+        +tags: ['marts', 'services_generaux']
 
 seeds:
   dbt_warehouse:

--- a/docs/migration-marts/inventory.md
+++ b/docs/migration-marts/inventory.md
@@ -72,11 +72,11 @@ Target names follow §0 convention. ⚠️ flags model names worth a second look
 |---|---|---|
 | ~~`mssql_sage/fct_mssql_sage__pnl_bu_kpis.sql`~~ → `finance/fct_finance__pnl_bu.sql` | `fct_finance__pnl_bu` | ✅ fully migrated. PR #76 merged. `.pbix` repointed by DA. Old BQ tables dropped (dev + prod). Row count + aggregate parity verified before drop. |
 
-### → `services_generaux/` (1)
+### → `services_generaux/` (1) ✅ migrated 2026-05-20
 
 | Current path | Target name | Notes |
 |---|---|---|
-| `gac/fct_gac__sinistres_sg.sql` | `fct_services_generaux__sinistre` | `_sg` redundant once in folder, singular |
+| ~~`gac/fct_gac__sinistres_sg.sql`~~ → `services_generaux/fct_services_generaux__sinistre.sql` | `fct_services_generaux__sinistre` | PR Phase 2 #2. Existing `alias=` cleaned up during the migration. |
 
 ### → `supply_chain/` (3)
 

--- a/models/marts/services_generaux/_services_generaux__marts_models.yml
+++ b/models/marts/services_generaux/_services_generaux__marts_models.yml
@@ -1,9 +1,8 @@
-# models/marts/gac/_gac__marts_models.yml
 version: 2
 
 models:
-  - name: fct_gac__sinistres_sg
-    description: "Données de sinistres issues du modèle stg_gac__sinistres_sg"
+  - name: fct_services_generaux__sinistre
+    description: "Sinistres véhicules issus du fournisseur GAC, enrichis pour reporting Services Généraux."
     columns:
       # Infos Sinistre
       - name: n_de_sinistre
@@ -77,10 +76,9 @@ models:
 
       - name: cout_client
         description: "Coût restant à charge pour le client"
-      
+
       - name: dbt_updated_at
         description: "Metadata DBT"
 
       - name: dbt_invocation_id
         description: "Metadata DBT"
-

--- a/models/marts/services_generaux/fct_services_generaux__sinistre.sql
+++ b/models/marts/services_generaux/fct_services_generaux__sinistre.sql
@@ -1,7 +1,5 @@
 {{ config(
-    materialized='table',
-    schema='marts',
-    alias='fct_gac__sinistres_sg'
+    materialized='table'
 ) }}
 
 select


### PR DESCRIPTION
## Summary
Phase 2 PR #2 of the marts refacto by BU. Single mart, isolated source (\`gac\` via \`pipeline-sftp-evs\`). Following the same pattern validated on the finance migration (PR #76).

## Changes in this PR (dbt repo)
- New folder \`models/marts/services_generaux/\` with \`_services_generaux__marts_models.yml\`
- \`git mv\` + rename: \`fct_gac__sinistres_sg.sql\` → \`services_generaux/fct_services_generaux__sinistre.sql\`
- **Drop leftover \`alias='fct_gac__sinistres_sg'\`** from the config block (alias pattern abandoned per \`docs/migration-marts/README.md\` §5.2)
- \`dbt_project.yml\`: drop \`gac\` marts subkey, add \`services_generaux\` subkey
- \`docs/migration-marts/inventory.md\`: row marked migrated
- Empty \`models/marts/gac/\` folder removed

## Companion changes (separate repos, direct master)
- \`/mnt/data/workflows\`: new \`transform-services-generaux-daily.yaml\`
- \`/mnt/data/infra\`: new workflow + scheduler blocks. **Daily 10:00 Paris** (gac EL at 08:00 + 2h margin). User runs \`terraform plan/apply\` themselves at merge time.

## Merge-day coordination (per validated finance pattern)
1. Merge this PR → CI rebuilds \`prod_marts.fct_services_generaux__sinistre\` automatically
2. User runs \`terraform apply\` → creates the new scheduler
3. (Optional) trigger \`transform-services-generaux-daily\` manually via Cloud Workflows console
4. BQ MCP parity check (row count + aggregates) — old vs new table
5. DA repoints the \`.pbix\` to \`prod_marts.fct_services_generaux__sinistre\` and republishes
6. \`DROP TABLE prod_marts.fct_gac__sinistres_sg\` once BI is confirmed green (dev + prod)

## Test plan
- [x] \`dbt parse\` succeeds (no warnings, no errors)
- [ ] CI \`dbt build --exclude resource_type:snapshot\` green
- [ ] Post-merge: parity check on row count + sums between old/new BQ tables
- [ ] DA: \`.pbix\` repointed and dataset refreshes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)