### PR TITLE
refacto(marts): clean config block — remove description=, consolidate YAML configs

### DIFF
--- a/models/marts/finance/fct_finance__pnl_bu.sql
+++ b/models/marts/finance/fct_finance__pnl_bu.sql
@@ -1,4 +1,4 @@
-{{ config(materialized='table',description='PnL complet avec réel, budget, YTD, N-1 et écarts') }}
+{{ config(materialized='table') }}
 
 with scenarios as (
 -- Scénarios

--- a/models/marts/lcdp/dim_lcdp__company.sql
+++ b/models/marts/lcdp/dim_lcdp__company.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension client/company enrichie à partir des labels associés (zone géo, domaine activité, modèles, etc.) et des informations de localisation.'
-  )
-}}
+{{ config(materialized='table') }}
 
 with company_labels as (
     select

--- a/models/marts/lcdp/dim_lcdp__device.sql
+++ b/models/marts/lcdp/dim_lcdp__device.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension device enrichie à partir des labels associés (catégorie, état, statut, marque, types, etc.)'
-  )
-}}
+{{ config(materialized='table') }}
 
 with device_labels as (
     select

--- a/models/marts/lcdp/dim_lcdp__product.sql
+++ b/models/marts/lcdp/dim_lcdp__product.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension produit enrichie à partir des labels associés (famille, groupe, marque, bio, etc.) filtré sur les produits de type 1 (produit) et 5 (Ligne de prix).'
-  )
-}}
+{{ config(materialized='table') }}
 
 with product_labels as (
     select

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -387,12 +387,7 @@ models:
       [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__contract, pivot des labels via stg_oracle_neshu__label_has_contract (ISACTIVE, ENGAGEMENT, NOMBRE_COLLAB). Sélection du contrat principal par company_id : tri descendant sur current_end_date puis sur original_start_date, conservation du premier.
       [GRAIN] 1 ligne par contract_id (et indirectement 1 par company_id — warn-tested).
       [NOTES] is_active converti depuis label ISACTIVE. engagement_clean = parsing numérique d'engagement_raw.
-    
-    config:
-      materialized: table
-      cluster_by:
-        - contract_id
-    
+
     columns:
       - name: contract_id
         description: Identifiant unique du contrat
@@ -511,9 +506,6 @@ models:
       [COMMENT CONSTRUITE] Pour chaque passage APPRO d'une machine, calcul via LAG du passage précédent pour borner la période d'écoulement ; q_consommee = somme des télémétries entre les deux passages ; q_chargee = somme des chargements lors du passage actuel. Sources : int_oracle_neshu__chargement_tasks, int_oracle_neshu__telemetry_tasks, jointes par device_id et period bounds.
       [GRAIN] 1 ligne par (device_id, date_debut_passage_appro, product_code).
       [NOTES] roadman_code = roadman ayant réalisé le passage. product_type aplati pour filtre BI.
-
-    config:
-      materialized: table
 
     columns:
       - name: device_id

--- a/models/marts/neshu/dim_neshu__company.sql
+++ b/models/marts/neshu/dim_neshu__company.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension client/company enrichie à partir des labels associés (région, secteur, statut, etc.) et des informations de localisation.'
-  )
-}}
+{{ config(materialized='table') }}
 
 with company_labels as (
     select

--- a/models/marts/neshu/dim_neshu__contract.sql
+++ b/models/marts/neshu/dim_neshu__contract.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension contrat : pivot des labels et sélection du contrat actif principal par client.'
-  )
-}}
+{{ config(materialized='table', cluster_by=['contract_id']) }}
 
 with contract_labels as (
     select

--- a/models/marts/neshu/dim_neshu__device.sql
+++ b/models/marts/neshu/dim_neshu__device.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension device enrichie à partir des labels associés (état, statut, gamme, catégorie, marque, etc.)'
-  )
-}}
+{{ config(materialized='table') }}
 
 with device_labels as (
     select

--- a/models/marts/neshu/dim_neshu__product.sql
+++ b/models/marts/neshu/dim_neshu__product.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension produit enrichie à partir des labels associés (type, famille, groupe, marque, etc.) filtré sur les produits de type 1 (produit) et 5 (Ligne de prix).',
-  )
-}}
+{{ config(materialized='table') }}
 
 with product_labels as (
     select

--- a/models/marts/neshu/dim_neshu__resource.sql
+++ b/models/marts/neshu/dim_neshu__resource.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension des ressources Oracle (roadmen et véhicules) enrichie avec les labels (ISACTIVE, Fonction) et le code GEA. Filtrée sur les types PERSON et VEHICLE. Le code GEA est jointé uniquement sur les PERSON via ref_oracle_neshu__roadman_gea.'
-  )
-}}
+{{ config(materialized='table') }}
 
 with resources_labels as (
     select

--- a/models/marts/neshu/dim_neshu__vehicule_roadman.sql
+++ b/models/marts/neshu/dim_neshu__vehicule_roadman.sql
@@ -1,9 +1,4 @@
-{{
-  config(
-    materialized='table',
-    description='Dimension Vehicules et Roadman pour les taches'
-  )
-}}
+{{ config(materialized='table') }}
 
 select
     r.idresources as resources_vehicule_id,

--- a/models/marts/neshu/fct_neshu__appro.sql
+++ b/models/marts/neshu/fct_neshu__appro.sql
@@ -5,8 +5,7 @@
         'data_type': 'timestamp',
         'granularity': 'day'
     },
