### PR TITLE
docs(marts): standardize description format to [QUOI/COMMENT/GRAIN/NOTES]

### DIFF
--- a/docs/audits/marts-audit-2026-05-22.md
+++ b/docs/audits/marts-audit-2026-05-22.md
@@ -1,0 +1,231 @@
+# Audit marts — 2026-05-22
+
+Scope : 5 BUs migrées (`finance`, `services_generaux`, `supply_chain`, `neshu`, `lcdp`).
+Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : description 4 blocs, tests minimum, config hygiène, star schema).
+
+> **MAJ 2026-05-22 (post-PR description trame)** — branche `feature/marts-description-trame-4-blocs` : **18/18 descriptions reformatées** au standard `[QUOI MÉTIER] / [COMMENT CONSTRUITE] / [GRAIN] / [NOTES]`. Mentions BI laissées en place (à retirer dans une PR séparée).
+
+## Synthèse exécutive
+
+| Pilier | État global | Détail |
+|---|---|---|
+| 1. Description trame 4 blocs | ✅ 18/18 conformes (était 0/18) | finance, services_generaux, supply_chain (3), neshu (12), lcdp (3). |
+| 2. Tests obligatoires | ⚠️ 14/18 OK sur PK | PK dims/facts globalement testées. **FK relationships manquantes** sur ~60 % des facts. |
+| 3. Tests recommandés | ❌ Quasi-absents | `accepted_values`, `row_count_between`, `unique_combination_of_columns`, `expression_is_true` : 3 marts conformes sur 18. |
+| 4. Config hygiène | ❌ 14/18 violent la règle | `description=` présent dans `{{ config() }}` de 14 marts (interdit en marts depuis refacto — la description vit en YAML). Aucun `tags=[...]` constaté ✅. |
+| 5. Star schema | ✅ Globalement OK | Pas de fact-à-fact ni snowflake détecté. Cas à vérifier : `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` (chevauchement périmètre). |
+| 6. Référence à un nom de rapport BI dans description | ⚠️ 3 cas | `fct_neshu__consommation`, `fct_neshu__chargement_consommation`, `fct_neshu__chargement_quinzaine` mentionnent "Business Review", "BI taux d'écoulement", etc. — à déplacer dans `models/exposures/neshu.yml`. |
+
+---
+
+## finance/
+
+### fct_finance__pnl_bu
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ 2 phrases, pas de [GRAIN] explicite. Grain implicite = (scenario, annee, mois, bu, kpi).
+- **Tests obligatoires** : ⚠️ `not_null` OK sur scenario/annee/mois/bu/kpi. Pas de FK (table standalone) → OK.
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `scenario` (`AVEC_PROVISIONS_CP`, `SANS_PROVISIONS_CP`), `unique_combination_of_columns(scenario, annee, mois, bu, kpi)`, `expect_table_row_count_to_be_between`. `accepted_values` sur `kpi` ✅.
+- **Config hygiène** : ❌ `description='PnL complet avec réel, budget, YTD, N-1 et écarts'` dans le config block — à supprimer.
+- **Structure** : ✅ standalone fact, pas de FK donc pas de star schema applicable.
+- **Suggestion** :
+  - Ajouter trame YAML : `[QUOI MÉTIER] P&L mensuel par BU. [COMMENT CONSTRUITE] Issu de int_sage__pnl + scenarios CP. [GRAIN] 1 ligne par (scenario, annee, mois, bu, kpi). [NOTES] Inclut YTD, N-1, écarts, % CA.`
+  - Tests : `unique_combination_of_columns(scenario, annee, mois, bu, kpi)`, `accepted_values` sur `scenario`.
+  - Supprimer `description=` du config.
+
+---
+
+## services_generaux/
+
+### fct_services_generaux__sinistre
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 ligne unique, pas de blocs, pas de [GRAIN].
+- **Tests obligatoires** : ⚠️ `unique` sur `n_de_sinistre` et `reference_gac` mais **pas de `not_null`** (un sinistre sans numéro casserait silencieusement). Aucune FK déclarée (table standalone).
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `resp`, `cloture`, `statut_actuel`, `genre_fiscal`, `tiers`. Manque `row_count_between`. Pas de bornes sur `cout_global`, `franchise` (>= 0).
+- **Config hygiène** : ✅ propre.
+- **Structure** : ✅ pas d'OBT, mais colonnes `dbt_updated_at` / `dbt_invocation_id` exposées : pratique discutable (à valider, plutôt côté metadata interne).
+- **Suggestion** :
+  - Ajouter trame avec `[GRAIN] 1 ligne par sinistre (n_de_sinistre)`.
+  - Ajouter `not_null` sur PK ; `accepted_values` sur `cloture`/`statut_actuel` (explorer prod_marts pour bornes réelles).
+
+---
+
+## supply_chain/
+
+### fct_supply_chain__stock_neshu
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ 1 phrase, pas de blocs, pas de [GRAIN]. Grain implicite : (id_entity, product_code, date_system).
+- **Tests obligatoires** : ⚠️ `not_null` OK sur id_entity, date_system, product_code, file_datetime. Pas de FK déclarée (source externe Cloud Run pré-dim).
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `entity_type` (depot/vehicule), `is_out_of_stock`. Pas de `unique_combination_of_columns`, ni `row_count_between`, ni `>=0` sur `stock_at_date`/`stock_inventaire`/`dpa`/`purchase_price`.
+- **Config hygiène** : ❌ `description=` dans le config — à supprimer.
+- **Suggestion** : ajouter trame + `unique_combination_of_columns(id_entity, product_code, date_system)` + bornes >=0 sur stocks.
+
+### fct_supply_chain__stock_yuman
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 ligne, pas de [GRAIN].
+- **Tests obligatoires** : ⚠️ `not_null` sur `reference` et `stock_date`. Pas de FK.
+- **Tests recommandés** : ❌ tout manque (accepted_values sur `stock` si liste finie de dépôts/techniciens, row_count, >=0 sur `quantite`).
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : ajouter trame `[GRAIN] 1 ligne par (reference, stock, stock_date)` + `unique_combination_of_columns` + `quantite >= 0`.
+
+### fct_supply_chain__flux_neshu
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ description riche multi-bloc mais sans tags `[QUOI MÉTIER] / [GRAIN]`. Grain mois implicite mentionné en prose.
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `mois_date`, `not_null` sur `annee`/`mois`.
+- **Tests recommandés** : ✅ 3 `expression_is_true` au niveau model (`stock_total = stock_depot + stock_vehicule`, non-négatifs). ⚠️ Manque `row_count_between`, `expect_column_values_to_be_between` sur `mois_date` (plage attendue).
+- **Config hygiène** : ✅ propre.
+- **Suggestion** : reformater description avec les balises canoniques. Ajouter borne de `mois_date` (`'2020-01-01'` → `current_date()`).
+
+---
+
+## neshu/
+
+### dim_neshu__company
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de blocs, pas de [GRAIN].
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `company_id`.
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `sector` (HORECA/OFFICE), `client_status` (OR/ARGENT/BRONZE), `is_active` (true/false). Pas de `row_count_between`.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : ajouter trame `[GRAIN] 1 ligne par company_id` + accepted_values sur les ~6 colonnes labels bornées.
+
+### dim_neshu__product
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `product_id`.
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `product_type` (9 valeurs définies dans `fct_neshu__consommation` — réutiliser la même liste), `is_active`. Pas de row_count.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : ajouter trame + `accepted_values` cohérent avec `fct_neshu__consommation`.
+
+### dim_neshu__device
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
+- **Tests obligatoires** : ✅ PK testée ; FK `company_id` avec `not_null` + `relationships` vers `dim_neshu__company` ✅ (exemplaire).
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `device_brand` (NESPRESSO/NESTLE/ANIMO), `device_economic_model`, `is_active`. Pas de row_count.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : ajouter trame + accepted_values + reproduire le pattern `not_null + relationships` ailleurs.
+
+### dim_neshu__contract
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ 2 phrases, grain mentionné en prose ("un seul contrat actif par client") mais pas via balise [GRAIN].
+- **Tests obligatoires** : ✅ `unique` + `not_null` sur `contract_id`. ⚠️ `company_id` testé via `unique_combination_of_columns` warn — bon, mais idéalement `relationships` vers `dim_neshu__company` aussi.
+- **Tests recommandés** : ⚠️ `unique_combination_of_columns(company_id)` ✅. Manque `accepted_values` sur `is_active`. Pas de bornes sur `nombre_collab` (>= 0), `engagement_clean`.
+- **Config hygiène** : ❌ doublon : config dans le YAML (`config: materialized + cluster_by`) **et** dans le SQL (`{{ config(materialized=..., description=...) }}`). Supprimer le `description=` SQL + consolider config (préférer un seul endroit, idéalement SQL).
+- **Suggestion** : trancher l'endroit canonique du config block (SQL uniquement), ajouter trame.
+
+### dim_neshu__vehicule_roadman
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 phrase, pas de [GRAIN].
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `resources_vehicule_id`. `unique` sur `vehicule_code` ✅. `unique` sur `roadman_code` (sans not_null — un véhicule sans roadman?).
+- **Tests recommandés** : ❌ tout manque.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Structure** : ⚠️ **Chevauchement avec `dim_neshu__resource`** qui couvre déjà PERSON + VEHICULE. À clarifier : pourquoi 2 dims ressources ? Risque de snowflake/doublon de référentiel.
+- **Suggestion** : ajouter trame + statuer sur fusion/dépréciation vs `dim_neshu__resource`.
+
+### dim_neshu__resource
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ description riche (sources, hiérarchie, notes BI) mais pas de balises canoniques, pas de [GRAIN].
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `resources_id`. `not_null` sur `resources_code`, `resources_type`, `is_active` ✅.
+- **Tests recommandés** : ❌ Manque `accepted_values` sur `resources_type` (PERSON, VEHICULE), `code_status_record` (1/autre), `is_active`. Pas de row_count.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : ajouter trame + accepted_values sur resources_type.
+
+### fct_neshu__consommation
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ multi-paragraphe sans balises ; **mentionne "Business Review Neshu"** → à déplacer dans exposures.
+- **Tests obligatoires** : ✅ `not_null` + `relationships` sur company_id, product_id ; `relationships` sur device_id (nullable OK pour LIVRAISON). `not_null` sur `consumption_date`.
+- **Tests recommandés** : ✅ Exemplaire — `unique_combination_of_columns`, `expression_is_true` (device_id NULL ⇒ LIVRAISON), `accepted_values` sur product_type/data_source, `accepted_range` sur consumption_date. ⚠️ Pas de `row_count_between`, pas de borne `quantity >= 0`.
+- **Config hygiène** : ❌ `description=` dans config + mention BI ("BR Neshu") — à supprimer.
+- **Suggestion** : modèle de référence pour les autres facts. Ajouter trame + retirer description= + `quantity >= 0`.
+
+### fct_neshu__chargement_consommation
+- **Description trame** : ✅ (MAJ 2026-05-22) — trame canonique appliquée.
+- **Description trame (avant MAJ)** : ✅ mentionnait `Grain : (device, passage_appro, product)` en prose — meilleur que les autres mais sans balise.
+- **Tests obligatoires** : ⚠️ `not_null` sur device_id, date_debut_passage_appro, product_type, product_code. **Manque `relationships`** sur device_id → `dim_neshu__device`, product_code n'est pas un FK direct.
+- **Tests recommandés** : ❌ Pas de `unique_combination_of_columns(device_id, date_debut_passage_appro, product_code)`. Pas de `>= 0` sur `q_consommee`/`q_chargee`. Pas de row_count.
+- **Config hygiène** : ❌ `description=` + mention BI ("BI de taux d ecoulement et Suivi des chargements machines gratuités") — à déplacer dans exposures.
+- **Suggestion** : ajouter relationships sur device_id, unique_combination, bornes >=0.
+
+### fct_neshu__chargement_quinzaine
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ 2 lignes, pas de [GRAIN].
+- **Tests obligatoires** : ⚠️ `not_null` sur product_type/company_code/annee_chgt/quinzaine_chgt. Pas de FK (company_code au lieu de company_id — entorse aux conventions des facts).
+- **Tests recommandés** : ❌ `unique_combination_of_columns(product_type, company_code, annee_chgt, quinzaine_chgt)` manquant. `quinzaine_chgt` entre 1 et 27 ? `quantite_chargee >= 0` ?
+- **Config hygiène** : ❌ `description=` + mention BI — à déplacer.
+- **Suggestion** : remplacer `company_code` par `company_id` (FK propre) si possible, sinon ajouter `relationships` via clé naturelle. Ajouter unique_combination + bornes.
+
+### fct_neshu__appro
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ multi-paragraphe descriptive, pas de [GRAIN] explicite (grain = task_id).
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `task_id`, `not_null` sur `resources_roadman_id`. ❌ **Manque `relationships`** : device_id → `dim_neshu__device`, company_id → `dim_neshu__company`, resources_roadman_id → `dim_neshu__resource`.
+- **Tests recommandés** : ❌ Pas d'`accepted_values` sur `task_status_code` (PLANIFIE/FAIT/ENCOURS reclassé). Pas de bornes sur durées (`passage_duration_min >= 0`, `work_duration_min between 0 and 720`). Pas de row_count.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : prioriser ajout des 3 `relationships` (vraie valeur business). Ajouter bornes durées et accepted_values task_status_code.
+
+### fct_neshu__maintenance_preventive
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ⚠️ très riche (règles métier, sources), pas de balises canoniques, pas de [GRAIN] explicite (1 par device).
+- **Tests obligatoires** : ✅ Exemplaire — `not_null` + `unique` + `relationships` sur device_id ; `not_null` sur device_code/device_name/company_code/company_name/device_last_installation_date/retard_bol/retard_delai/source_last_preventive/status_inter ; `relationships` sur material_id (warn, nullable) ✅.
+- **Tests recommandés** : ✅ `accepted_values` sur `source_last_preventive` et `status_inter` ✅. ❌ Manque `row_count_between` et bornes `retard_delai`.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Note structure** : `unique` sur device_id → c'est en fait une dim enrichie (1 ligne par machine) plus qu'un fact transactionnel. Naming `fct_` discutable mais acceptable si interprété comme "état observé à date".
+- **Suggestion** : modèle de référence pour les tests. Retirer description= + ajouter row_count + bornes retard.
+
+### fct_neshu__workorder_delai
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
+- **Tests obligatoires** : ⚠️ `unique` sur demand_id et workorder_id (sans not_null), `relationships` sur material_id/site_id/client_id ✅. ❌ **Manque `not_null`** sur les FK.
+- **Tests recommandés** : ❌ Manque accepted_values sur `workorder_type_clean`, `pricing_type` (Tarif normal/Remise niv1/Remise niv2), `billing_validation_status` (VALIDATED/MISSING_TARIF/NOT_BILLABLE), `to_invoice`. Pas de `>= 0` sur `amount`, `delai_jours_ouvres`, `recurrence_count`. Pas de row_count.
+- **Config hygiène** : ✅ propre (seul mart neshu sans `description=` en config !).
+- **Suggestion** : ajouter trame + not_null sur FK + accepted_values + bornes.
+
+---
+
+## lcdp/
+
+### dim_lcdp__company
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `company_id`.
+- **Tests recommandés** : ❌ Pas d'`accepted_values` sur is_active, geo_zone, activity_domain, business_model, key_account. Pas de row_count.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : trame + accepted_values bornés sur labels.
+
+### dim_lcdp__product
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `product_id`.
+- **Tests recommandés** : ❌ tout manque.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : trame + accepted_values sur product_family/product_group/is_active.
+
+### dim_lcdp__device
+- **Description trame** : ✅ (MAJ 2026-05-22)
+- **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
+- **Tests obligatoires** : ⚠️ `not_null` + `unique` sur `device_id` ✅. ❌ **Manque `relationships`** sur company_id → `dim_lcdp__company` (présent dans dim_neshu__device, à reproduire ici).
+- **Tests recommandés** : ❌ Pas d'`accepted_values` sur device_state, device_material_status, audit_type, currency_mode, is_active, etc. Pas de row_count.
+- **Config hygiène** : ❌ `description=` à supprimer.
+- **Suggestion** : reproduire le pattern de `dim_neshu__device` (relationships sur company_id) + accepted_values sur labels.
+
+---
+
+## Recommandations priorisées pour PRs séparées
+
+1. **PR "config hygiène"** (cosmétique, faible risque, gros impact lisibilité)
+   - Supprimer `description=` du `{{ config() }}` dans 14 marts. La description en YAML reste.
+   - Consolider `dim_neshu__contract` : config en SQL uniquement (retirer le bloc `config:` du YAML).
+
+2. **PR "description trame 4 blocs"** (cosmétique)
+   - Reformater les 18 descriptions YAML avec `[QUOI MÉTIER] / [COMMENT CONSTRUITE] / [GRAIN] / [NOTES]`.
+   - Retirer les mentions de rapports BI dans `fct_neshu__consommation`, `fct_neshu__chargement_consommation`, `fct_neshu__chargement_quinzaine`.
+
+3. **PR "tests FK relationships"** (réelle valeur business)
+   - Ajouter `not_null + relationships` sur les FK manquantes : `fct_neshu__appro` (device_id, company_id, resources_roadman_id), `fct_neshu__chargement_consommation` (device_id), `fct_neshu__workorder_delai` (not_null sur FK), `dim_lcdp__device` (company_id).
+
+4. **PR "tests accepted_values + bornes"** (qualité métier — explorer prod via BQ MCP avant de figer les listes)
+   - Listes `accepted_values` sur statuts, types, modèles économiques, etc.
+   - Bornes `>= 0` sur quantités, durées, montants.
+   - `unique_combination_of_columns` sur clés composites des facts.
+
+5. **PR "row_count + plages dates"** (warn-only, garde-fou ordre de grandeur)
+   - `expect_table_row_count_to_be_between` et `expect_column_values_to_be_between` (dates) — bornes à calibrer via BQ MCP.
+
+6. **PR séparée à statuer** : `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` — clarifier le périmètre et déprécier l'un des deux si redondant.

