### PR TITLE
refacto(intermediate): extract int_oracle_neshu__appro_tasks_enriched

### DIFF
--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -880,6 +880,87 @@ models:
           - not_null
 
 
+  - name: int_oracle_neshu__appro_tasks_enriched
+    description: |
+      Tâches appro enrichies du référentiel (company, device, roadman, GEA)
+      et du statut normalisé (ENCOURS reclassé en FAIT après validation métier).
+      Base partagée entre fct_neshu__appro (analyse roadman/jour avec pointage
+      et métriques journalières) et tout fact dérivé au grain machine.
+      Grain : 1 ligne par task_id (passage appro).
+    columns:
+      - name: task_id
+        description: "ID de la tâche"
+        tests:
+          - unique
+          - not_null
+      - name: device_id
+        description: "ID du device (NULL toléré, cf. task_id 11460408 - source Oracle)"
+      - name: company_id
+        description: "ID de la company cliente"
+        tests:
+          - not_null
+      - name: resources_roadman_id
+        description: "ID du roadman (resources type=2)"
+        tests:
+          - not_null
+      - name: roadman_code
+        description: "Code roadman"
+      - name: gea_code
+        description: "Code GEA mappé depuis ref_oracle_neshu__roadman_gea"
+      - name: device_code
+        description: "Code device"
+      - name: device_name
+        description: "Nom device"
+      - name: device_info
+        description: "Libellé concat 'nom - code'"
+      - name: company_code
+        description: "Code company"
+      - name: company_name
+        description: "Nom company"
+      - name: company_info
+        description: "Libellé concat 'nom - code'"
+      - name: task_status_code
+        description: "Statut normalisé (ENCOURS reclassé en FAIT)"
+        tests:
+          - not_null
+      - name: is_done
+        description: "Indicateur binaire : 1 si FAIT ou ENCOURS"
+      - name: is_planned
+        description: "Indicateur binaire : 1 si PREVU, FAIT ou ENCOURS"
+      - name: task_start_date
+        description: "Date début passage"
+        tests:
+          - not_null
+      - name: task_end_date
+        description: "Date fin passage"
+      - name: start_date_day
+        description: "task_start_date tronqué au jour"
+      - name: passage_duration_min
+        description: "Durée du passage en minutes (NULL si non FAIT ou dates manquantes)"
+      - name: passage_duration_hours
+        description: "Durée du passage en heures"
+      - name: passage_duration_interval
+        description: "Durée brute en INTERVAL (audit)"
+      - name: product_source_id
+        description: "ID source du produit (idresources)"
+      - name: product_destination_id
+        description: "ID destination du produit"
+      - name: product_source_type
+        description: "Type de la source produit (RESOURCES, etc.)"
+      - name: product_destination_type
+        description: "Type de la destination produit"
+      - name: task_location_info
+        description: "Infos de localisation de la tâche"
+      - name: created_at
+        description: "Timestamp création source"
+        tests:
+          - not_null
+      - name: updated_at
+        description: "Timestamp dernière modif source"
+        tests:
+          - not_null
+
+
   - name: int_oracle_neshu__inter_techinique_tasks
     description: >
       Table intermédiaire des inter technique.