-    cluster_by=['company_id', 'device_id', 'roadman_code'],
-    description='Table de faits des passages appro enrichi avec les pointages des roadmen et calcul de métriques associées sur les durees de passage et de travail'
+    cluster_by=['company_id', 'device_id', 'roadman_code']
 ) }}
 
 -- Un seul pointage par jour et par roadman

--- a/models/marts/neshu/fct_neshu__chargement_consommation.sql
+++ b/models/marts/neshu/fct_neshu__chargement_consommation.sql
@@ -5,8 +5,7 @@
             'field': 'date_debut_passage_appro',
             'data_type': 'date'
         },
-        cluster_by=['device_id'],
-        description='Table de faits des chargement et consommation (telemetrie) par type de produit, par machine et date de passage appro - Utilisée pour les BI de taux d ecoulement et Suivi des chargements machines gratuités'
+        cluster_by=['device_id']
     )
 }}
 

--- a/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
+++ b/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
@@ -1,8 +1,5 @@
 -- models/fct_chargement_quinzaine.sql
-{{ config(
-    materialized='table',
-    description='Table de faits des chargement et consommation (telemetrie) par type de produit, par machine et date de passage appro - Utilisée pour les BI de taux d ecoulement et Suivi des chargements machines gratuités'
-) }}
+{{ config(materialized='table') }}
 
 with base as (
     select

--- a/models/marts/neshu/fct_neshu__consommation.sql
+++ b/models/marts/neshu/fct_neshu__consommation.sql
@@ -5,8 +5,7 @@
             'field': 'consumption_date',
             'data_type': 'date'
         },
-        cluster_by=['company_id','product_id','device_id'],
-        description='Table de faits des consommations clients pour la BR Neshu - agrégation des données télémétrie, chargement et livraison - Application règles métiers'
+        cluster_by=['company_id','product_id','device_id']
     )
 }}
 

--- a/models/marts/neshu/fct_neshu__maintenance_preventive.sql
+++ b/models/marts/neshu/fct_neshu__maintenance_preventive.sql
@@ -1,8 +1,7 @@
 -- fct_technique__machines_maintenance_tracking.sql
 {{ config(
-    materialized = "table",
-    cluster_by = ['company_code', 'device_code'],
-    description = "Table de faits du suivi des maintenances préventives des machines NESHU (Oracle + Yuman)."
+    materialized='table',
+    cluster_by=['company_code', 'device_code']
 ) }}
 
 -- LISTE MACHINE DLOG filtré & clean

--- a/models/marts/supply_chain/fct_supply_chain__stock_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_neshu.sql
@@ -3,8 +3,7 @@
     partition_by={
         'field': 'date_system',
         'data_type': 'timestamp'
-    },
-    description='Table de fait marts afin de suivre l"inventaire véhicule roadman + dépôt filtrer sur vehicule actif et depôt 1-5 10 et 13, enrichi et cleané'
+    }
 ) }}
 
 with resources_labels as (

--- a/models/marts/supply_chain/fct_supply_chain__stock_yuman.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_yuman.sql
@@ -3,8 +3,7 @@
     partition_by={
         'field': 'stock_date',
         'data_type': 'date'
-    },
-    description='Table de faits des stocks des pièces Yuman journaliers pour chaque stock technicien et dépôt'
+    }
 ) }}
 
 with filtered_stocks as (


### PR DESCRIPTION
## Contexte

Stacked sur #83 (description trame 4 blocs). À merger **après** #83.

Audit identifié dans `docs/audits/marts-audit-2026-05-22.md` : 14/18 marts violaient la convention \"description en YAML uniquement\" (cf. CONVENTIONS.md § Marts — pattern complet) en gardant un \`description=\` redondant dans le \`{{ config() }}\`. Deux modèles avaient aussi un doublon de config (YAML + SQL).

## Summary

- Supprime \`description=\` de \`{{ config() }}\` dans **17 marts SQL** (finance, supply_chain ×2, neshu ×12, lcdp ×3). La description vit désormais en YAML uniquement, \`persist_docs\` propage à BigQuery.
- Consolide \`dim_neshu__contract\` : déplacement de \`materialized\` + \`cluster_by\` du bloc \`config:\` YAML vers \`{{ config() }}\` SQL (suppression du doublon).
- Supprime le bloc \`config: materialized: table\` redondant dans `fct_neshu__chargement_consommation` (déjà dans le SQL).

## Hors scope

- Staging conserve `description=` dans `{{ config() }}` (convention historique, non concerné).
- Aucun changement sur les autres clés de `{{ config() }}` (matérialisation, partitions, clusters inchangés).

## Impact

- **0 changement de logique SQL** ni de matérialisation
- `dbt parse` OK
- Diff = -81 lignes / +19 lignes (purement nettoyage)

## Test plan

- [x] `dbt parse` réussit
- [x] `grep description= models/marts/**/*.sql` → 0 résultat
- [ ] Vérifier que `persist_docs` pousse bien les descriptions YAML à BigQuery sur `dim_neshu__contract` et `fct_neshu__chargement_consommation` (modèles touchés au YAML)

🤖 Generated with [Claude Code](https://claude.com/claude-code)