--- a/models/marts/finance/_finance__marts_models.yml
+++ b/models/marts/finance/_finance__marts_models.yml
@@ -2,9 +2,11 @@ version: 2
 
 models:
   - name: fct_finance__pnl_bu
-    description: >
-      P&L mensuel par Business Unit, avec scénarios avec et sans provisions congés payés.
-      Inclut KPI mensuels, YTD, N-1, écarts, évolutions et pourcentages du chiffre d'affaires.
+    description: |
+      [QUOI MÉTIER] P&L mensuel par Business Unit analytique, avec scénarios avec/sans provisions congés payés.
+      [COMMENT CONSTRUITE] Issu des écritures comptables Sage (int_sage__pnl) agrégées par BU et KPI ; deux scénarios calculés : AVEC_PROVISIONS_CP (toutes écritures) et SANS_PROVISIONS_CP (exclut comptes 645800, 641200). Enrichi des valeurs YTD, N-1 et écarts/évolutions.
+      [GRAIN] 1 ligne par (scenario, annee, mois, bu, kpi).
+      [NOTES] Les KPI couvrent : CA, CONSOMMATION_MP_SSTT, MASSE_SALARIALE, FRAIS_DIRECTS_AMORTISSEMENTS, MARGE_BRUTE, MARGE_NETTE. BU_NON_RENSEIGNEE pour les écritures sans imputation analytique.
 
     columns:
       - name: scenario

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -4,9 +4,11 @@ version: 2
 models:
   # COMPANY
   - name: dim_lcdp__company