--- a/models/intermediate/oracle_neshu/int_oracle_neshu__appro_tasks_enriched.sql
+++ b/models/intermediate/oracle_neshu/int_oracle_neshu__appro_tasks_enriched.sql
@@ -1,0 +1,110 @@
+{{ config(materialized='table') }}
+
+-- ============================================================
+-- CTE 1 : Roadman associé à chaque tâche appro
+-- Jointure stg_oracle_neshu__task_has_resources × resources (type=2 = PERSON)
+-- ============================================================
+with resources_roadman as (
+    select
+        thr.idtask,
+        min(r.idresources) as resources_roadman_id,
+        min(r.code) as roadman_code
+    from {{ ref('stg_oracle_neshu__task_has_resources') }} as thr
+    inner join {{ ref('stg_oracle_neshu__resources') }} as r
+        on
+            thr.idresources = r.idresources
+            and r.idresources_type = 2
+    group by thr.idtask
+),
+
+-- ============================================================
+-- CTE 2 : Enrichissement tâche appro
+-- Joint le référentiel company, device, GEA. Normalise le statut
+-- (ENCOURS reclassé en FAIT après validation métier). Calcule la
+-- durée brute du passage.
+-- ============================================================
+enriched as (
+    select
+        -- IDs
+        pa.task_id,
+        pa.device_id,
+        pa.company_id,
+        pa.product_source_id,
+        r.resources_roadman_id,
+        pa.product_destination_id,
+        pa.product_source_type,
+        pa.product_destination_type,
+
+        -- Codes et libellés aplatis
+        pa.company_code,
+        c.name as company_name,
+        c.name || ' - ' || pa.company_code as company_info,
+        d.code as device_code,
+        d.name as device_name,
+        d.name || ' - ' || d.code as device_info,
+        g.gea_code,
+        r.roadman_code,
+        pa.task_location_info,
+
+        -- Statut normalisé (ENCOURS → FAIT)
+        case
+            when pa.task_status_code in ('FAIT', 'ENCOURS') then 'FAIT'
+            else pa.task_status_code
+        end as task_status_code,
+        case when pa.task_status_code in ('FAIT', 'ENCOURS') then 1 else 0 end as is_done,
+        case when pa.task_status_code in ('PREVU', 'FAIT', 'ENCOURS') then 1 else 0 end as is_planned,
+
+        -- Dates
+        date(pa.task_start_date) as start_date_day,
+        pa.task_start_date,
+        pa.task_end_date,
+
+        -- Durée du passage
+        pa.task_end_date - pa.task_start_date as passage_duration_interval,
+        case
+            when
+                pa.task_start_date is not null
+                and pa.task_end_date is not null
+                and pa.task_status_code = 'FAIT'
+                then
+                    timestamp_diff(
+                        pa.task_end_date,
+                        pa.task_start_date,
+                        second
+                    ) / 60.0
+        end as passage_duration_min,
+        case
+            when
+                pa.task_start_date is not null
+                and pa.task_end_date is not null
+                and pa.task_status_code = 'FAIT'
+                then
+                    timestamp_diff(
+                        pa.task_end_date,
+                        pa.task_start_date,
+                        second
+                    ) / 3600.0
+        end as passage_duration_hours,
+
+        -- Métadonnées
+        pa.created_at,
+        pa.updated_at
+
+    from {{ ref('int_oracle_neshu__appro_tasks') }} as pa
+
+    left join resources_roadman as r
+        on pa.task_id = r.idtask
+
+    left join {{ ref('ref_oracle_neshu__roadman_gea') }} as g
+        on r.roadman_code = g.roadman_code
+
+    left join {{ ref('stg_oracle_neshu__company') }} as c
+        on pa.company_id = c.idcompany
+
+    left join {{ ref('stg_oracle_neshu__device') }} as d
+        on pa.device_id = d.iddevice
+
+    where r.resources_roadman_id is not null
+)
+
+select * from enriched

--- a/models/marts/neshu/fct_neshu__appro.sql
+++ b/models/marts/neshu/fct_neshu__appro.sql
@@ -8,7 +8,10 @@
     cluster_by=['company_id', 'device_id', 'roadman_code']
 ) }}
 
