### PR TITLE
test(marts): add FK relationships on nullable FKs (PR B)

### DIFF
--- a/docs/audits/marts-audit-2026-05-22.md
+++ b/docs/audits/marts-audit-2026-05-22.md
@@ -7,10 +7,16 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
 >
 > **MAJ 2026-05-22 (PR #84, config hygiène mergée)** — `description=` retirée du `{{ config() }}` dans 17 marts ; doublon de config consolidé sur `dim_neshu__contract` et `fct_neshu__chargement_consommation`.
 >
-> **MAJ 2026-05-22 (PR #85, FK relationships en review)** — 7 FK `relationships` ajoutées sur `fct_neshu__appro` (×3, dont 1 warn), `fct_neshu__chargement_consommation` (×2), `dim_neshu__contract`, `dim_lcdp__device`. Colonne `product_id` exposée dans `fct_neshu__chargement_consommation` pour permettre une FK propre (vs `product_code` non-unique côté dim).
+> **MAJ 2026-05-22 (PR #85, FK relationships mergée)** — 7 FK `relationships` ajoutées sur `fct_neshu__appro` (×3, dont 1 warn), `fct_neshu__chargement_consommation` (×2), `dim_neshu__contract`, `dim_lcdp__device`. Colonne `product_id` exposée dans `fct_neshu__chargement_consommation` pour permettre une FK propre (vs `product_code` non-unique côté dim).
+>
+> **MAJ 2026-05-22 (PR B, FK FK warn → error nullable-tolérant)** — Vérification BQ : 6 FK à NULLs tolérés ont 0 fantôme en prod. Tests `relationships` ajoutés en sévérité error (le test dbt ignore les NULLs par défaut). Modifs :
+> - `dim_neshu__resource.company_id` et `company_storehouse_id` : `relationships` ajoutés
+> - `fct_neshu__appro.device_id` : passage de warn → error (excès de prudence, 0 fantôme prod)
+> - `fct_neshu__workorder_delai` : tests existants (material/site/client_id) conservés en error (0 fantôme)
+> - **Reporté** : `roadman_code` → 37 606 codes orphelins (VARKEMA, vappro, PREPA RUNGIS) — sujet de refacto naming, pas de test FK.
 >
 > **Anomalies prod détectées via MCP BQ (à investiguer hors-audit)** :
-> - `dim_neshu__company.company_code` : 1 doublon (EVS auto-référencée comme client + société) — à dédupliquer côté modèle
+> - `dim_neshu__company.company_code` : 1 doublon (EVS auto-référencée comme client + société). **Non bloquant** : aucun mart ne joint sur `company_code` (tous joignent sur `company_id`). `company_code` est purement un attribut d'affichage BI. À garder en l'état.
 > - `dim_neshu__resource.location_id` : 100 % NULL (218/218) — colonne morte à supprimer
 > - `fct_neshu__appro.device_id` : 1 NULL sur 540 448 (task_id 11460408, source Oracle) — laissé en warn
 
@@ -243,10 +249,10 @@ Référence : `CONVENTIONS.md` § Marts — pattern complet (4 piliers : descrip
    - `expect_table_row_count_to_be_between` et `expect_column_values_to_be_between` (dates) — bornes à calibrer via BQ MCP.
 
 7. 🟠 **PR data quality / cleanup** (suite aux explorations MCP) :
-   - Dédupliquer `dim_neshu__company.company_code` (1 doublon : EVS comme client + société)
    - Supprimer `dim_neshu__resource.location_id` (100 % NULL en prod)
    - Statuer sur `dim_neshu__vehicule_roadman` vs `dim_neshu__resource` (chevauchement périmètre)
    - Investiguer/signaler côté Oracle la `task_id 11460408` (device NULL en source)
+   - ~~Doublon `company_code`~~ : non bloquant (purement affichage, jointures internes sur `company_id`)
 
 8. 🟠 **PR exposures cleanup** — retirer les mentions de rapports BI dans descriptions :
    - `fct_neshu__consommation` ("Business Review Neshu")

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -617,10 +617,20 @@ models:
           Pour un roadman (PERSON) : NULL.
 
       - name: company_id
-        description: "Identifiant de l'entreprise à laquelle est rattachée la ressource"
+        description: "Identifiant de l'entreprise à laquelle est rattachée la ressource (NULL toléré : ressources génériques, comptes API, véhicules sans rattachement)"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
 
       - name: company_storehouse_id
-        description: "Identifiant de l'entreprise entrepôt associée à la ressource"
+        description: "Identifiant de l'entreprise entrepôt associée à la ressource (NULL toléré : véhicules itinérants sans dépôt fixe)"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
 
       - name: location_id
         description: "Identifiant de la localisation de la ressource"
@@ -693,14 +703,12 @@ models:
           - unique
 
       - name: device_id
-        description: Identifiant du device associé à la tâche
+        description: Identifiant du device associé à la tâche (NULL toléré, cf. task_id 11460408 — source Oracle)
         tests:
           - relationships:
               arguments:
                 to: ref('dim_neshu__device')
                 field: device_id
-              config:
-                severity: warn
 
       - name: company_id
         description: Identifiant de l'entreprise cliente


### PR DESCRIPTION
## Contexte

PR B du plan d'audit \`docs/audits/marts-audit-2026-05-22.md\`. Suite de PR #85.

**Insight clé** : le test dbt \`relationships\` **ignore les NULLs par défaut**. Pour une FK nullable, on peut donc poser \`relationships\` en sévérité **error** (sans \`not_null\`) tant qu'aucune valeur non-null ne pointe vers une dim inexistante (fantôme).

Vérification via MCP BQ : **0 fantôme en prod** sur les 6 FK candidates.

## Summary

### Tests ajoutés (relationships, default error)

| Modèle | FK | NULLs prod | Justification |
|---|---|---|---|
| \`dim_neshu__resource\` | \`company_id\` | 8 / 218 | Ressources génériques, comptes API, véhicules sans rattachement |
| \`dim_neshu__resource\` | \`company_storehouse_id\` | 15 / 218 | Véhicules itinérants sans dépôt fixe |

### Modification

- \`fct_neshu__appro.device_id\` : passage de \`severity: warn\` → \`error\` (default). Le warn ajouté en PR #85 était un excès de prudence — 0 fantôme prod, le seul NULL (task_id 11460408, source Oracle) ne fait pas échouer un test relationships.

### Conservés tels quels

Tests existants en error qui passent grâce au comportement \"relationships ignore les NULLs\" :
- \`fct_neshu__workorder_delai.material_id\` (1 714 NULLs, 0 fantôme)
- \`fct_neshu__workorder_delai.site_id\` (2 NULLs, 0 fantôme)
- \`fct_neshu__workorder_delai.client_id\` (1 NULL, 0 fantôme)

### Reporté hors-PR

- \`fct_neshu__chargement_consommation.roadman_code\` : **37 606 orphelins prod**
  - Top : VARKEMA (33 674), LIBRE ANCIEN SJEROME (2 901), vappro01/02 (951), PREPA RUNGIS (80)
  - La colonne contient des codes mixtes (véhicules spéciaux + sites logistiques), pas seulement des roadmen → sujet de refacto naming, pas de test FK

### Bundle docs

- MAJ \`docs/audits/marts-audit-2026-05-22.md\` :
  - Bannière PR B
  - Clarification du \"doublon company_code\" : impact nul (toutes les jointures internes utilisent \`company_id\`)

## Hors scope

- PR \`accepted_values\` + bornes + \`unique_combination_of_columns\` (qualité métier)
- PR \`row_count_between\` + plages dates (garde-fou ordre de grandeur)
- PR data quality / cleanup (location_id mort, statuer vehicule_roadman vs resource)
- PR refacto naming \`roadman_code\` (à investiguer côté \`fct_neshu__chargement_consommation\`)

## Test plan

- [x] \`dbt parse\` réussit
- [x] \`dbt build -s fct_neshu__appro dim_neshu__resource\` sur dev : 16/16 PASS
- [x] BQ MCP : 0 fantôme confirmé sur les 6 FK candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)