### PR TITLE
refacto(marts): migrate commerce — rename + 4-block trame + orchestration

### DIFF
--- a/docs/migration-marts/inventory.md
+++ b/docs/migration-marts/inventory.md
@@ -74,11 +74,11 @@ External source `fct_lcdp__monitoring_passage_appro` already migrated in PR #82.
 
 Folders `yuman/` et `nesp_tech/` supprimés (vides après le move). Subkeys `yuman:` et `nesp_tech:` retirés de `dbt_project.yml`.
 
-### → `commerce/` (1)
+### → `commerce/` (1) ✅ migrated 2026-05-22
 
 | Current path | Target name | Notes |
 |---|---|---|
-| `commerce/fct_commerce__machines_avec_interventions.sql` | `fct_commerce__machine_intervention` | singular, drop `_avec_` connector |
+| ~~`commerce/fct_commerce__machines_avec_interventions.sql`~~ → `commerce/fct_commerce__machine_intervention.sql` | `fct_commerce__machine_intervention` | rename in-place (singular, drop `_avec_` connector). YAML enrichi avec trame description 4 blocs + tests (accepted_values, expect_column_values_to_be_between, expect_table_row_count_to_be_between). Workflow `transform-commerce-daily` créé en même temps avec 2 schedulers weekdays 08:30 + 10:00. |
 
 ### → `finance/` (1) ✅ DONE 2026-05-20
 

--- a/models/marts/commerce/_commerce__marts_models.yml
+++ b/models/marts/commerce/_commerce__marts_models.yml
@@ -1,49 +1,57 @@
 version: 2
 
 models:
-  - name: fct_commerce__machines_avec_interventions
-    description: >
-      Table détaillée des interventions techniques clôturées sur les 6 derniers mois,
-      enrichie des informations client et du libellé machine normalisé.
-      Granularité : 1 ligne par intervention.
-    config:
-      materialized: table
+  - name: fct_commerce__machine_intervention
+    description: |
+      [QUOI MÉTIER]
+      Interventions techniques EVS sur le parc machines Nespresso, clôturées
+      sur les 6 derniers mois glissants. Vue consolidée Nespresso pour le suivi
+      commercial / activité.
+
+      [COMMENT CONSTRUITE]
+      Issu de int_nesp_tech__interventions_dedup (interventions Nespresso reçues
+      par fichier Excel) filtré sur états clôturés ('terminée signée', 'signature
+      différée', 'terminée non signée') et date_heure_fin >= today - 6 mois.
+      Joint à int_nesp_co__clients_enrichis pour les coordonnées client (n_client
+      = third). Joint à ref_nesp_tech__machines_clean pour normaliser le libellé
+      machine.
+
+      [GRAIN]
+      1 ligne par intervention (n_planning).
+
+      [NOTES]
+      Sources nesp_tech (fichier Excel hebdo Mon 07:30) et nesp_co (fichier Excel
+      daily 08:00) — pas de base de données, donc pas de vraies dims, les
+      attributs client/machine sont aplatis depuis les intermediates. INNER JOIN
+      sur le client : une intervention sans client matching est exclue. Rafraîchi
+      2× par jour weekdays (08:30 + 10:00) via transform-commerce-daily.
 
     columns:
-
-      # -----------------------------------------------------------------------
-      # [A] Identification client
-      # -----------------------------------------------------------------------
+      # === Identification client ===
       - name: mc
-        description: Identifiant unique du client (tiers). Clé de jointure avec le référentiel clients.
+        description: Identifiant unique du client (n_client Nespresso = third nesp_co).
         tests:
           - not_null
 
       - name: nom_client
-        description: Raison sociale ou nom du client.
+        description: Raison sociale du client.
 
       - name: mc_nom_client
-        description: Concaténation de l'identifiant client et de son nom (format "mc - nom_client").
+        description: Concaténation 'mc - nom_client' pour les libellés BI.
 
       - name: secteur
-        description: Secteur d'activité du client (ex. santé, industrie, tertiaire…).
+        description: Secteur d'activité du client.
 
-      # -----------------------------------------------------------------------
-      # [B] Coordonnées & contact client
-      # -----------------------------------------------------------------------
+      # === Contact client ===
       - name: contact_client
         description: Nom du donneur d'ordre côté client (order_placer_name).
 
       - name: telephone
-        description: Numéro de téléphone du contact client (order_placer_phone).
+        description: Téléphone du contact client (order_placer_phone).
 
-      # -----------------------------------------------------------------------
-      # [C] Localisation client
-      # -----------------------------------------------------------------------
+      # === Localisation client ===
       - name: adresse
-        description: >
-          Adresse postale du client, construite par concaténation de
-          third_address_1 et third_address_2 (NULL traité comme chaîne vide).
+        description: Adresse postale construite par concaténation des lignes 1 et 2.
 
       - name: ville
         description: Ville du client.
@@ -51,50 +59,47 @@ models:
       - name: code_postal
         description: Code postal du client.
 
-      # -----------------------------------------------------------------------
-      # [D] Identification machine
-      # -----------------------------------------------------------------------
+      # === Identification machine ===
       - name: n_serie_machine
         description: Numéro de série de la machine.
         tests:
           - not_null
 
       - name: code_machine
-        description: Code technique de la machine (ex. référence catalogue interne).
+        description: Code technique catalogue de la machine.
 
       - name: nom_machine
-        description: Libellé brut de la machine tel qu'il apparaît dans les interventions.
+        description: Libellé brut de la machine tel qu'il apparaît dans les interventions Nespresso.
 
       - name: machine
-        description: >
-          Libellé normalisé de la machine issu de ref_nesp_tech__machines_clean.
-          Peut être NULL si le nom_machine ne trouve pas de correspondance dans
-          la table de référence.
+        description: Libellé normalisé de la machine via ref_nesp_tech__machines_clean. NULL si pas de mapping.
 
-      # -----------------------------------------------------------------------
-      # [E] Informations intervention
-      # -----------------------------------------------------------------------
+      # === Intervention ===
       - name: intervention
-        description: Numéro de planning de l'intervention (n_planning). Identifiant technique de l'intervention.
+        description: Identifiant unique de l'intervention (n_planning Nespresso).
         tests:
           - not_null
           - unique
 
       - name: date_intervention
-        description: Date et heure de fin de l'intervention clôturée.
+        description: Date et heure de fin de l'intervention.
         tests:
           - not_null
+          - dbt_expectations.expect_column_values_to_be_between:
+              arguments:
+                min_value: "timestamp_sub(current_timestamp(), interval 200 day)"
+                max_value: "current_timestamp()"
+              config:
+                severity: warn
 
       - name: consignes
         description: Consignes transmises au technicien avant l'intervention.
 
       - name: observations
-        description: Observations saisies par le technicien à la clôture de l'intervention.
+        description: Observations saisies par le technicien à la clôture.
 
       - name: etat_intervention
-        description: >
-          État de clôture de l'intervention.
-          Valeurs possibles : 'terminée signée', 'signature différée', 'terminée non signée'.
+        description: État de clôture de l'intervention (filtré sur les états clôturés en amont).
         tests:
           - not_null
           - accepted_values:
@@ -103,3 +108,12 @@ models:
                   - terminée signée
                   - signature différée
                   - terminée non signée
+
+    # === TESTS AU NIVEAU MODELE ===
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 100
+            max_value: 100000
+          config:
+            severity: warn

--- a/models/marts/commerce/fct_commerce__machine_intervention.sql
+++ b/models/marts/commerce/fct_commerce__machine_intervention.sql
@@ -1,7 +1,6 @@
 {{
     config(
-        materialized='table',
-        description='Interventions techniques clôturées sur les 6 derniers mois, enrichies des informations client et machine. Granularité : 1 ligne par intervention.'
+        materialized='table'
     )
 }}
 


### PR DESCRIPTION
## Summary
**Dernière PR Phase 2** du refacto marts by BU 🎉 — la 7ème et dernière BU à migrer.

Commerce avait déjà son folder mais le mart portait l'ancien nom **et l'orchestration n'existait pas** (orphelin depuis sa migration en \`marts/commerce/\`).

## Changes dbt
- Rename : \`fct_commerce__machines_avec_interventions\` → \`fct_commerce__machine_intervention\` (singular, drop \`_avec_\` connector per CONVENTIONS § Nommage des marts)
- SQL : \`description=\` retirée du \`{{ config() }}\` (persist_docs gère via YAML — convention "Config block hygiène")
- YAML : description en **trame 4 blocs** [QUOI MÉTIER] / [COMMENT CONSTRUITE] / [GRAIN] / [NOTES] selon CONVENTIONS § Marts — pattern complet. Premier mart à appliquer pleinement la convention dès la création.
- YAML tests enrichis :
  - Existants conservés : \`unique\` + \`not_null\` sur \`intervention\` (PK), \`accepted_values\` sur \`etat_intervention\`, \`not_null\` sur PKs
  - Nouveaux : \`expect_column_values_to_be_between\` sur \`date_intervention\` (warn, fenêtre 200 jours) + \`expect_table_row_count_to_be_between\` (warn, 100-100K lignes)
- \`inventory.md\` : commerce row marked ✅ migrated

**Note** : pas de FK \`relationships\` test possible car sources nesp_tech + nesp_co sont des fichiers Excel sans modèle relationnel propre — pas de dims dans ce périmètre.

## Companion changes (séparés, déjà pushés direct master)
- \`/mnt/data/workflows\` commit \`f5ddefe\` : \`transform-commerce-daily.yaml\` créé (sources nesp_co + nesp_tech, tag:commerce)
- \`/mnt/data/infra\` commit \`5231ecb\` : 1 workflow + 1 scheduler Terraform
  - Schedule \`30 8,10 * * 1-5\` (weekdays 08:30 + 10:30 Paris)
  - 08:30 : catches nesp_co fresh data (Excel daily 08:00 + 30 min margin)
  - 10:30 : catches nesp_tech fresh data on Mondays (Excel Mon 07:30 + 3h margin)
  - Pattern cohérent avec \`transform-supply-chain-daily\` (\`0 3,7 * * *\`)

## Bonus — gap d'orchestration corrigé
Avant cette PR, le mart commerce était **orphelin** : depuis son passage en \`marts/commerce/\` (tag \`commerce\` via folder), \`pipeline-sftp-nesp-client\` (qui sélectionne \`tag:nesp_co\`) ne le rebuildait plus. La PR crée l'orchestration manquante.

## Merge-day sequence
1. Merge cette PR
2. \`terraform plan\` côté infra → **+2 ressources** (workflow + scheduler)
3. \`terraform apply\`
4. Trigger \`transform-commerce-daily\` manuellement (console GCP) pour matérialiser tout de suite
5. Parity check via BQ MCP (row count + cardinalités + sums) entre ancienne et nouvelle table — old vs new
6. DA repoint le \`.pbix\` qui consomme le mart commerce (si applicable)
7. DROP de l'ancienne table BQ : \`prod_marts.fct_commerce__machines_avec_interventions\` (+ dev_marts)

## Test plan
- [x] \`dbt parse\` succeeds (no warnings, no errors)
- [ ] CI \`dbt build --exclude resource_type:snapshot\` green
- [ ] Post-merge: parity check sur la table
- [ ] DA: \`.pbix\` repointé si concerné

## État global du refacto
**7/7 BUs migrées** après merge de cette PR ✅ :
finance, services_generaux, supply_chain, neshu, lcdp, technique, **commerce**.

Reste **Phase 3 cleanup** uniquement (resserrement des \`tag:<source>\` selectors dans les pipelines EL — cosmétique/défensif).

🤖 Generated with [Claude Code](https://claude.com/claude-code)