--- Un seul pointage par jour et par roadman
+-- ============================================================
+-- CTE 1 : Pointage unique par roadman / jour
+-- 1 ligne par (roadman, jour) avec le premier pointage START_DAY
+-- ============================================================
 with pointage_unique_par_jour as (
     select
         task_id,
@@ -62,104 +65,25 @@ pointage_final_table as (
     where rn = 1 and resources_roadman_id is not null
 ),
 
-resources_roadman as (
-    select
-        thr.idtask,
-        min(r.idresources) as resources_roadman_id,
-        min(r.code) as roadman_code
-    from {{ ref('stg_oracle_neshu__task_has_resources') }} as thr
-    inner join {{ ref('stg_oracle_neshu__resources') }} as r
-        on
-            thr.idresources = r.idresources
-            and r.idresources_type = 2
-    group by thr.idtask
-),
-
+-- ============================================================
+-- CTE 2 : Tâches appro enrichies + pointage joint
+-- ============================================================
 passage_appro as (
     select
-        pa.task_id,
-        pa.device_id,
-        pa.company_id,
-        pa.product_source_id,
-        r.resources_roadman_id,
-        pa.product_destination_id,
-        pa.product_source_type,
-        pa.product_destination_type,
-        pa.company_code,
-        c.name as company_name,
-        c.name || ' - ' || pa.company_code as company_info,
-        d.code as device_code,
-        d.name as device_name,
-        d.name || ' - ' || d.code as device_info,
-        g.gea_code,
-        r.roadman_code,
-        pa.task_location_info,
-        case
-            when pa.task_status_code in ('FAIT', 'ENCOURS') then 'FAIT'
-            else pa.task_status_code
-        end as task_status_code,
+        e.*,
         p.date_pointage,
         p.date_pointage_jour,
-        date(pa.task_start_date) as start_date_day,
-        pa.task_start_date,
-        pa.task_end_date,
-        -- Durée brute (audit)
-        pa.task_end_date - pa.task_start_date as passage_duration_interval,
-        -- Métrique BI
-        case
-            when
-                pa.task_start_date is not null
-                and pa.task_end_date is not null
-                and pa.task_status_code = 'FAIT'
-                then
-                    timestamp_diff(
-                        pa.task_end_date,
-                        pa.task_start_date,
-                        second
-                    ) / 60.0
-        end as passage_duration_min,
-        case
-            when
-                pa.task_start_date is not null
-                and pa.task_end_date is not null
-                and pa.task_status_code = 'FAIT'
-                then
-                    timestamp_diff(
-                        pa.task_end_date,
-                        pa.task_start_date,
-                        second
-                    ) / 3600.0
-        end as passage_duration_hours,
-        case when pa.task_status_code in ('FAIT', 'ENCOURS') then 1 else 0 end as is_done,
-        case when pa.task_status_code in ('PREVU', 'FAIT', 'ENCOURS') then 1 else 0 end as is_planned,
-        case
-            when p.date_pointage is null then 1
-            else 0
-        end as pointage_missing_flag,
-        pa.created_at,
-        pa.updated_at
-    from {{ ref('int_oracle_neshu__appro_tasks') }} as pa
-
-    left join resources_roadman as r
-        on pa.task_id = r.idtask
-
-    left join {{ ref('ref_oracle_neshu__roadman_gea') }} as g
-        on r.roadman_code = g.roadman_code
-
-    left join {{ ref('stg_oracle_neshu__company') }} as c
-        on pa.company_id = c.idcompany
-
-    left join {{ ref('stg_oracle_neshu__device') }} as d
-        on pa.device_id = d.iddevice
-
+        case when p.date_pointage is null then 1 else 0 end as pointage_missing_flag
+    from {{ ref('int_oracle_neshu__appro_tasks_enriched') }} as e
     left join pointage_final_table as p
         on
-            date(pa.task_start_date) = p.date_pointage_jour
-            and r.resources_roadman_id = p.resources_roadman_id
-
-    where r.resources_roadman_id is not null
+            e.start_date_day = p.date_pointage_jour
+            and e.resources_roadman_id = p.resources_roadman_id
 ),
 
+-- ============================================================
+-- CTE 3 : Métriques journalières par roadman (window functions)
+-- ============================================================
 passage_with_metrics as (
     select
         pa.*,
@@ -198,8 +122,6 @@ passage_with_metrics as (
             order by pa.task_start_date
         ) as passage_rank_of_day,
 
-        -- 📊 NOUVEAUX CALCULS DE TAUX --
-
         -- Compteurs pour le roadman ce jour
         sum(pa.is_done) over (
             partition by pa.resources_roadman_id, date(pa.task_start_date)
@@ -228,7 +150,9 @@ passage_with_metrics as (
     from passage_appro as pa
 ),
 
--- Calcul de work_duration_min
+-- ============================================================
+-- CTE 4 : Calcul de work_duration_min (nettoyé des aberrants)
+-- ============================================================
 passage_work_duration as (
     select
         *,
@@ -254,7 +178,9 @@ passage_work_duration as (
     from passage_with_metrics
 )
 
--- Final table
+-- ============================================================
+-- Sélection finale
+-- ============================================================
 select
     -- 1️⃣ IDs
     task_id,
@@ -300,7 +226,7 @@ select
         else 0
     end as passage_client_done,
 
-    -- 📊 Nouveaux KPI taux de réalisation
+    -- 📊 KPI taux de réalisation
     done_count_roadman_day,
     planned_count_roadman_day,
     taux_realisation_roadman_day,


### PR DESCRIPTION
## Contexte

Préparation d'architecture pour PR #77 et tout futur mart consommant les passages appro NESHU à un grain différent que `task`.

Aujourd'hui, la logique d'enrichissement task-level (jointures référentielles + normalisation statut ENCOURS→FAIT + durée) vit dans \`fct_neshu__appro\`. Tout autre mart qui voudrait consommer ces données serait obligé :
- soit de dupliquer cette logique (drift, bugs)
- soit de violer la règle "no fact-to-fact joins" (cf. CLAUDE.md)

Cette PR extrait la logique partagée dans un intermediate dédié.

## Architecture

\`\`\`
int_oracle_neshu__appro_tasks (base, existant)
    ↓
int_oracle_neshu__appro_tasks_enriched (NOUVEAU)
    ↓                              ↓
fct_neshu__appro                  [futurs marts à grain machine,
(+ pointage                        ex. int_oracle_neshu__appro_machine_context
 + window metrics                  pour PR #77]
 + work_duration)
\`\`\`

## Summary

### Nouvel intermediate \`int_oracle_neshu__appro_tasks_enriched\`

**Grain** : 1 ligne par \`task_id\` (passage appro).

**Contenu** :
- Référentiel aplati : company_code/name/info, device_code/name/info, GEA code, roadman_code
- Statut normalisé (ENCOURS reclassé en FAIT après validation métier)
- Indicateurs \`is_done\`, \`is_planned\`
- Durées passage (interval, min, hours)

**Tests** :
- \`unique\` + \`not_null\` sur \`task_id\` (PK)
- \`not_null\` sur \`company_id\`, \`resources_roadman_id\`, \`task_status_code\`, \`task_start_date\`, \`created_at\`, \`updated_at\`
- Pas de \`not_null\` sur \`device_id\` (1 NULL connu, task 11460408, anomalie source Oracle)

### Refacto \`fct_neshu__appro\`

- Consomme maintenant \`int_oracle_neshu__appro_tasks_enriched\` (au lieu de reconstruire les jointures référentielles)
- Garde la logique **spécifique au mart** :
  - Pointage roadman/jour (CTE \`pointage_*\`)
  - Métriques journalières par window functions (CTE \`passage_with_metrics\`)
  - Nettoyage des work_duration aberrants (CTE \`passage_work_duration\`)
- **317 → 254 lignes** (-20%)
- Tous les tests existants conservés et passent

## Hors scope

- PR B : nouvel intermediate \`int_oracle_neshu__appro_machine_context\` (grain device) qui consommera l'enriched
- PR C : refacto PR #77 pour consommer B + correction conventions

## Test plan

- [x] \`dbt build -s int_oracle_neshu__appro_tasks_enriched fct_neshu__appro\` sur dev : 17/17 PASS
- [x] Row count préservé : 539k rows fct_neshu__appro identique avant/après
- [ ] **À valider avant merge prod** : diff de données (row count + sum des principales métriques) entre fct_neshu__appro avant/après refacto. Le rebuild devrait être identique mais à confirmer via \`dbt-audit-helper\` ou requête manuelle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)