-    description: >
-      Dimension client/company enrichie à partir des labels associés (zone géo, domaine activité, modèles, etc.)
-      et des informations de localisation.
+    description: |
+      [QUOI MÉTIER] Dimension client (company) LCDP enrichie des labels métier et de la localisation.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__company joint à stg_oracle_lcdp__location pour les coordonnées, et pivot des labels (stg_oracle_lcdp__label_has_company + label + label_family) sur les familles : ZGEO, DOMACT, BUSMOD, GC, ISACTIVE, MODEH, MODEOF, MODER, PROPRIO, REPRES, BL_GRP, MEF, Gestion reliquat.
+      [GRAIN] 1 ligne par company_id.
+      [NOTES] parent_company_id permet la hiérarchie société-mère/fille. is_active converti en booléen (TRUE si label ISACTIVE='yes').
     columns:
       - name: company_id
         description: "Identifiant unique de la société"
@@ -90,9 +92,11 @@ models:
 
   # PRODUCT
   - name: dim_lcdp__product
-    description: >
-      Dimension produit enrichie à partir des labels associés (famille, groupe, marque, bio, etc.)
-      filtré sur les produits de type 1 (produit) et 5 (Ligne de prix).
+    description: |
+      [QUOI MÉTIER] Dimension produit LCDP enrichie des labels métier (famille, groupe, marque, bio).
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__product filtré sur product_type_id IN (1, 5), enrichi par pivot des labels via stg_oracle_lcdp__label_has_product : FAMIPRO, GROUPRO, MARQPRO, BIO, ISACTIVE. created_at corrigé si NULL pour idproduct=1 (fallback updated_at).
+      [GRAIN] 1 ligne par product_id.
+      [NOTES] product_type_id : 1 = produit, 5 = ligne de prix. is_active converti en booléen.
     columns:
       - name: product_id
         description: "Identifiant unique du produit"
