### PR TITLE
fix(nesp_co): dedupe staging on id only, ordered by extracted_at

### DIFF
--- a/models/staging/nesp_co/_nesp_co__models.yml
+++ b/models/staging/nesp_co/_nesp_co__models.yml
@@ -4,13 +4,6 @@ models:
   # ACTIVITE
   - name: stg_nesp_co__activite
     description: "Activite transformés et nettoyés depuis la source Nespresso Commerce Activite"
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - activity_id
-              - employee_responsible
-              - activity_type
     columns:
       - name: employee_responsible
         description: "Identifiant de l'employé responsable"
@@ -20,6 +13,7 @@ models:
         description: "Identifiant de l'activité commerciale"
         tests:
           - not_null
+          - unique
       - name: c4c_id_commercial
         description: "Id C4C du commercial"
       - name: activity_type
@@ -72,18 +66,12 @@ models:
   # OPPORTUNITE
   - name: stg_nesp_co__opportunite
     description: "Opportunités transformés et nettoyés depuis la source Nespresso Commerce Opportunite"
-    tests:
-      - dbt_utils.unique_combination_of_columns:
-          arguments:
-            combination_of_columns:
-              - opportunity_id
-              - employee_responsible
-              - created_by
     columns:
       - name: opportunity_id
         description: "Identifiant de l'opportunité commerciale"
         tests:
           - not_null
+          - unique
       - name: employee_responsible
         description: "Nom de l'employé responsable"
         tests:

--- a/models/staging/nesp_co/stg_nesp_co__activite.sql
+++ b/models/staging/nesp_co/stg_nesp_co__activite.sql
@@ -58,8 +58,8 @@ deduped as (
     select *
     from base_activite
     qualify row_number() over (
-        partition by activity_id, employee_responsible, activity_type
-        order by file_date desc
+        partition by activity_id
+        order by extracted_at desc
     ) = 1
 
 )

--- a/models/staging/nesp_co/stg_nesp_co__opportunite.sql
+++ b/models/staging/nesp_co/stg_nesp_co__opportunite.sql
@@ -71,8 +71,8 @@ deduped as (
     from base_opportunite
     where opportunity_id is not null
     qualify row_number() over (
-        partition by opportunity_id, employee_responsible, created_by
-        order by file_date desc
+        partition by opportunity_id
+        order by extracted_at desc
     ) = 1
 
 )


### PR DESCRIPTION
## Summary
- `stg_nesp_co__activite` and `stg_nesp_co__opportunite` now dedupe on `activity_id` / `opportunity_id` only, via `row_number() over (partition by <id> order by extracted_at desc)`.
- Previous logic used a multi-column partition (`id, employee_responsible, activity_type/created_by`) ordered by `file_date`, which kept duplicates per id.
- YAML tests updated: `dbt_utils.unique_combination_of_columns` removed, `unique` test added on the id column (alongside the existing `not_null`).

## Test plan
- [x] `dbt build -s stg_nesp_co__activite stg_nesp_co__opportunite` — 2 models built, 8 tests passing (including new `unique` on `activity_id` and `opportunity_id`).
- [ ] Vérifier impact downstream (intermediate/marts consommant ces stagings) après merge.