### PR TITLE
feat(neshu): machine_appro_intervention — replaces PR #77 with post-refacto structure

### DIFF
--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -961,6 +961,82 @@ models:
           - not_null
 
 
+  - name: int_oracle_neshu__appro_machine_context
+    description: |
+      [QUOI MÉTIER]
+      Contexte appro par machine : pour chaque device ayant eu au moins un
+      passage appro, expose son dernier passage FAIT, son prochain PRÉVU, et
+      des compteurs (total, à venir, 30j, 90j).
+
+      [COMMENT CONSTRUITE]
+      Agrégation de `int_oracle_neshu__appro_tasks_enriched` (grain task)
+      vers le grain device. Utilise `row_number() over (partition by device_id
+      order by task_start_date)` pour identifier le dernier FAIT et le
+      prochain PRÉVU. Référentiel devices = uniquement les machines avec ≥ 1
+      passage (pas de jointure sur `dim_neshu__device`).
+
+      [GRAIN]
+      1 ligne par device_id (PK).
+
+      [NOTES]
+      Pas de filtre temporel ni de filtre `is_active` ici — l'intermediate
+      reste agnostique, les marts en aval filtrent. `company_id` est extrait
+      via `any_value()` car normalement stable par device ; à surveiller via
+      data quality. Pattern factorisé pour éviter de dupliquer la logique
+      "dernier appro / prochain appro / compteurs" dans plusieurs marts
+      consommateurs.
+    columns:
+      - name: device_id
+        description: "ID du device (PK)"
+        tests:
+          - unique
+          - not_null
+      - name: company_id
+        description: "ID company stable par device (any_value sur les tasks)"
+        tests:
+          - not_null
+      - name: last_appro_task_id
+        description: "ID du dernier passage FAIT (NULL si jamais d'appro FAIT)"
+      - name: last_appro_date
+        description: "Date du dernier passage FAIT"
+      - name: last_appro_roadman_id
+        description: "ID du roadman du dernier passage FAIT"
+      - name: last_appro_roadman_code
+        description: "Code du roadman du dernier passage FAIT"
+      - name: last_appro_gea_code
+        description: "Code GEA du dernier passage FAIT"
+      - name: days_since_last_appro
+        description: "Nombre de jours depuis le dernier passage FAIT (NULL si aucun)"
+      - name: next_appro_task_id
+        description: "ID du prochain passage PRÉVU à venir (NULL si rien de planifié)"
+      - name: next_appro_date
+        description: "Date du prochain passage PRÉVU"
+      - name: next_appro_roadman_id
+        description: "ID du roadman planifié sur le prochain passage"
+      - name: next_appro_roadman_code
+        description: "Code du roadman planifié"
+      - name: next_appro_gea_code
+        description: "Code GEA planifié"
+      - name: days_until_next_appro
+        description: "Nombre de jours jusqu'au prochain passage PRÉVU (NULL si aucun)"
+      - name: nb_appros_realises_total
+        description: "Compteur total des passages FAIT (toute période)"
+        tests:
+          - not_null
+      - name: nb_appros_planifies_a_venir
+        description: "Compteur des passages PRÉVU encore à venir"
+        tests:
+          - not_null
+      - name: nb_appros_realises_30d
+        description: "Compteur des passages FAIT sur les 30 derniers jours"
+        tests:
+          - not_null
+      - name: nb_appros_realises_90d
+        description: "Compteur des passages FAIT sur les 90 derniers jours"
+        tests:
+          - not_null
+
+
   - name: int_oracle_neshu__inter_techinique_tasks
     description: >
       Table intermédiaire des inter technique.