@@ -137,8 +141,11 @@ models:
 
   # DEVICE
   - name: dim_lcdp__device
-    description: >
-      Dimension device enrichie à partir des labels associés (catégorie, état, statut, marque, types, etc.)
+    description: |
+      [QUOI MÉTIER] Dimension machine LCDP enrichie des labels métier (catégorie, état, types fontaine/broyeur/percolateur/SP).
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__device joint à stg_oracle_lcdp__company (company_code, company_name) et stg_oracle_lcdp__location (access_info → device_location). Pivot des labels via stg_oracle_lcdp__label_has_device sur les familles : CATMACH, MARQUE, ETAT_MACHINE, STATUT_MATERIEL, TYPEAUDIT, TYDA, LCDPMON, TYPFONT, TYPBROY, TYPPERCO, TYPSP, TYPDASA, MODSP, MARQSP, BADGE, ISACTIVE.
+      [GRAIN] 1 ligne par device_id.
+      [NOTES] device_iddevice = parent device (hiérarchie). is_active converti en booléen. Relationship vers dim_lcdp__company non encore déclarée (à ajouter dans la PR FK tests).
     columns:
       - name: device_id
         description: "Identifiant unique du device"

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -4,9 +4,11 @@ version: 2
 models:
   # COMPANY
   - name: dim_neshu__company
