### PR TITLE
docs(neshu): FK tests + multi-match diagnostic on fct_neshu__machine_appro_intervention

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1126,7 +1126,16 @@ models:
       [NOTES]
       ⚠️ Jointure cross-source actuellement fragile (string match
       device_code ↔ serial). Une table de mapping device Yuman ↔ device
-      Oracle Neshu est prévue en suivant PR pour remplacer ce match string.
+      Oracle Neshu pourrait remplacer ce match string si besoin futur.
+      Diagnostic effectué (2026-05-24) : 94 % des devices avec workorders
+      curative ont un match 1-1 propre (1175/1250). 6 % (75 devices) ont
+      2 materials Yuman par device — pour ces cas, les attributs détaillés
+      `past_/current_/future_*` ne reflètent qu'un seul material (choisi
+      par row_number partition sur serial_clean order by date_done desc).
+      Les compteurs (`nb_interventions_15j`) restent justes car comptent
+      tous les workorders distincts du serial. ROI bridge faible — pas
+      prioritaire tant que le DA ne signale pas de pain métier.
+
       Replace l'ancienne PR #77 (Rim) qui plaçait ce mart à tort dans
       `marts/technique/` avec un nom au pluriel et une logique appro
       enfouie en 7 CTEs (factorisée via l'intermediate).
@@ -1198,6 +1207,11 @@ models:
       # === Bucket : intervention curative récente (15j) ===
       - name: past_material_id
         description: FK Yuman vers dim_technique__material — material concerné par la dernière intervention 15j (NULL si pas d'intervention 15j).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__material')
+                field: material_id
       - name: past_intervention_id
         description: ID Yuman du workorder de la dernière intervention 15j.
       - name: past_intervention_date
@@ -1220,6 +1234,11 @@ models:
       # === Bucket : intervention en cours ===
       - name: current_material_id
         description: FK Yuman vers dim_technique__material — material de l'intervention en cours.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__material')
+                field: material_id
       - name: current_intervention_id
         description: ID Yuman du workorder en cours.
       - name: current_demand_description
@@ -1238,6 +1257,11 @@ models:
       # === Bucket : prochaine intervention planifiée ===
       - name: future_material_id
         description: FK Yuman vers dim_technique__material — material de l'intervention planifiée.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__material')
+                field: material_id
       - name: future_intervention_id
         description: ID Yuman du workorder planifié.
       - name: future_intervention_planned_date


### PR DESCRIPTION
## Summary
Follow-up de #93 — ajoute les tests FK qui manquaient sur les material_id Yuman, et documente le diagnostic du mapping device Neshu × material Yuman.

## Contexte
Audit du mapping cross-source effectué via BQ MCP (2026-05-24) :
- **94 %** des devices Neshu avec workorders curative ont un match 1-1 propre (1 175 / 1 250)
- **6 %** (75 devices) ont 2 materials Yuman par device
- Max constaté : 2 materials Yuman par device (pas 6 comme craint initialement)
- Compteurs `nb_interventions_15j` restent justes (COUNT DISTINCT sur tous workorders du serial)
- Attributs détaillés `past_/current_/future_*` ne reflètent qu'un material si multi-match (choix par `row_number() partition by serial_clean order by date_done desc`)

**Décision** : pas de bridge table maintenant (ROI faible). Option B = documenter la limite + ajouter les FK tests qui manquaient.

## Changes
- 3 nouveaux `relationships` tests (severity: **error**) :
  - \`past_material_id\` → \`dim_technique__material.material_id\`
  - \`current_material_id\` → \`dim_technique__material.material_id\`
  - \`future_material_id\` → \`dim_technique__material.material_id\`

  Severity = **error** confirmée via vérification BQ : 0 orphan en prod sur les 5 FK du mart (device_id, company_id, past/current/future_material_id). Tout drift futur sera capté.

- \`[NOTES]\` enrichi avec les chiffres du diagnostic + raisonnement pour ne pas construire de bridge tant que le DA ne signale pas de pain métier.

## Vérifications faites
- \`dbt parse\` ✅
- BQ FK check : 0 orphan sur les 5 FK
- Volumétrie mart : 1 823 lignes, 57 past / 4 current / 1 future en prod

## Test plan
- [x] \`dbt parse\` succeeds
- [x] BQ FK orphans = 0 (5/5)
- [ ] CI green
- [ ] Post-merge : les 3 nouveaux tests passent en CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)