--- a/models/intermediate/oracle_neshu/int_oracle_neshu__appro_machine_context.sql
+++ b/models/intermediate/oracle_neshu/int_oracle_neshu__appro_machine_context.sql
@@ -1,0 +1,203 @@
+{{ config(materialized='table') }}
+
+-- ============================================================
+-- int_oracle_neshu__appro_machine_context
+--
+-- Grain : 1 ligne par device_id.
+--
+-- Objectif : fournir le "contexte appro" de chaque machine ayant eu
+-- au moins un passage appro :
+--   - dernier passage FAIT (date, roadman, GEA)
+--   - prochain passage PRÉVU (date, roadman, GEA)
+--   - compteurs (total, à venir, 30j, 90j)
+--
+-- Source unique : int_oracle_neshu__appro_tasks_enriched (grain task).
+-- Pas de filtre temporel ni de statut device — l'intermediate reste
+-- agnostique, les marts en aval filtrent (is_active, période, etc.).
+-- ============================================================
+
+with appro_tasks as (
+
+    select
+        task_id,
+        device_id,
+        company_id,
+        task_start_date,
+        task_end_date,
+        task_status_code,
+        resources_roadman_id,
+        roadman_code,
+        gea_code
+    from {{ ref('int_oracle_neshu__appro_tasks_enriched') }}
+    where device_id is not null
+
+),
+
+-- ============================================================
+-- CTE 2 : référentiel devices distincts + company_id stable
+-- (any_value : si un device a eu plusieurs companies au fil du temps,
+-- on prend l'une d'elles — anomalie rare, à surveiller côté data
+-- quality)
+-- ============================================================
+devices as (
+
+    select
+        device_id,
+        any_value(company_id) as company_id
+    from appro_tasks
+    group by device_id
+
+),
+
+-- ============================================================
+-- CTE 3 : dernier passage FAIT par device (row_number)
+-- ============================================================
+last_done_ranked as (
+
+    select
+        device_id,
+        task_id,
+        task_start_date,
+        resources_roadman_id,
+        roadman_code,
+        gea_code,
+        row_number() over (
+            partition by device_id
+            order by task_start_date desc
+        ) as rn
+    from appro_tasks
+    where task_status_code = 'FAIT'
+
+),
+
+last_done as (
+
+    select
+        device_id,
+        task_id as last_appro_task_id,
+        task_start_date as last_appro_date,
+        resources_roadman_id as last_appro_roadman_id,
+        roadman_code as last_appro_roadman_code,
+        gea_code as last_appro_gea_code,
+        date_diff(
+            current_date(),
+            date(task_start_date),
+            day
+        ) as days_since_last_appro
+    from last_done_ranked
+    where rn = 1
+
+),
+
+-- ============================================================
+-- CTE 4 : prochain passage PRÉVU par device (row_number)
+-- Filtre : passage encore à venir (task_start_date >= maintenant)
+-- ============================================================
+next_planned_ranked as (
+
+    select
+        device_id,
+        task_id,
+        task_start_date,
+        resources_roadman_id,
+        roadman_code,
+        gea_code,
+        row_number() over (
+            partition by device_id
+            order by task_start_date asc
+        ) as rn
+    from appro_tasks
+    where
+        task_status_code = 'PREVU'
+        and task_start_date >= current_timestamp()
+
+),
+
+next_planned as (
+
+    select
+        device_id,
+        task_id as next_appro_task_id,
+        task_start_date as next_appro_date,
+        resources_roadman_id as next_appro_roadman_id,
+        roadman_code as next_appro_roadman_code,
+        gea_code as next_appro_gea_code,
+        date_diff(
+            date(task_start_date),
+            current_date(),
+            day
+        ) as days_until_next_appro
+    from next_planned_ranked
+    where rn = 1
+
+),
+
+-- ============================================================
+-- CTE 5 : compteurs par device
+--   - total réalisés (toute période)
+--   - à venir (prévus dans le futur)
+--   - réalisés sur 30/90 derniers jours
+-- ============================================================
+counters as (
+
+    select
+        device_id,
+        countif(task_status_code = 'FAIT') as nb_appros_realises_total,
+        countif(
+            task_status_code = 'PREVU'
+            and task_start_date >= current_timestamp()
+        ) as nb_appros_planifies_a_venir,
+        countif(
+            task_status_code = 'FAIT'
+            and task_start_date >= timestamp_sub(
+                current_timestamp(), interval 30 day
+            )
+        ) as nb_appros_realises_30d,
+        countif(
+            task_status_code = 'FAIT'
+            and task_start_date >= timestamp_sub(
+                current_timestamp(), interval 90 day
+            )
+        ) as nb_appros_realises_90d
+    from appro_tasks
+    group by device_id
+
+)
+
+select
+    -- IDs propres
+    d.device_id,
+    d.company_id,
+
+    -- Dernier passage FAIT
+    ld.last_appro_task_id,
+    ld.last_appro_date,
+    ld.last_appro_roadman_id,
+    ld.last_appro_roadman_code,
+    ld.last_appro_gea_code,
+    ld.days_since_last_appro,
+
+    -- Prochain passage PRÉVU
+    np.next_appro_task_id,
+    np.next_appro_date,
+    np.next_appro_roadman_id,
+    np.next_appro_roadman_code,
+    np.next_appro_gea_code,
+    np.days_until_next_appro,
+
+    -- Compteurs (NULL devient 0 pour les machines sans passage)
+    coalesce(c.nb_appros_realises_total, 0) as nb_appros_realises_total,
+    coalesce(c.nb_appros_planifies_a_venir, 0) as nb_appros_planifies_a_venir,
+    coalesce(c.nb_appros_realises_30d, 0) as nb_appros_realises_30d,
+    coalesce(c.nb_appros_realises_90d, 0) as nb_appros_realises_90d
+
+from devices as d
+
+left join last_done as ld
+    on d.device_id = ld.device_id
+
+left join next_planned as np
+    on d.device_id = np.device_id
+
+left join counters as c
+    on d.device_id = c.device_id

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1101,3 +1101,154 @@ models:
         description: Date de creation de reference, selon les regles NESHU
 
 