-    description: >
-      Dimension client/company enrichie à partir des labels associés (région, secteur, statut, etc.)
-      et des informations de localisation.
+    description: |
+      [QUOI MÉTIER] Dimension client (company) Neshu enrichie des labels métier et de la localisation.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__company joint à stg_oracle_neshu__location pour les coordonnées, et pivot des labels (stg_oracle_neshu__label_has_company + label + label_family) sur les familles : REGION, SECTEUR_ACTVITE, CODE_SECTEUR, SECTEUR_DACTIVITE, TRANCHE_COLLAB, TYPECOMPAGNIE, MODELEECOCLIENT, STATUT_CLIENT, ISACTIVE, KA, KATIERS, TELETRAVAIL, PROADMAN, GSM_TERRAIN, BADGE, RECYCLAGE.
+      [GRAIN] 1 ligne par company_id.
+      [NOTES] is_active converti en booléen (TRUE si label ISACTIVE='yes').
     columns:
       - name: company_id
         description: "Identifiant unique de la société"
@@ -96,9 +98,11 @@ models:
 
   # PRODUCT
   - name: dim_neshu__product
-    description: >
-      Dimension produit enrichie à partir des labels associés (type, famille, groupe, marque, etc.)
-      et filtrée sur les produits de type 1 (produit) et 5 (ligne de prix).
+    description: |
+      [QUOI MÉTIER] Dimension produit Neshu enrichie des labels métier (famille, groupe, marque, bio, propriétaire).
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__product filtré sur product_type_id IN (1, 5), enrichi par pivot des labels via stg_oracle_neshu__label_has_product : MARQUEP, PROPRIETAIRE, FAMILLE, BIO, GROUPE, ISACTIVE. product_type standardisé via règle métier (CAFE CAPS, THE, CHOCOLATS VAN HOUTEN, BOISSONS GOURMANDES, ACCESSOIRES, CAFENOIR, SNACKING, BOISSONS FRAICHES, INDEFINI).
+      [GRAIN] 1 ligne par product_id.
+      [NOTES] product_type_id : 1 = produit, 5 = ligne de prix. is_active converti en booléen.
     columns:
       - name: product_id
         description: "Identifiant unique du produit"
@@ -151,9 +155,11 @@ models:
 
     # DEVICE
   - name: dim_neshu__device
