### PR TITLE
test(marts): add FK relationships tests + expose product_id in chargement_consommation

### DIFF
--- a/docs/audits/marts-audit-2026-05-22.md
+++ b/docs/audits/marts-audit-2026-05-22.md
@@ -3,16 +3,25 @@
 Scope : 5 BUs migrées (`finance`, `services_generaux`, `supply_chain`, `neshu`, `lcdp`).
 Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : description 4 blocs, tests minimum, config hygiène, star schema).
 
-> **MAJ 2026-05-22 (post-PR description trame)** — branche `feature/marts-description-trame-4-blocs` : **18/18 descriptions reformatées** au standard `[QUOI MÉTIER] / [COMMENT CONSTRUITE] / [GRAIN] / [NOTES]`. Mentions BI laissées en place (à retirer dans une PR séparée).
+> **MAJ 2026-05-22 (PR #83, description trame mergée)** — **18/18 descriptions reformatées** au standard `[QUOI MÉTIER] / [COMMENT CONSTRUITE] / [GRAIN] / [NOTES]`. Mentions BI laissées en place (à retirer dans une PR séparée).
+>
+> **MAJ 2026-05-22 (PR #84, config hygiène mergée)** — `description=` retirée du `{{ config() }}` dans 17 marts ; doublon de config consolidé sur `dim_neshu__contract` et `fct_neshu__chargement_consommation`.
+>
+> **MAJ 2026-05-22 (PR #85, FK relationships en review)** — 7 FK `relationships` ajoutées sur `fct_neshu__appro` (×3, dont 1 warn), `fct_neshu__chargement_consommation` (×2), `dim_neshu__contract`, `dim_lcdp__device`. Colonne `product_id` exposée dans `fct_neshu__chargement_consommation` pour permettre une FK propre (vs `product_code` non-unique côté dim).
+>
+> **Anomalies prod détectées via MCP BQ (à investiguer hors-audit)** :
+> - `dim_neshu__company.company_code` : 1 doublon (EVS auto-référencée comme client + société) — à dédupliquer côté modèle
+> - `dim_neshu__resource.location_id` : 100 % NULL (218/218) — colonne morte à supprimer
+> - `fct_neshu__appro.device_id` : 1 NULL sur 540 448 (task_id 11460408, source Oracle) — laissé en warn
 
 ## Synthèse exécutive
 
 | Pilier | État global | Détail |
 |---|---|---|
-| 1. Description trame 4 blocs | ✅ 18/18 conformes (était 0/18) | finance, services_generaux, supply_chain (3), neshu (12), lcdp (3). |
-| 2. Tests obligatoires | ⚠️ 14/18 OK sur PK | PK dims/facts globalement testées. **FK relationships manquantes** sur ~60 % des facts. |
+| 1. Description trame 4 blocs | ✅ 18/18 conformes (PR #83) | finance, services_generaux, supply_chain (3), neshu (12), lcdp (3). |
+| 2. Tests obligatoires | ⚠️ Progression PR #85 | 7 FK `relationships` ajoutées. Reste FK warn (material_id, roadman_code, company_storehouse_id, etc.) en PR B. |
 | 3. Tests recommandés | ❌ Quasi-absents | `accepted_values`, `row_count_between`, `unique_combination_of_columns`, `expression_is_true` : 3 marts conformes sur 18. |
-| 4. Config hygiène | ❌ 14/18 violent la règle | `description=` présent dans `{{ config() }}` de 14 marts (interdit en marts depuis refacto — la description vit en YAML). Aucun `tags=[...]` constaté ✅. |
+| 4. Config hygiène | ✅ Résolu (PR #84) | `description=` retirée des 17 marts. Aucun `tags=[...]` constaté ✅. |
 | 5. Star schema | ✅ Globalement OK | Pas de fact-à-fact ni snowflake détecté. Cas à vérifier : `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` (chevauchement périmètre). |
 | 6. Référence à un nom de rapport BI dans description | ⚠️ 3 cas | `fct_neshu__consommation`, `fct_neshu__chargement_consommation`, `fct_neshu__chargement_quinzaine` mentionnent "Business Review", "BI taux d'écoulement", etc. — à déplacer dans `models/exposures/neshu.yml`. |
 
@@ -106,7 +115,7 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
 ### dim_neshu__contract
 - **Description trame** : ✅ (MAJ 2026-05-22)
 - **Description trame (avant MAJ)** : ⚠️ 2 phrases, grain mentionné en prose ("un seul contrat actif par client") mais pas via balise [GRAIN].
-- **Tests obligatoires** : ✅ `unique` + `not_null` sur `contract_id`. ⚠️ `company_id` testé via `unique_combination_of_columns` warn — bon, mais idéalement `relationships` vers `dim_neshu__company` aussi.
+- **Tests obligatoires** : ✅ `unique` + `not_null` sur `contract_id`. ✅ **PR #85** : `not_null` + `relationships` ajoutés sur `company_id`. `unique_combination_of_columns` warn conservé.
 - **Tests recommandés** : ⚠️ `unique_combination_of_columns(company_id)` ✅. Manque `accepted_values` sur `is_active`. Pas de bornes sur `nombre_collab` (>= 0), `engagement_clean`.
 - **Config hygiène** : ❌ doublon : config dans le YAML (`config: materialized + cluster_by`) **et** dans le SQL (`{{ config(materialized=..., description=...) }}`). Supprimer le `description=` SQL + consolider config (préférer un seul endroit, idéalement SQL).
 - **Suggestion** : trancher l'endroit canonique du config block (SQL uniquement), ajouter trame.
@@ -139,7 +148,7 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
 ### fct_neshu__chargement_consommation
 - **Description trame** : ✅ (MAJ 2026-05-22) — trame canonique appliquée.
 - **Description trame (avant MAJ)** : ✅ mentionnait `Grain : (device, passage_appro, product)` en prose — meilleur que les autres mais sans balise.
-- **Tests obligatoires** : ⚠️ `not_null` sur device_id, date_debut_passage_appro, product_type, product_code. **Manque `relationships`** sur device_id → `dim_neshu__device`, product_code n'est pas un FK direct.
+- **Tests obligatoires** : ✅ **PR #85** — `not_null` + `relationships` ajoutés sur `device_id` → `dim_neshu__device` et `product_id` → `dim_neshu__product` (colonne `product_id` ajoutée à la sortie, propagée depuis la jointure interne existante).
 - **Tests recommandés** : ❌ Pas de `unique_combination_of_columns(device_id, date_debut_passage_appro, product_code)`. Pas de `>= 0` sur `q_consommee`/`q_chargee`. Pas de row_count.
 - **Config hygiène** : ❌ `description=` + mention BI ("BI de taux d ecoulement et Suivi des chargements machines gratuités") — à déplacer dans exposures.
 - **Suggestion** : ajouter relationships sur device_id, unique_combination, bornes >=0.
@@ -155,7 +164,7 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
 ### fct_neshu__appro
 - **Description trame** : ✅ (MAJ 2026-05-22)
 - **Description trame (avant MAJ)** : ⚠️ multi-paragraphe descriptive, pas de [GRAIN] explicite (grain = task_id).
-- **Tests obligatoires** : ✅ `not_null` + `unique` sur `task_id`, `not_null` sur `resources_roadman_id`. ❌ **Manque `relationships`** : device_id → `dim_neshu__device`, company_id → `dim_neshu__company`, resources_roadman_id → `dim_neshu__resource`.
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `task_id`. ✅ **PR #85** : `not_null` + `relationships` ajoutés sur `company_id` → `dim_neshu__company` et `resources_roadman_id` → `dim_neshu__resource` ; `relationships` warn sur `device_id` → `dim_neshu__device` (1 NULL prod toléré, task_id 11460408).
 - **Tests recommandés** : ❌ Pas d'`accepted_values` sur `task_status_code` (PLANIFIE/FAIT/ENCOURS reclassé). Pas de bornes sur durées (`passage_duration_min >= 0`, `work_duration_min between 0 and 720`). Pas de row_count.
 - **Config hygiène** : ❌ `description=` à supprimer.
 - **Suggestion** : prioriser ajout des 3 `relationships` (vraie valeur business). Ajouter bornes durées et accepted_values task_status_code.
@@ -200,7 +209,7 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
 ### dim_lcdp__device
 - **Description trame** : ✅ (MAJ 2026-05-22)
 - **Description trame (avant MAJ)** : ❌ 1 paragraphe, pas de [GRAIN].
-- **Tests obligatoires** : ⚠️ `not_null` + `unique` sur `device_id` ✅. ❌ **Manque `relationships`** sur company_id → `dim_lcdp__company` (présent dans dim_neshu__device, à reproduire ici).
+- **Tests obligatoires** : ✅ `not_null` + `unique` sur `device_id`. ✅ **PR #85** : `not_null` + `relationships` ajoutés sur `company_id` → `dim_lcdp__company` (pattern de `dim_neshu__device` reproduit).
 - **Tests recommandés** : ❌ Pas d'`accepted_values` sur device_state, device_material_status, audit_type, currency_mode, is_active, etc. Pas de row_count.
 - **Config hygiène** : ❌ `description=` à supprimer.
 - **Suggestion** : reproduire le pattern de `dim_neshu__device` (relationships sur company_id) + accepted_values sur labels.
@@ -209,23 +218,37 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
 
 ## Recommandations priorisées pour PRs séparées
 
-1. **PR "config hygiène"** (cosmétique, faible risque, gros impact lisibilité)
-   - Supprimer `description=` du `{{ config() }}` dans 14 marts. La description en YAML reste.
-   - Consolider `dim_neshu__contract` : config en SQL uniquement (retirer le bloc `config:` du YAML).
+1. ✅ **PR #84 — "config hygiène" (MERGÉE)** — `description=` retirée du `{{ config() }}` dans 17 marts, doublons consolidés sur `dim_neshu__contract` et `fct_neshu__chargement_consommation`.
 
-2. **PR "description trame 4 blocs"** (cosmétique)
-   - Reformater les 18 descriptions YAML avec `[QUOI MÉTIER] / [COMMENT CONSTRUITE] / [GRAIN] / [NOTES]`.
-   - Retirer les mentions de rapports BI dans `fct_neshu__consommation`, `fct_neshu__chargement_consommation`, `fct_neshu__chargement_quinzaine`.
+2. ✅ **PR #83 — "description trame 4 blocs" (MERGÉE)** — 18/18 descriptions au standard. Mentions BI conservées (à retirer dans une PR séparée).
 
-3. **PR "tests FK relationships"** (réelle valeur business)
-   - Ajouter `not_null + relationships` sur les FK manquantes : `fct_neshu__appro` (device_id, company_id, resources_roadman_id), `fct_neshu__chargement_consommation` (device_id), `fct_neshu__workorder_delai` (not_null sur FK), `dim_lcdp__device` (company_id).
+3. ✅ **PR #85 — "tests FK relationships" verts (en review)** — `not_null + relationships` sur 6 FK + 1 warn :
+   - `fct_neshu__appro` : `company_id`, `resources_roadman_id`, `device_id` (warn)
+   - `fct_neshu__chargement_consommation` : `device_id`, `product_id` (+ propagation `product_id` dans le SQL)
+   - `dim_neshu__contract` : `company_id`
+   - `dim_lcdp__device` : `company_id`
 
-4. **PR "tests accepted_values + bornes"** (qualité métier — explorer prod via BQ MCP avant de figer les listes)
+4. 🟠 **PR B "tests FK relationships warn"** (à faire) — FK avec NULLs tolérés :
+   - `fct_neshu__workorder_delai` : `material_id`, `site_id`, `client_id` (nullables, warn) — éventuellement `not_null` sur site/client si métier confirme bug
+   - `fct_neshu__chargement_consommation` : `roadman_code` → `dim_neshu__resource.resources_code` filtré PERSON (warn)
+   - `dim_neshu__resource` : `company_id`, `company_storehouse_id` (warn)
+   - `fct_neshu__appro` : retirer le warn sur `device_id` si métier confirme bug source (task_id 11460408)
+
+5. 🟠 **PR "tests accepted_values + bornes"** (qualité métier — explorer prod via BQ MCP avant de figer les listes)
    - Listes `accepted_values` sur statuts, types, modèles économiques, etc.
    - Bornes `>= 0` sur quantités, durées, montants.
    - `unique_combination_of_columns` sur clés composites des facts.
 
-5. **PR "row_count + plages dates"** (warn-only, garde-fou ordre de grandeur)
+6. 🟠 **PR "row_count + plages dates"** (warn-only, garde-fou ordre de grandeur)
    - `expect_table_row_count_to_be_between` et `expect_column_values_to_be_between` (dates) — bornes à calibrer via BQ MCP.
 
-6. **PR séparée à statuer** : `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` — clarifier le périmètre et déprécier l'un des deux si redondant.
+7. 🟠 **PR data quality / cleanup** (suite aux explorations MCP) :
+   - Dédupliquer `dim_neshu__company.company_code` (1 doublon : EVS comme client + société)
+   - Supprimer `dim_neshu__resource.location_id` (100 % NULL en prod)
+   - Statuer sur `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` (chevauchement périmètre)
+   - Investiguer/signaler côté Oracle la `task_id 11460408` (device NULL en source)
+
+8. 🟠 **PR exposures cleanup** — retirer les mentions de rapports BI dans descriptions :
+   - `fct_neshu__consommation` ("Business Review Neshu")
+   - `fct_neshu__chargement_consommation` ("BI taux d'écoulement")
+   - `fct_neshu__chargement_quinzaine` ("Suivi des chargements machines gratuités")

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -145,7 +145,7 @@ models:
       [QUOI MÉTIER] Dimension machine LCDP enrichie des labels métier (catégorie, état, types fontaine/broyeur/percolateur/SP).
       [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__device joint à stg_oracle_lcdp__company (company_code, company_name) et stg_oracle_lcdp__location (access_info → device_location). Pivot des labels via stg_oracle_lcdp__label_has_device sur les familles : CATMACH, MARQUE, ETAT_MACHINE, STATUT_MATERIEL, TYPEAUDIT, TYDA, LCDPMON, TYPFONT, TYPBROY, TYPPERCO, TYPSP, TYPDASA, MODSP, MARQSP, BADGE, ISACTIVE.
       [GRAIN] 1 ligne par device_id.
-      [NOTES] device_iddevice = parent device (hiérarchie). is_active converti en booléen. Relationship vers dim_lcdp__company non encore déclarée (à ajouter dans la PR FK tests).
+      [NOTES] device_iddevice = parent device (hiérarchie). is_active converti en booléen.
     columns:
       - name: device_id
         description: "Identifiant unique du device"
@@ -161,6 +161,12 @@ models:
 
       - name: company_id
         description: "ID de l'entreprise cliente"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__company')
+                field: company_id
 
       - name: location_id
         description: "ID de la localisation"

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -399,7 +399,13 @@ models:
       - name: company_id
         description: Identifiant de l'entreprise cliente associée au contrat
         data_type: number
-      
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
+
       - name: contract_code
         description: Code du contrat
         data_type: varchar
@@ -504,14 +510,18 @@ models:
     description: |
       [QUOI MÉTIER] Quantités chargées vs consommées par machine et par passage APPRO (taux d'écoulement).
       [COMMENT CONSTRUITE] Pour chaque passage APPRO d'une machine, calcul via LAG du passage précédent pour borner la période d'écoulement ; q_consommee = somme des télémétries entre les deux passages ; q_chargee = somme des chargements lors du passage actuel. Sources : int_oracle_neshu__chargement_tasks, int_oracle_neshu__telemetry_tasks, jointes par device_id et period bounds.
-      [GRAIN] 1 ligne par (device_id, date_debut_passage_appro, product_code).
-      [NOTES] roadman_code = roadman ayant réalisé le passage. product_type aplati pour filtre BI.
+      [GRAIN] 1 ligne par (device_id, date_debut_passage_appro, product_id).
+      [NOTES] roadman_code = roadman ayant réalisé le passage. product_type aplati pour filtre BI. product_code conservé en attribut d'affichage.
 
     columns:
       - name: device_id
         description: "Identifiant du device ayant effectué le passage."
         tests:
           - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__device')
+                field: device_id
 
       - name: date_debut_passage_appro
         description: "Date du passage APPRO (troncature à la journée)."
@@ -531,11 +541,20 @@ models:
         description: "Type de produit associé aux quantités consommées ou chargées."
         tests:
           - not_null
-      
-      - name: product_code
-        description: "Code produit associé aux quantités consommées ou chargées."
+
+      - name: product_id
+        description: "Identifiant unique du produit (FK vers dim_neshu__product)."
         tests:
-          - not_null      
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__product')
+                field: product_id
+
+      - name: product_code
+        description: "Code produit (attribut d'affichage, aplati depuis dim_neshu__product)."
+        tests:
+          - not_null
 
       - name: q_consommee
         description: "Quantité consommée entre le passage précédent et le passage actuel."
@@ -675,14 +694,31 @@ models:
 
       - name: device_id
         description: Identifiant du device associé à la tâche
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__device')
+                field: device_id
+              config:
+                severity: warn
 
       - name: company_id
         description: Identifiant de l'entreprise cliente
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
 
       - name: resources_roadman_id
         description: Identifiant du roadman ayant effectué le passage
         tests:
           - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__resource')
+                field: resources_id
 
       # =====================
       # 2️⃣ Attributs

--- a/models/marts/neshu/fct_neshu__chargement_consommation.sql
+++ b/models/marts/neshu/fct_neshu__chargement_consommation.sql
@@ -44,6 +44,7 @@ telemetry_agg as (
             when p.product_type in ('BOISSONS FRAICHES', 'SNACKING') then 'SODA + SNACKS'
             else p.product_type
         end) as product_type,
+        p.product_id,
         p.product_code,
         coalesce(sum(t.telemetry_quantity), 0) as q_consommee
     from passage_avec_suivant as pa
@@ -54,7 +55,7 @@ telemetry_agg as (
             between coalesce(pa.date_passage_precedent, timestamp('2024-12-30 00:00:00')) and pa.task_start_date
     left join {{ ref('dim_neshu__product') }} as p
         on t.product_id = p.product_id
-    group by 1, 2, 3, 4, 5
+    group by 1, 2, 3, 4, 5, 6
     having p.product_type is not null or sum(t.telemetry_quantity) > 0
 ),
 
@@ -71,6 +72,7 @@ chargement_agg as (
             when p.product_type in ('BOISSONS FRAICHES', 'SNACKING') then 'SODA + SNACKS'
             else p.product_type
         end) as product_type,
+        p.product_id,
         p.product_code,
         coalesce(sum(cm.load_quantity), 0) as q_chargee
     from passage_avec_suivant as pa
@@ -80,7 +82,7 @@ chargement_agg as (
             and date(pa.task_start_date) = date(cm.task_start_date)
     left join {{ ref('dim_neshu__product') }} as p
         on cm.product_id = p.product_id
-    group by 1, 2, 3, 4, 5
+    group by 1, 2, 3, 4, 5, 6
     having product_type is not null or sum(cm.load_quantity) > 0
 ),
 
@@ -96,6 +98,7 @@ fusion_telemetry_chargement as (
         min(pa.date_passage_precedent) as date_passage_precedent,
         max(pa.roadman_code) as roadman_code,
         coalesce(t.product_type, c.product_type) as product_type,
+        coalesce(t.product_id, c.product_id) as product_id,
         coalesce(t.product_code, c.product_code) as product_code,
         sum(coalesce(t.q_consommee, 0)) as q_consommee,
         max(coalesce(c.q_chargee, 0)) as q_chargee
@@ -105,13 +108,13 @@ fusion_telemetry_chargement as (
             t.device_id = c.device_id
             and t.task_start_date = c.task_start_date
             and t.product_type = c.product_type
-            and t.product_code = c.product_code
+            and t.product_id = c.product_id
     left join passage_avec_suivant as pa
         on
             pa.device_id = coalesce(t.device_id, c.device_id)
             and pa.task_start_date = coalesce(t.task_start_date, c.task_start_date)
     group by
-        1, 2, 6, 7
+        1, 2, 6, 7, 8
 )
 
 -- -----------------------------------------------------------------------------------
@@ -124,6 +127,7 @@ select
     date_passage_precedent,
     roadman_code,
     product_type,
+    product_id,
     product_code,
     q_consommee,
     q_chargee,


### PR DESCRIPTION
## Contexte

PR A du plan d'audit `docs/audits/marts-audit-2026-05-22.md`.

L'audit a identifié plusieurs FK exposées dans les facts/dims sans test `relationships` associé. Cette PR couvre les **6 cas \"verts\"** où la FK est évidente et la prod est propre (0 violation BQ confirmée via MCP).

## Summary

### Tests ajoutés

| Modèle | FK | Sévérité |
|---|---|---|
| `fct_neshu__appro` | `company_id` → `dim_neshu__company` | not_null + relationships (error) |
| `fct_neshu__appro` | `resources_roadman_id` → `dim_neshu__resource.resources_id` | not_null + relationships (error) |
| `fct_neshu__appro` | `device_id` → `dim_neshu__device` | relationships (**warn** — 1 NULL prod sur 540k) |
| `fct_neshu__chargement_consommation` | `device_id` → `dim_neshu__device` | not_null + relationships |
| `fct_neshu__chargement_consommation` | `product_id` → `dim_neshu__product` | not_null + relationships (**colonne ajoutée**) |
| `dim_neshu__contract` | `company_id` → `dim_neshu__company` | not_null + relationships |
| `dim_lcdp__device` | `company_id` → `dim_lcdp__company` | not_null + relationships |

### Modification SQL — `fct_neshu__chargement_consommation`

Propagation de `product_id` depuis `dim_neshu__product` jusqu'à la sortie. La jointure interne se faisait déjà sur `product_id` (lignes 56, 82), mais seul `product_code` était exposé. Ce code n'est pas testable en `relationships` propre (la dim n'a pas de test `unique` sur `product_code`).

- `product_id` ajouté aux CTE `telemetry_agg` / `chargement_agg` + group by
- Jointure `full join` entre les 2 CTE désormais sur `product_id` (équivalent fonctionnel à `product_code`, plus propre)
- `product_code` conservé en attribut d'affichage pour le BI
- Grain documenté mis à jour : `(device_id, date_debut_passage_appro, product_id)`

## Hors scope

- PR B (suite) : tests `relationships` warn sur les FK avec nulls tolérés (`material_id`, `roadman_code`, etc.)
- Doublon `company_code` dans `dim_neshu__company` (1 ligne EVS auto-référencée) : à investiguer côté modèle séparément
- Colonne `dim_neshu__resource.location_id` 100 % NULL : suppression à statuer

## Test plan

- [x] \`dbt parse\` réussit
- [x] \`dbt build -s fct_neshu__chargement_consommation\` sur dev : 8/8 PASS
- [x] \`dbt build -s fct_neshu__appro dim_neshu__contract dim_lcdp__device\` sur dev : 22/22 PASS
- [ ] Vérifier en prod que les colonnes `product_id` apparaissent bien dans `prod_marts.fct_neshu__chargement_consommation` après merge
- [ ] Si un rapport Power BI consomme déjà `fct_neshu__chargement_consommation`, vérifier qu'il n'est pas impacté par l'ajout de la colonne (additive, donc safe a priori)

🤖 Generated with [Claude Code](https://claude.com/claude-code)