+
+  - name: fct_neshu__machine_appro_intervention
+    description: |
+      [QUOI MÉTIER]
+      Vue cross-source Neshu × Yuman par machine en appro : pour chaque
+      device Neshu ayant au moins un passage appro, expose son contexte appro
+      (dernier FAIT, prochain PRÉVU, compteurs) et ses interventions curatives
+      Yuman dans 3 buckets (récente 15j, en cours, prochaine planifiée).
+
+      [COMMENT CONSTRUITE]
+      Joint `int_oracle_neshu__appro_machine_context` (intermediate
+      factorisé, grain device) avec `dim_neshu__device` et
+      `dim_neshu__company` (attributs display). Côté Yuman, filtre
+      `int_yuman__demands_workorders_enriched` sur partenaire NESHU et
+      catégorie CURATIVE*, puis dispatch en 3 buckets selon le statut
+      (workorder_status + demand_status). Cross-source join sur
+      `UPPER(TRIM(device_code))` = `serial_clean` (normalisation Yuman :
+      strip 'NESH_' prefix).
+
+      [GRAIN]
+      1 ligne par device_id Neshu (ayant ≥ 1 passage appro).
+
+      [NOTES]
+      ⚠️ Jointure cross-source actuellement fragile (string match
+      device_code ↔ serial). Une table de mapping device Yuman ↔ device
+      Oracle Neshu est prévue en suivant PR pour remplacer ce match string.
+      Replace l'ancienne PR #77 (Rim) qui plaçait ce mart à tort dans
+      `marts/technique/` avec un nom au pluriel et une logique appro
+      enfouie en 7 CTEs (factorisée via l'intermediate).
+
+      OBT controlled : seuls les IDs (device_id, company_id, material_id par
+      bucket) + 1-3 attributs d'affichage par dim sont exposés. Les autres
+      attributs dim (brand, technician_equipe, client_category) sont
+      accessibles via jointure depuis le BI (dim_technique__material,
+      dim_technique__technician).
+    columns:
+      - name: device_id
+        description: Identifiant unique de la machine Neshu (PK + FK vers dim_neshu__device).
+        tests:
+          - unique
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__device')
+                field: device_id
+      - name: company_id
+        description: FK vers dim_neshu__company (client de la machine).
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
+      - name: device_code
+        description: Code interne machine — utilisé pour la jointure cross-source vers Yuman.
+      - name: device_name
+        description: Nom de la machine (display).
+      - name: company_name
+        description: Nom du client (display).
+
+      # === Contexte appro ===
+      - name: last_appro_date
+        description: Date du dernier passage appro FAIT (NULL si aucun).
+      - name: last_appro_roadman_code
+        description: Code roadman du dernier passage FAIT.
+      - name: last_appro_gea_code
+        description: Code GEA du dernier passage FAIT.
+      - name: days_since_last_appro
+        description: Nombre de jours depuis le dernier passage FAIT.
+      - name: next_appro_date
+        description: Date du prochain passage appro PRÉVU (NULL si rien planifié).
+      - name: next_appro_roadman_code
+        description: Code roadman du prochain passage PRÉVU.
+      - name: next_appro_gea_code
+        description: Code GEA du prochain passage PRÉVU.
+      - name: days_until_next_appro
+        description: Nombre de jours jusqu'au prochain passage PRÉVU.
+      - name: nb_appros_realises_total
+        description: Compteur total des passages FAIT (toute période).
+        tests:
+          - not_null
+      - name: nb_appros_planifies_a_venir
+        description: Compteur des passages PRÉVU encore à venir.
+        tests:
+          - not_null
+      - name: nb_appros_realises_30d
+        description: Compteur des passages FAIT sur les 30 derniers jours.
+        tests:
+          - not_null
+      - name: nb_appros_realises_90d
+        description: Compteur des passages FAIT sur les 90 derniers jours.
+        tests:
+          - not_null
+
+      # === Bucket : intervention curative récente (15j) ===
+      - name: past_material_id
+        description: FK Yuman vers dim_technique__material — material concerné par la dernière intervention 15j (NULL si pas d'intervention 15j).
+      - name: past_intervention_id
+        description: ID Yuman du workorder de la dernière intervention 15j.
+      - name: past_intervention_date
+        description: Date de la dernière intervention curative dans les 15 derniers jours.
+      - name: past_demand_description
+        description: Description de la demande Yuman (texte libre).
+      - name: past_demand_created_at
+        description: Date de création de la demande Yuman.
+      - name: past_demand_category_name
+        description: Catégorie de demande Yuman (filtrée sur CURATIVE*).
+      - name: past_intervention_title
+        description: Titre du workorder.
+      - name: past_intervention_report
+        description: Rapport d'intervention saisi par le technicien.
+      - name: nb_interventions_15j
+        description: Nombre total d'interventions curatives sur les 15 derniers jours pour cette machine.
+        tests:
+          - not_null
+
+      # === Bucket : intervention en cours ===
+      - name: current_material_id
+        description: FK Yuman vers dim_technique__material — material de l'intervention en cours.
+      - name: current_intervention_id
+        description: ID Yuman du workorder en cours.
+      - name: current_demand_description
+        description: Description de la demande Yuman en cours.
+      - name: current_demand_created_at
+        description: Date de création de la demande Yuman en cours.
+      - name: current_demand_category_name
+        description: Catégorie de demande Yuman en cours.
+      - name: current_intervention_title
+        description: Titre du workorder en cours.
+      - name: current_intervention_report
+        description: Rapport (peut être vide si pas encore renseigné).
+      - name: current_date_done
+        description: Date done (normalement NULL si en cours, valeur si transition).
+
+      # === Bucket : prochaine intervention planifiée ===
+      - name: future_material_id
+        description: FK Yuman vers dim_technique__material — material de l'intervention planifiée.
+      - name: future_intervention_id
+        description: ID Yuman du workorder planifié.
+      - name: future_intervention_planned_date
+        description: Date planifiée du workorder.
+      - name: future_demand_description
+        description: Description de la demande Yuman planifiée.
+      - name: future_demand_created_at
+        description: Date de création de la demande Yuman planifiée.
+      - name: future_demand_category_name
+        description: Catégorie de demande Yuman planifiée.
+      - name: future_intervention_title
+        description: Titre du workorder planifié.
+      - name: future_intervention_report
+        description: Rapport (normalement vide pour un planifié).

--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -1,0 +1,325 @@
+{{ config(materialized='table') }}
+
+-- ============================================================
+-- fct_neshu__machine_appro_intervention
+--
+-- Grain : 1 ligne par device Neshu en appro (ayant ≥ 1 passage).
+--
+-- Objectif métier : cross-source Neshu × Yuman, pour chaque machine
+-- Neshu en appro, expose son contexte appro (dernier FAIT, prochain
+-- PRÉVU) + ses interventions curatives Yuman (passé 15j, en cours,
+-- futur).
+--
+-- Sources :
+--   - int_oracle_neshu__appro_machine_context (grain device, factorisé)
+--   - dim_neshu__device, dim_neshu__company (attributs display)
+--   - int_yuman__demands_workorders_enriched (interventions Yuman)
+--
+-- ⚠️ Jointure cross-source fragile : device_code Neshu = serial Yuman
+-- (UPPER + TRIM + strip 'NESH_'). À remplacer par une table de mapping
+-- device Yuman ↔ device Oracle Neshu dans un suivant PR.
+-- ============================================================
+
+-- ============================================================
+-- CTE 1 : Contexte appro machine + attributs display Neshu
+-- ============================================================
+with appro_context as (
+
+    select
+        ctx.device_id,
+        ctx.company_id,
+
+        -- Display attributes via conformed dims
+        d.device_code,
+        d.device_name,
+        c.company_name,
+
+        -- Appro context (depuis l'intermediate)
+        ctx.last_appro_task_id,
+        ctx.last_appro_date,
+        ctx.last_appro_roadman_id,
+        ctx.last_appro_roadman_code,
+        ctx.last_appro_gea_code,
+        ctx.days_since_last_appro,
+
+        ctx.next_appro_task_id,
+        ctx.next_appro_date,
+        ctx.next_appro_roadman_id,
+        ctx.next_appro_roadman_code,
+        ctx.next_appro_gea_code,
+        ctx.days_until_next_appro,
+
+        ctx.nb_appros_realises_total,
+        ctx.nb_appros_planifies_a_venir,
+        ctx.nb_appros_realises_30d,
+        ctx.nb_appros_realises_90d
+    from {{ ref('int_oracle_neshu__appro_machine_context') }} as ctx
+    left join {{ ref('dim_neshu__device') }} as d
+        on ctx.device_id = d.device_id
+    left join {{ ref('dim_neshu__company') }} as c
+        on ctx.company_id = c.company_id
+
+),
+
+-- ============================================================
+-- CTE 2 : Interventions Yuman NESHU curatives, normalisées
+-- Grain : 1 ligne par (material, workorder).
+-- ⚠️ serial_clean = jointure fragile vers Neshu device_code.
+-- ============================================================
+yuman_workorders as (
+
+    select
+        material_id,
+        material_serial_number,
+        upper(trim(replace(material_serial_number, 'NESH_', '')))
+            as serial_clean,
+        workorder_id as intervention_id,
+
+        -- Champs métier essentiels
+        any_value(demand_description) as demand_description,
+        any_value(demand_created_at) as demand_created_at,
+        any_value(demand_category_name) as demand_category_name,
+        any_value(workorder_title) as intervention_title,
+        any_value(workorder_report) as intervention_report,
+
+        -- Statuts (pour les flags)
+        any_value(demand_status) as demand_status,
+        any_value(workorder_status) as intervention_status,
+        max(date_done) as date_done,
+        min(date_planned) as date_planned,
+
+        -- Flags bucket
+        case
+            when
+                max(date_done) is not null
+                and date(max(date_done))
+                between date_sub(current_date(), interval 15 day)
+                and current_date()
+                then 1
+            else 0
+        end as is_past_intervention_15d,
+        case
+            when
+                any_value(workorder_status) = 'In progress'
+                and any_value(demand_status) = 'Accepted'
+                then 1
+            else 0
+        end as is_current_intervention,
+        case
+            when
+                any_value(workorder_status) = 'Scheduled'
+                and any_value(demand_status) = 'Accepted'
+                and min(date_planned) is not null
+                and min(date_planned) > current_timestamp()
+                then 1
+            else 0
+        end as is_future_intervention
+    from {{ ref('int_yuman__demands_workorders_enriched') }}
+    where
+        material_serial_number is not null
+        and upper(trim(partner_name)) = 'NESHU'
+        and upper(trim(demand_category_name)) like 'CURATIVE%'
+    group by
+        material_id, material_serial_number, serial_clean, workorder_id
+
+),
+
+-- ============================================================
+-- CTE 3 : Compteur 15j par machine
+-- ============================================================
+past_count_15d as (
+
+    select
+        serial_clean,
+        count(distinct intervention_id) as nb_interventions_15j
+    from yuman_workorders
+    where is_past_intervention_15d = 1
+    group by serial_clean
+
+),
+
+-- ============================================================
+-- CTE 4 : Dernière intervention 15j par machine (row_number)
+-- ============================================================
+past_15d_ranked as (
+
+    select
+        serial_clean,
+        material_id,
+        intervention_id,
+        date_done,
+        demand_description,
+        demand_created_at,
+        demand_category_name,
+        intervention_title,
+        intervention_report,
+        row_number() over (
+            partition by serial_clean
+            order by date_done desc
+        ) as rn
+    from yuman_workorders
+    where is_past_intervention_15d = 1
+
+),
+
+past_15d as (
+    select
+        serial_clean,
+        material_id as past_material_id,
+        intervention_id as past_intervention_id,
+        date_done as past_intervention_date,
+        demand_description as past_demand_description,
+        demand_created_at as past_demand_created_at,
+        demand_category_name as past_demand_category_name,
+        intervention_title as past_intervention_title,
+        intervention_report as past_intervention_report
+    from past_15d_ranked
+    where rn = 1
+),
+
+-- ============================================================
+-- CTE 5 : Intervention en cours par machine
+-- ============================================================
+current_ranked as (
+
+    select
+        serial_clean,
+        material_id,
+        intervention_id,
+        demand_description,
+        demand_created_at,
+        demand_category_name,
+        intervention_title,
+        intervention_report,
+        date_done,
+        row_number() over (
+            partition by serial_clean
+            order by demand_created_at desc
+        ) as rn
+    from yuman_workorders
+    where is_current_intervention = 1
+
+),
+
+current_inter as (
+    select
+        serial_clean,
+        material_id as current_material_id,
+        intervention_id as current_intervention_id,
+        demand_description as current_demand_description,
+        demand_created_at as current_demand_created_at,
+        demand_category_name as current_demand_category_name,
+        intervention_title as current_intervention_title,
+        intervention_report as current_intervention_report,
+        date_done as current_date_done
+    from current_ranked
+    where rn = 1
+),
+
+-- ============================================================
+-- CTE 6 : Prochaine intervention planifiée par machine
+-- ============================================================
+future_ranked as (
+
+    select
+        serial_clean,
+        material_id,
+        intervention_id,
+        date_planned,
+        demand_description,
+        demand_created_at,
+        demand_category_name,
+        intervention_title,
+        intervention_report,
+        row_number() over (
+            partition by serial_clean
+            order by date_planned asc
+        ) as rn
+    from yuman_workorders
+    where is_future_intervention = 1
+
+),
+
+future_inter as (
+    select
+        serial_clean,
+        material_id as future_material_id,
+        intervention_id as future_intervention_id,
+        date_planned as future_intervention_planned_date,
+        demand_description as future_demand_description,
+        demand_created_at as future_demand_created_at,
+        demand_category_name as future_demand_category_name,
+        intervention_title as future_intervention_title,
+        intervention_report as future_intervention_report
+    from future_ranked
+    where rn = 1
+)
+
+-- ============================================================
+-- Assemblage final
+-- ============================================================
+select
+    -- IDs (FKs vers dim_neshu__device, dim_neshu__company)
+    ac.device_id,
+    ac.company_id,
+
+    -- Display attributes (1-3 par dim parente)
+    ac.device_code,
+    ac.device_name,
+    ac.company_name,
+
+    -- Contexte appro
+    ac.last_appro_date,
+    ac.last_appro_roadman_code,
+    ac.last_appro_gea_code,
+    ac.days_since_last_appro,
+    ac.next_appro_date,
+    ac.next_appro_roadman_code,
+    ac.next_appro_gea_code,
+    ac.days_until_next_appro,
+    ac.nb_appros_realises_total,
+    ac.nb_appros_planifies_a_venir,
+    ac.nb_appros_realises_30d,
+    ac.nb_appros_realises_90d,
+
+    -- Bucket : intervention curative récente (15j)
+    p15.past_material_id,
+    p15.past_intervention_id,
+    p15.past_intervention_date,
+    p15.past_demand_description,
+    p15.past_demand_created_at,
+    p15.past_demand_category_name,
+    p15.past_intervention_title,
+    p15.past_intervention_report,
+    coalesce(pc15.nb_interventions_15j, 0) as nb_interventions_15j,
+
+    -- Bucket : intervention en cours
+    ci.current_material_id,
+    ci.current_intervention_id,
+    ci.current_demand_description,
+    ci.current_demand_created_at,
+    ci.current_demand_category_name,
+    ci.current_intervention_title,
+    ci.current_intervention_report,
+    ci.current_date_done,
+
+    -- Bucket : prochaine intervention planifiée
+    fi.future_material_id,
+    fi.future_intervention_id,
+    fi.future_intervention_planned_date,
+    fi.future_demand_description,
+    fi.future_demand_created_at,
+    fi.future_demand_category_name,
+    fi.future_intervention_title,
+    fi.future_intervention_report
+from appro_context as ac
+-- ⚠️ Jointure cross-source fragile sur string normalisée
+-- À remplacer par une table de mapping device dans un suivant PR
+left join past_15d as p15
+    on upper(trim(ac.device_code)) = p15.serial_clean
+left join past_count_15d as pc15
+    on upper(trim(ac.device_code)) = pc15.serial_clean
+left join current_inter as ci
+    on upper(trim(ac.device_code)) = ci.serial_clean
+left join future_inter as fi
+    on upper(trim(ac.device_code)) = fi.serial_clean


### PR DESCRIPTION
## Summary
Remplace #77 (par @RimEVS) en adaptant le mart au post-refacto marts by BU et en factorisant la logique appro dans un intermediate dédié.

**Crédit Rim** : la logique métier de ce mart (contexte appro Neshu + 3 buckets d'interventions Yuman) vient de son travail dans #77. Cette PR reprend cette logique et l'adapte à la nouvelle structure du projet (refacto by BU mergé entre-temps), avec aussi un nettoyage architectural (factorisation intermediate + réduction OBT + naming convention).

## Commits

1. \`c51ac17\` — feat(intermediate): add \`int_oracle_neshu__appro_machine_context\`
   - Factorise la logique "contexte appro par machine" (last/next/compteurs)
   - Grain : 1 ligne par \`device_id\`
   - Source : \`int_oracle_neshu__appro_tasks_enriched\` (PR #88 récente)
   - Réutilisable pour tout futur mart à grain machine + contexte appro

2. \`edc822e\` — feat(neshu): add \`fct_neshu__machine_appro_intervention\`
   - Mart cross-source Neshu × Yuman, grain device
   - Consomme l'intermediate ci-dessus + \`dim_neshu__device\` + \`dim_neshu__company\` + \`int_yuman__demands_workorders_enriched\`
   - 3 buckets d'interventions curatives Yuman : past 15j / current / future

## Différences vs PR #77

| Aspect | PR #77 | Cette PR |
|---|---|---|
| Folder | \`marts/technique/\` ❌ | \`marts/neshu/\` ✅ |
| Nom | \`fct_technique__machines_appro_interventions\` (pluriels) | \`fct_neshu__machine_appro_intervention\` (singulier) |
| Lignes SQL | 654 | 320 |
| Logique appro | 7 CTEs dans le mart | Factorisée en intermediate |
| Refs | \`fct_oracle_neshu__appro\` (cassé post-refacto) | \`int_oracle_neshu__appro_machine_context\` (frais) |
| OBT | ~49 cols (material_brand, technician_equipe, client_category par bucket) | ~40 cols (IDs + display 1-3 par dim) |
| Description config | \`description=\` dans \`{{ config() }}\` | Aucun (YAML uniquement) |
| Trame description | Prose libre | 4 blocs canoniques |

## Conformance CONVENTIONS § Marts — pattern complet

- [x] Description YAML en 4 blocs \`[QUOI MÉTIER]/[COMMENT CONSTRUITE]/[GRAIN]/[NOTES]\`
- [x] Grain explicite (1 ligne par device_id Neshu)
- [x] \`{{ config() }}\` ne contient que \`materialized\`
- [x] FKs exposées + \`relationships\` tests sur device_id, company_id
- [x] PK : unique + not_null sur device_id
- [x] Pas de mention de rapport BI dans la description
- [x] Star schema respecté (pas de jointure fait-à-fait, pas de snowflake, OBT controlled)

## Smell connu (à corriger plus tard)

⚠️ Jointure cross-source toujours fragile : \`UPPER(TRIM(ac.device_code)) = p15.serial_clean\` (normalisation Yuman strip \`NESH_\` prefix). Documentée en \`[NOTES]\` + commentaire dans le SQL. À remplacer par une **table de mapping device Yuman ↔ device Oracle Neshu** dans un PR suivant.

## Post-merge

- Fermer #77 sans merge (replaced by this PR — la décision a été prise vu la divergence structurelle après le refacto marts by BU).
- Le commit \`c51ac17\` introduit un nouvel intermediate réutilisable, indépendamment du mart : si on veut différer le mart, on peut quand même merger l'intermediate seul.

## Test plan

- [x] \`dbt parse\` succeeds
- [x] \`dbt compile\` succeeds sur les 2 nouveaux modèles
- [x] SQLFluff lint OK
- [ ] CI \`dbt build --exclude resource_type:snapshot\` green
- [ ] Post-merge : valider via BQ la cohérence des données (devices, compteurs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)