-    description: >
-      Dimension device enrichie à partir des labels associés (état, statut, gamme, catégorie, marque, etc.),
-      filtrée sur les machines (type 1).
+    description: |
+      [QUOI MÉTIER] Dimension machine Neshu enrichie des labels métier et rattachée au client (company).
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__device filtré sur device_type_id=1 (machines), joint à stg_oracle_neshu__location pour device_location, et pivot des labels via stg_oracle_neshu__label_has_device : MARQUE, GAMME, CATEGORIE, MODECOMA, ISACTIVE. company_id avec relationship vers dim_neshu__company.
+      [GRAIN] 1 ligne par device_id.
+      [NOTES] device_iddevice = parent device (NULL si pas d'équipement parent). is_active converti en booléen.
     columns:
       - name: device_id
         description: "Identifiant unique de la machine"
@@ -219,11 +225,11 @@ models:
 
 # FACT BUSINESS REVIEW
   - name: fct_neshu__consommation
-    description: >
-      Table de faits des consommations clients pour la Business Review Neshu.
-      Consolidation des données télémétrie, chargement et livraison avec application
-      des règles métier spécifiques (gratuité vs payant, types de produits, etc.).
-      Utilisée pour les analyses de consommation, comparatifs annuels et reporting client.
+    description: |
+      [QUOI MÉTIER] Consommations produits clients Neshu, consolidées depuis 3 sources opérationnelles.
+      [COMMENT CONSTRUITE] Union de 3 flux : télémétrie machines (int_oracle_neshu__telemetry_tasks), chargements machines (int_oracle_neshu__chargement_tasks), livraisons directes (int_oracle_neshu__livraison_tasks). Enrichi par dim_neshu__company, dim_neshu__device, dim_neshu__product. Application des règles métier : multiplicateurs pour rames/boîtes, distinction gratuit/payant, exclusion produits hors périmètre. location='LIVRAISON' et device_*='LIVRAISON' pour les flux livraison directe (sans machine).
+      [GRAIN] 1 ligne par (company_id, device_id, product_id, location_id, location, consumption_date, data_source).
+      [NOTES] data_source ∈ {TELEMETRIE, CHARGEMENT, LIVRAISON}. device_id NULL uniquement si data_source='LIVRAISON' (invariant testé).
     
     columns:
       # === IDENTIFIANTS ===
@@ -377,9 +383,10 @@ models:
       # === CONTRACT ===
   - name: dim_neshu__contract
     description: |
-      Dimension contrat : pivot des labels et sélection du contrat actif principal par client.
-      Cette table contient un seul contrat actif par client (company_id), sélectionné selon
-      la date de fin de contrat la plus récente, puis la date de début la plus récente.
+      [QUOI MÉTIER] Dimension contrat Neshu : 1 contrat actif principal sélectionné par client.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__contract, pivot des labels via stg_oracle_neshu__label_has_contract (ISACTIVE, ENGAGEMENT, NOMBRE_COLLAB). Sélection du contrat principal par company_id : tri descendant sur current_end_date puis sur original_start_date, conservation du premier.
+      [GRAIN] 1 ligne par contract_id (et indirectement 1 par company_id — warn-tested).
+      [NOTES] is_active converti depuis label ISACTIVE. engagement_clean = parsing numérique d'engagement_raw.
     
     config:
       materialized: table
@@ -460,10 +467,11 @@ models:
 
   # marts/oracle_neshu/_oracle_neshu__marts_models.yml
   - name: dim_neshu__vehicule_roadman
-    description: >
-      Dimension regroupant les véhicules et roadmen issus de la table
-      `stg_oracle_neshu__resources`, enrichie avec le code GEA provenant
-      de la référence `ref_oracle_neshu__roadman_gea`.
+    description: |
+      [QUOI MÉTIER] Dimension véhicule-roadman : pivot véhicule avec son roadman associé et son code GEA.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__resources filtré sur les véhicules, joint au roadman associé via resources_idresources, enrichi du code GEA depuis ref_oracle_neshu__roadman_gea (seed reference).
+      [GRAIN] 1 ligne par véhicule (resources_vehicule_id).
+      [NOTES] Périmètre partiellement redondant avec dim_neshu__resource (qui couvre PERSON + VEHICULE) — usage spécifique pour les facts orientés véhicule. À clarifier lors d'une refacto ultérieure.
 
     columns:
       - name: resources_vehicule_id
@@ -498,11 +506,11 @@ models:
         description: "Code GEA rattaché au roadman, issu du modèle ref_oracle_neshu__roadman_gea."
 
   - name: fct_neshu__chargement_consommation
-    description: >
-      Table de faits des chargements et consommations télémetrie par passage APPRO.
-      Pour chaque passage, mesure les quantités consommées entre le passage précédent
-      et le passage actuel, et les quantités chargées lors de ce passage.
-      Grain : (device, passage_appro, product).
+    description: |
+      [QUOI MÉTIER] Quantités chargées vs consommées par machine et par passage APPRO (taux d'écoulement).
+      [COMMENT CONSTRUITE] Pour chaque passage APPRO d'une machine, calcul via LAG du passage précédent pour borner la période d'écoulement ; q_consommee = somme des télémétries entre les deux passages ; q_chargee = somme des chargements lors du passage actuel. Sources : int_oracle_neshu__chargement_tasks, int_oracle_neshu__telemetry_tasks, jointes par device_id et period bounds.
+      [GRAIN] 1 ligne par (device_id, date_debut_passage_appro, product_code).
+      [NOTES] roadman_code = roadman ayant réalisé le passage. product_type aplati pour filtre BI.
 
     config:
       materialized: table
@@ -545,9 +553,11 @@ models:
 
 
   - name: fct_neshu__chargement_quinzaine
-    description: >
-      Table de faits calculant les quantités chargées par type de produit,
-      société, année et quinzaine (périodes de 14 jours démarrant un lundi).
+    description: |
+      [QUOI MÉTIER] Quantités chargées par client, type de produit, année et quinzaine.
+      [COMMENT CONSTRUITE] Issu de int_oracle_neshu__chargement_tasks joint à dim_neshu__product (product_type) et dim_neshu__device (company_code). Regroupement BOISSONS FRAICHES + SNACKING → SODA + SNACKS pour le reporting BI. Quinzaine calculée depuis le lundi de référence de l'année (FLOOR(jours / 14) + 1).
+      [GRAIN] 1 ligne par (product_type, company_code, annee_chgt, quinzaine_chgt).
+      [NOTES] quinzaine_chgt ∈ [1, 27].
 
     columns:
       - name: product_type
@@ -576,18 +586,10 @@ models:
 
   - name: dim_neshu__resource
     description: |
-      Dimension des ressources Oracle Neshu regroupant les **roadmen** (PERSON) et les **véhicules** (VEHICULE).
-
-      Enrichie avec :
-      - Les labels Oracle (ISACTIVE, Fonction) pivotés depuis `label_has_resources`
-      - Le code GEA du roadman depuis `ref_oracle_neshu__roadman_gea` (jointure sur `resources_code`, PERSON uniquement)
-
-      **Hiérarchie véhicule/roadman :**
-      `resources_idresources` pointe vers l'ID du roadman associé au véhicule.
-      Pour un roadman (PERSON), ce champ est NULL.
-
-      **Note :** `code_status_record` est conservé comme colonne pour permettre un filtrage
-      à la volée côté BI (1 = actif). Le filtre n'est pas appliqué dans le modèle.
+      [QUOI MÉTIER] Dimension ressource Oracle Neshu : roadmen (PERSON) + véhicules (VEHICULE) avec hiérarchie.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__resources, pivot des labels via stg_oracle_neshu__label_has_resources : ISACTIVE, Fonction. Enrichi du code GEA depuis ref_oracle_neshu__roadman_gea (seed) sur les PERSON uniquement (jointure resources_code).
+      [GRAIN] 1 ligne par resources_id.
+      [NOTES] Hiérarchie : resources_idresources d'un VEHICULE pointe vers l'ID du roadman PERSON associé ; NULL pour les roadmen. code_status_record conservé (1=actif) sans filtre — filtrage à la volée côté BI. is_active converti en booléen.
     columns:
       - name: resources_id
         description: "Identifiant unique de la ressource dans Oracle"
@@ -661,11 +663,11 @@ models:
         description: "Date de dernière mise à jour de la ressource dans Oracle"
 
   - name: fct_neshu__appro
-    description: >
-      Table de faits représentant les passages des roadmen,
-      enrichie avec des métriques journalières de temps de travail
-      et de performance (durée de passage, temps de travail quotidien, rang du passage).
-      Les statuts ENCOURS ont été reclassés comme FAIT suite à validation métier.
+    description: |
+      [QUOI MÉTIER] Passages APPRO des roadmen enrichis des métriques journalières de temps de travail.
+      [COMMENT CONSTRUITE] Issu de int_oracle_neshu__appro_tasks joint à int_oracle_neshu__pointage_tasks (START_DAY) pour le pointage journalier du roadman. Calculs window function par roadman et jour : rang du passage, nombre quotidien de passages, durée moyenne, durée nette du temps de travail (dernière fin - début effectif, nettoyée des valeurs aberrantes <0 ou >12h). Statut ENCOURS reclassé en FAIT après validation métier.
+      [GRAIN] 1 ligne par task_id (1 tâche APPRO).
+      [NOTES] effective_work_start = pointage si disponible, sinon première tâche du jour. is_planned/is_done : indicateurs binaires.
 
     columns:
 
@@ -786,21 +788,10 @@ models:
 
   - name: fct_neshu__maintenance_preventive
     description: |
-      Table de faits pour le suivi des maintenances préventives des machines NESHU.
-
-      Cette table croise les données Oracle (DLOG) et Yuman pour :
-      - Identifier les machines en retard de maintenance préventive
-      - Calculer le délai de retard ou d'avance par rapport à l'échéance annuelle
-      - Suivre le statut des demandes d'intervention ouvertes ou planifiées
-
-      **Règles métier de calcul du retard :**
-      - Machine < 13 mois (395 jours) : pas de retard (période de grâce)
-      - Machine sans préventive : en retard si > 365 jours après installation
-      - Machine avec préventives : en retard si dernière préventive > 365 jours
-
-      **Sources de données :**
-      - Oracle NESHU (DLOG) : machines et interventions techniques (preventive dlog)
-      - Yuman : matériels, clients, sites et workorders
+      [QUOI MÉTIER] État de la maintenance préventive par machine NESHU : retard, échéance, statut intervention.
+      [COMMENT CONSTRUITE] Croisement Oracle DLOG (dim_neshu__device filtré sur is_active + types 1/2 + liste de modèles éligibles + company_code au format CN[0-9]{4}, préfixé NESH_) et Yuman (stg_yuman__materials, clients, sites, workorders) sur le numéro de série. retard_delai = jours restants (+) ou de retard (−) vs échéance annuelle (365 jours). Règles métier : machine < 395j = période de grâce (pas de retard) ; sinon comparaison à la dernière préventive (source Yuman prioritaire sur DLOG, sinon date d'installation).
+      [GRAIN] 1 ligne par device_id (état courant par machine).
+      [NOTES] Naming fct_ retenu (état observé à date) mais comportement dim-like (unique sur device_id). status_inter ∈ {Ouvert, Planifie, Aucune}. source_last_preventive ∈ {yuman, dlog, aucune}.
 
     columns:
       - name: device_id
@@ -917,13 +908,11 @@ models:
 
 
   - name: fct_neshu__workorder_delai
-    description: >
-      Table de fait marts de tarification automatique des interventions (workorders).
-      Ce modèle enrichit les données unifiées des interventions et des demandes issues de 
-      `int_yuman__demands_workorders_enriched` avec les référentiels de types d'intervention,
-      machines, tarifications et zones géographiques. 
-      Il calcule les prix automatiques des interventions selon les règles de récurrence, 
-      de partenaire et de localisation (métropole).
+    description: |
+      [QUOI MÉTIER] Délai de traitement des interventions Yuman (workorders) et tarification automatique associée.
+      [COMMENT CONSTRUITE] Issu de fct_yuman__workorder_pricing (qui consolide demandes + bons de travail Yuman avec tarification automatique). Calcul du délai en jours ouvrés via generate_date_array entre date_creation_ref (créa workorder, ou demande si workorder NULL ; décalée au lendemain si > 16h) et date_done. Type de délai selon règles NESHU validées par le Responsable Technique.
+      [GRAIN] 1 ligne par workorder_id (et par demand_id — bijection testée par unique).
+      [NOTES] billing_validation_status ∈ {VALIDATED, MISSING_TARIF, NOT_BILLABLE}. pricing_type ∈ {Tarif normal, Remise niv1, Remise niv2}.
 
     columns:
       # --- IDENTIFIANTS ---

--- a/models/marts/services_generaux/_services_generaux__marts_models.yml
+++ b/models/marts/services_generaux/_services_generaux__marts_models.yml
@@ -2,7 +2,11 @@ version: 2
 
 models:
   - name: fct_services_generaux__sinistre
-    description: "Sinistres véhicules issus du fournisseur GAC, enrichis pour reporting Services Généraux."
+    description: |
+      [QUOI MÉTIER] Sinistres de la flotte de véhicules EVS (assurance, responsabilité, coûts).
+      [COMMENT CONSTRUITE] Lecture directe de stg_gac__sinistres_sg (fichier CSV déposé par GAC sur SFTP), avec extraction de la date de sinistre depuis le timestamp source et ajout des métadonnées dbt. Pas d'enrichissement métier ni de jointure.
+      [GRAIN] 1 ligne par sinistre (n_de_sinistre).
+      [NOTES] Source GAC = gestionnaire de flotte externe. Coûts ventilés en : cout_assureur, auto_assurance, franchise, cout_global, cout_client.
     columns:
       # Infos Sinistre
       - name: n_de_sinistre

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -2,7 +2,11 @@ version: 2
 
 models:
   - name: fct_supply_chain__stock_neshu
-    description: "Suivi inventaire théorique véhicule roadman + dépôt (filtre véhicules actifs et dépôts 1-5, 10, 13), enrichi et nettoyé. Source : Oracle Neshu via GCS."
+    description: |
+      [QUOI MÉTIER] Stock théorique journalier des produits Neshu, par véhicule roadman et par dépôt.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu_gcs__stock_theorique (export GCS quotidien Oracle Neshu), filtré sur les dépôts 01–05, 10, 13 (entity_type='company') et les véhicules actifs (label ISACTIVE='YES' via stg_oracle_neshu__label_has_resources). is_out_of_stock dérivé de stock_at_date=0. dpa fallback sur purchase_price si manquant.
+      [GRAIN] 1 ligne par (id_entity, product_code, date_system).
+      [NOTES] Source GCS = export Oracle vers Cloud Storage. plus/moins = écarts d'inventaire vs théorique.
     columns:
       - name: id_entity
         description: "Identifiant de l'entité (ressource ou dépôt)"
@@ -48,7 +52,11 @@ models:
           - not_null
 
   - name: fct_supply_chain__stock_yuman
-    description: "Suivi inventaire théorique des pièces/articles Yuman pour suivre l'évolution des stocks des techniciens et dépôts Yuman."
+    description: |
+      [QUOI MÉTIER] Stock journalier des pièces détachées Yuman, par technicien et par dépôt.
+      [COMMENT CONSTRUITE] Lecture directe de stg_yuman_gcs__stock_theorique (export GCS quotidien Yuman), avec conversion export_date → DATE et filtre sur reference et nom_du_stock non NULL.
+      [GRAIN] 1 ligne par (reference, stock, stock_date).
+      [NOTES] stock = libellé du stock physique (technicien ou dépôt Yuman).
     columns:
       - name: reference
         description: "Référence de l'article"
@@ -66,13 +74,11 @@ models:
           - not_null
 
   - name: fct_supply_chain__flux_neshu
-    description: >
-      Table de faits mensuelle consolidant l'ensemble des flux supply Neshu.
-      Elle combine :
-      - Les stocks réels issus des inventaires (prioritaires)
-      - Les stocks théoriques (fallback si absence d'inventaire)
-      - Les flux opérationnels (réceptions, livraisons, chargements)
-      La granularité est mensuelle (mois_date).
+    description: |
+      [QUOI MÉTIER] Flux supply Neshu mensuels (stocks dépôts/véhicules + réceptions/livraisons/chargements).
+      [COMMENT CONSTRUITE] Consolidation de 7 sources Oracle Neshu : inventaires (int_oracle_neshu__inventaire_tasks, prioritaires si VALIDE), stocks théoriques (stg_oracle_neshu_gcs__stock_theorique, fallback si pas d'inventaire), réceptions fournisseurs, livraisons clients, livraisons internes (véhicule/anim/prépa/périmé), chargements machines. Pour chaque source/mois, la date de référence inventaire est le dernier inventaire du mois sinon le premier des 5 jours du mois suivant. Agrégation mensuelle (date_trunc à month).
+      [GRAIN] 1 ligne par mois_date (premier jour du mois).
+      [NOTES] Démarrage des flux : 2025-01-01. Démarrage inventaires : 2024-12-01. stock_total = stock_depot + stock_vehicule (cohérence testée).
 
     columns:
 


### PR DESCRIPTION
## Contexte

Audit des 18 marts des 5 BUs migrées (`finance`, `services_generaux`, `supply_chain`, `neshu`, `lcdp`) vs `CONVENTIONS.md § Marts — pattern complet` : **0/18 descriptions** suivaient la trame canonique 4 blocs, et le grain explicite n'était jamais déclaré.

Rapport complet : `docs/audits/marts-audit-2026-05-22.md` (inclus dans cette PR).

## Summary

- Reformate les **18 descriptions YAML** au standard 4 blocs :
  ```
  [QUOI MÉTIER]      <1 phrase métier>
  [COMMENT CONSTRUITE] <sources + règles métier clés>
  [GRAIN]            1 ligne par <X>
  [NOTES]            <optionnel>
  ```
- Grain explicite ajouté pour chaque mart (1 ligne par X)
- Ajoute le rapport d'audit `docs/audits/marts-audit-2026-05-22.md` qui sert de référence pour les PRs suivantes

## Hors scope (PRs séparées à venir)

- Config hygiène : `description=` dans `{{ config() }}` — déjà préparée sur `feature/marts-config-hygiene` (à merger après celle-ci)
- Mentions de rapports BI dans 3 descriptions neshu (à déplacer vers `models/exposures/`)
- Ajout des tests `relationships` sur les FK manquantes
- Ajout des tests `accepted_values` / bornes / `unique_combination_of_columns`
- Statuer `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` (chevauchement)

## Impact

- **0 changement de logique SQL** — uniquement metadata YAML
- `dbt parse` OK
- Pas de matérialisation impactée

## Test plan

- [x] `dbt parse` réussit
- [ ] Reviewer la cohérence des `[GRAIN]` (point critique de la trame)
- [ ] Confirmer le ton "métier" du `[QUOI MÉTIER]` (pas trop technique)

🤖 Generated with [Claude Code](https://claude.com/claude-code)