### PR TITLE
feat(freshness): rollout — 5 tiers, full source coverage

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -462,15 +462,62 @@ models:
 
 ## Source freshness
 
-Configuree dans les fichiers `_<source>__sources.yml` avec `loaded_at_field: _sdc_extracted_at`.
+> Voir `docs/freshness.md` pour l'audit complet et la justification par source.
+
+### Tiers
 
 | Tier | warn_after | error_after | Sources |
 |------|-----------|-------------|---------|
 | Critique | 26h | 36h | oracle_neshu, oracle_lcdp |
-| Standard | 26h | 48h | yuman, mssql_sage, nesp_tech |
-| Relaxe | 7j | 14j | gac, yuman_gcs, oracle_neshu_gcs |
+| Standard | 26h | 48h | yuman, mssql_sage, nesp_co (activite/opportunite) |
+| Hebdomadaire | 8j | 14j | nesp_tech |
+| Relaxe | 7j | 14j | gac, yuman_gcs, oracle_neshu_gcs, zoho_desk |
+| Manuel | 60j | 90j | nesp_co (nespresso_base_client) |
+
+### Deux mecanismes selon le type de timestamp source
+
+**Methode A — `dbt source freshness` natif** quand la source brute a un champ TIMESTAMP ou DATE :
+
+```yaml
+# _<source>__sources.yml
+sources:
+  - name: <source>
+    config:
+      loaded_at_field: _sdc_extracted_at
+      freshness:
+        warn_after: {count: 26, period: hour}
+        error_after: {count: 48, period: hour}
+    tables:
+      - name: <referentiel_stable>
+        config:
+          freshness: null   # desactive — table immuable
+```
 
 Commande : `dbt source freshness`
+
+**Methode B — test `dbt_expectations` sur staging** quand la source brute n'a qu'un champ STRING (external tables GCS, taps custom dlt). Le staging fait le cast en TIMESTAMP, on monitore a ce niveau :
+
+```yaml
+# _<source>__models.yml
+models:
+  - name: stg_<source>__<table>
+    tests:
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 8
+          config:
+            severity: warn
+```
+
+Commande : couvert par `dbt test` standard.
+
+### Regles
+
+- **`freshness: null` uniquement sur les referentiels vraiment immuables** (codes, libellés, types). Toute source qui porte des evenements doit avoir un seuil, quitte a le mettre tres large.
+- **Ne jamais repeter** le freshness par table quand il est identique au defaut source — c'est du bruit YAML.
+- **Toujours commenter le tier** en regard du bloc freshness (`# Freshness: tier Standard — 26h warn / 48h error`).
 
 ---
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -127,4 +127,10 @@ snapshots:
   dbt_warehouse:
     +target_schema: "{{ 'snapshots_dev' if target.name == 'dev' else 'snapshots' }}"
     +tags: ['snapshots']
+
+# Vars
+vars:
+  # Required by dbt_date (transitive dep of dbt_expectations) for recency checks.
+  # Cf. docs/freshness.md méthode B.
+  'dbt_date:time_zone': 'Europe/Paris'
     

--- a/docs/freshness.md
+++ b/docs/freshness.md
@@ -128,8 +128,11 @@ le staging.
 - Seuil : **2 jours / warn** (équivalent 26h/48h en granularité jour)
 
 ### `nesp_tech` — tier *Hebdomadaire*, méthode B
-Source brute : `extracted_at` STRING. Test sur les 2 staging
-(`stg_nesp_tech__interventions`, `stg_nesp_tech__articles`).
+Source brute : `extracted_at` est **STRING et NULL sur les fichiers récents**
+(le champ a été abandonné par l'export Arbiter). Bascule sur les colonnes
+business qui restent peuplées :
+- `stg_nesp_tech__interventions` : test sur **`date_heure_fin`** (TIMESTAMP)
+- `stg_nesp_tech__articles` : test sur **`date_intervention`** (DATE)
 - Seuil : **8 jours warn / 14 jours error**
 
 ### `oracle_neshu_gcs` — tier *Relaxe*, méthode B

--- a/models/staging/gac/_gac__sources.yml
+++ b/models/staging/gac/_gac__sources.yml
@@ -6,11 +6,12 @@ sources:
     description: "Données brutes extraites du fichier suivi des sinistres envoyé par GAC vers le FTP SG"
     config:
       tags: ['gac', 'source']
-      # Freshness: column containing extraction timestamp
+      # Freshness: tier Relaxe — 7j warn / 14j error
+      # Cf. docs/freshness.md
       loaded_at_field: _sdc_batched_at
-
-      # Default freshness thresholds for all tables
-      freshness: null
+      freshness:
+        warn_after: {count: 7, period: day}
+        error_after: {count: 14, period: day}
     tables:
       - name: gac_suivi_sinistres_sg
         description: "Table des sinistres des véhicules extraite depuis GAC vers SFTP EVS"

--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -8,19 +8,16 @@ sources:
     config:
       tags: ['mssql_sage', 'source']  # Déplacé dans config
 
-      # Freshness: column containing extraction timestamp
+      # Freshness: tier Standard — 26h warn / 48h error
+      # Cf. docs/freshness.md
       loaded_at_field: _sdc_extracted_at
-
-      # Default freshness thresholds for all tables
       freshness:
-        warn_after: {count: 26, period: hour}    # Warn if > 26h old
-        error_after: {count: 36, period: hour}  # Error before next business day
-        
+        warn_after: {count: 26, period: hour}
+        error_after: {count: 48, period: hour}
+
     tables:
       - name: dbo_f_ecriturea
         description: "Table des écritures analytiques (f_ecriturea) — détail des montants et quantités analytiques par écriture comptable"
-        config:  # ✅ Ajoutez cette section
-          loaded_at_field: _sdc_received_at
 
         columns:
           - name: ec_no
@@ -80,8 +77,6 @@ sources:
       # TABLE ECRITURE COMPTABLE
       - name: dbo_f_ecriturec
         description: "Table des écritures comptables (f_ecriturec) — enregistre les mouvements comptables avec leurs montants, comptes, dates et statuts"
-        config:
-          loaded_at_field: _sdc_received_at
 
         columns:
           - name: ec_no

--- a/models/staging/nesp_co/_nesp_co__models.yml
+++ b/models/staging/nesp_co/_nesp_co__models.yml
@@ -4,6 +4,15 @@ models:
   # ACTIVITE
   - name: stg_nesp_co__activite
     description: "Activite transformés et nettoyés depuis la source Nespresso Commerce Activite"
+    tests:
+      # Freshness fallback (tier Standard — source STRING timestamp, cf. docs/freshness.md)
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 2
+          config:
+            severity: warn
     columns:
       - name: employee_responsible
         description: "Identifiant de l'employé responsable"
@@ -66,6 +75,15 @@ models:
   # OPPORTUNITE
   - name: stg_nesp_co__opportunite
     description: "Opportunités transformés et nettoyés depuis la source Nespresso Commerce Opportunite"
+    tests:
+      # Freshness fallback (tier Standard — source STRING timestamp, cf. docs/freshness.md)
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 2
+          config:
+            severity: warn
     columns:
       - name: opportunity_id
         description: "Identifiant de l'opportunité commerciale"

--- a/models/staging/nesp_co/_nesp_co__sources.yml
+++ b/models/staging/nesp_co/_nesp_co__sources.yml
@@ -142,6 +142,13 @@ sources:
 
       - name: nespresso_base_client
         description: "Table des bases clients Nespresso EVS importé depuis le SFTP EVS du fichier Base - Clients"
+        # Freshness: tier Manuel — 60j warn / 90j error
+        # Livraison manuelle uniquement (pipeline-sftp-nesp-client). Cf. docs/freshness.md
+        config:
+          loaded_at_field: _sdc_extracted_at
+          freshness:
+            warn_after: {count: 60, period: day}
+            error_after: {count: 90, period: day}
         columns:
           - name: third
             description: "Identifiant unique du client."

--- a/models/staging/nesp_tech/_nesp_tech__models.yml
+++ b/models/staging/nesp_tech/_nesp_tech__models.yml
@@ -11,17 +11,19 @@ models:
     config:
       tags: ['nesp_tech', 'staging']
     tests:
-      # Freshness fallback (tier Hebdomadaire — source STRING timestamp, cf. docs/freshness.md)
+      # Freshness fallback (tier Hebdomadaire — extracted_at est NULL sur les fichiers
+      # récents côté source, on monitore date_heure_fin qui reflète l'activité réelle
+      # cf. docs/freshness.md)
       - dbt_expectations.expect_row_values_to_have_recent_data:
           arguments:
-            column_name: extracted_at
+            column_name: date_heure_fin
             datepart: day
             interval: 8
           config:
             severity: warn
       - dbt_expectations.expect_row_values_to_have_recent_data:
           arguments:
-            column_name: extracted_at
+            column_name: date_heure_fin
             datepart: day
             interval: 14
           config:
@@ -102,17 +104,18 @@ models:
     config:
       tags: ['nesp_tech', 'staging']
     tests:
-      # Freshness fallback (tier Hebdomadaire — source STRING timestamp, cf. docs/freshness.md)
+      # Freshness fallback (tier Hebdomadaire — extracted_at NULL sur fichiers récents,
+      # on monitore date_intervention — cf. docs/freshness.md)
       - dbt_expectations.expect_row_values_to_have_recent_data:
           arguments:
-            column_name: extracted_at
+            column_name: date_intervention
             datepart: day
             interval: 8
           config:
             severity: warn
       - dbt_expectations.expect_row_values_to_have_recent_data:
           arguments:
-            column_name: extracted_at
+            column_name: date_intervention
             datepart: day
             interval: 14
           config:

--- a/models/staging/nesp_tech/_nesp_tech__models.yml
+++ b/models/staging/nesp_tech/_nesp_tech__models.yml
@@ -11,6 +11,21 @@ models:
     config:
       tags: ['nesp_tech', 'staging']
     tests:
+      # Freshness fallback (tier Hebdomadaire — source STRING timestamp, cf. docs/freshness.md)
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 8
+          config:
+            severity: warn
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 14
+          config:
+            severity: error
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
@@ -87,6 +102,21 @@ models:
     config:
       tags: ['nesp_tech', 'staging']
     tests:
+      # Freshness fallback (tier Hebdomadaire — source STRING timestamp, cf. docs/freshness.md)
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 8
+          config:
+            severity: warn
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 14
+          config:
+            severity: error
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:

--- a/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
@@ -110,10 +110,6 @@ sources:
       # COMPANY
       - name: lcdp_company
         description: "Table des entreprises/clients"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcompany
             tests:
@@ -135,10 +131,6 @@ sources:
 
       - name: lcdp_company_has_location
         description: "Lien entreprise-location"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcompany
             tests:
@@ -156,10 +148,6 @@ sources:
       # CONTACT
       - name: lcdp_contact
         description: "Table des contacts"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcontact
             tests:
@@ -198,10 +186,6 @@ sources:
       # DEVICE
       - name: lcdp_device
         description: "Table des machines/équipements parc"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: iddevice
             tests:
@@ -218,10 +202,6 @@ sources:
       # LOCATION
       - name: lcdp_location
         description: "Table des localisations"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlocation
             tests:
@@ -234,10 +214,6 @@ sources:
       # PRODUCT
       - name: lcdp_product
         description: "Produits catalogue"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idproduct
             tests:
@@ -254,10 +230,6 @@ sources:
       # RESOURCES
       - name: lcdp_resources
         description: "Ressources (roadmen, véhicules)"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idresources
             tests:
@@ -280,10 +252,6 @@ sources:
       # LABEL JUNCTION TABLES (operational)
       - name: lcdp_label_has_company
         description: "Labels par entreprise"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -310,10 +278,6 @@ sources:
 
       - name: lcdp_label_has_device
         description: "Labels par device"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -326,10 +290,6 @@ sources:
 
       - name: lcdp_label_has_product
         description: "Labels par produit"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -342,10 +302,6 @@ sources:
 
       - name: lcdp_label_has_resources
         description: "Labels par ressource"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:

--- a/models/staging/oracle_neshu/_oracle_neshu__sources.yml
+++ b/models/staging/oracle_neshu/_oracle_neshu__sources.yml
@@ -110,10 +110,6 @@ sources:
       # COMPANY
       - name: evs_company
         description: "Table des entreprises/clients"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcompany
             tests:
@@ -135,10 +131,6 @@ sources:
 
       - name: evs_company_has_location
         description: "Lien entreprise-location"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcompany
             tests:
@@ -156,10 +148,6 @@ sources:
       # CONTACT
       - name: evs_contact
         description: "Table des contacts"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcontact
             tests:
@@ -174,10 +162,6 @@ sources:
       # CONTRACT
       - name: evs_contract
         description: "Table des contrats"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idcontract
             tests:
@@ -217,10 +201,6 @@ sources:
       # DEVICE
       - name: evs_device
         description: "Table des machines/équipements parc"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: iddevice
             tests:
@@ -237,10 +217,6 @@ sources:
       # LOCATION
       - name: evs_location
         description: "Table des localisations"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlocation
             tests:
@@ -253,10 +229,6 @@ sources:
       # PRODUCT
       - name: evs_product
         description: "Produits catalogue"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idproduct
             tests:
@@ -273,10 +245,6 @@ sources:
       # RESOURCES
       - name: evs_resources
         description: "Ressources (roadmen, véhicules)"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idresources
             tests:
@@ -299,10 +267,6 @@ sources:
       # LABEL JUNCTION TABLES (operational)
       - name: evs_label_has_company
         description: "Labels par entreprise"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -315,10 +279,6 @@ sources:
 
       - name: evs_label_has_contract
         description: "Labels par contrat"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -331,10 +291,6 @@ sources:
 
       - name: evs_label_has_device
         description: "Labels par device"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -347,10 +303,6 @@ sources:
 
       - name: evs_label_has_product
         description: "Labels par produit"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:
@@ -363,10 +315,6 @@ sources:
 
       - name: evs_label_has_resources
         description: "Labels par ressource"
-        config:
-          freshness:
-            warn_after: {count: 26, period: hour}
-            error_after: {count: 36, period: hour}
         columns:
           - name: idlabel
             tests:

--- a/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__models.yml
+++ b/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__models.yml
@@ -3,6 +3,22 @@ version: 2
 models:
   - name: stg_oracle_neshu_gcs__stock_theorique
     description: "Table staging des fichiers CSV quotidiens de stock théorique Oracle Neshu depuis GCS. Les colonnes sont typées et les dates converties en TIMESTAMP."
+    tests:
+      # Freshness fallback (tier Relaxe — source STRING timestamp, cf. docs/freshness.md)
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 7
+          config:
+            severity: warn
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: day
+            interval: 14
+          config:
+            severity: error
     columns:
       - name: id_entity
         description: "Identifiant de l'entité (ressource ou dépôt)"

--- a/models/staging/yuman/_yuman__sources.yml
+++ b/models/staging/yuman/_yuman__sources.yml
@@ -9,13 +9,12 @@ sources:
     config:
       tags: ['yuman', 'source']
 
-      # Freshness: column containing extraction timestamp
+      # Freshness: tier Standard — 26h warn / 48h error
+      # Cf. docs/freshness.md
       loaded_at_field: _sdc_extracted_at
-      
-      # Freshness thresholds for daily full refresh
       freshness:
-        warn_after: {count: 26, period: hour}   # Warn if > 26h (buffer for load delays)
-        error_after: {count: 36, period: hour}  # Error if missed a full day
+        warn_after: {count: 26, period: hour}
+        error_after: {count: 48, period: hour}
 
     tables:
       # ═══════════════════════════════════════════════════════════════════

--- a/models/staging/yuman_gcs/_yuman_gcs__sources.yml
+++ b/models/staging/yuman_gcs/_yuman_gcs__sources.yml
@@ -3,6 +3,14 @@ version: 2
 sources:
   - name: yuman_gcs
     schema: "prod_raw"
+    config:
+      tags: ['yuman_gcs', 'source']
+      # Freshness: tier Relaxe — 7j warn / 14j error
+      # Cf. docs/freshness.md
+      loaded_at_field: export_date
+      freshness:
+        warn_after: {count: 7, period: day}
+        error_after: {count: 14, period: day}
     tables:
       - name: ext_gcs_yuman__stock_theorique
         description: "External table pointing to JSON extracts from Yuman SFTP"

--- a/models/staging/zoho_desk/_zoho_desk__models.yml
+++ b/models/staging/zoho_desk/_zoho_desk__models.yml
@@ -231,6 +231,23 @@ models:
       Pour les métriques temporelles (tickets fermés/rouverts par mois),
       utiliser stg_zoho_desk__ticket_history — ne pas utiliser closed_time
       qui ne reflète que la fermeture la plus récente.
+    tests:
+      # Freshness fallback (tier Relaxe — source _dlt_load_id est STRING, cf. docs/freshness.md)
+      # On monitore created_time : ticketerie active → tickets créés régulièrement.
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: created_time
+            datepart: day
+            interval: 7
+          config:
+            severity: warn
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: created_time
+            datepart: day
+            interval: 14
+          config:
+            severity: error
     columns:
       - name: ticket_id
         description: "PK — identifiant unique du ticket (renommé depuis id)"


### PR DESCRIPTION
## Summary

Implements the freshness rollout discussed in `docs/freshness.md` (already merged on master).

- **Palier 1 — native `dbt source freshness`** : activate / align / clean configs across 7 source YAMLs
- **Palier 2 — `dbt_expectations` fallback** : adds recency tests on 5 staging models whose raw timestamp is a STRING (cast in staging only)
- **CONVENTIONS.md** : updates the *Source freshness* section to document the 5 tiers + 2 methods

After this PR, **all 10 sources are monitored**, either natively or via `dbt_expectations`.

## Changes

### Palier 1 (sources.yml)
| Source | Change |
|---|---|
| `gac` | Activate Relaxe 7j/14j on `_sdc_batched_at` (was `null`) |
| `yuman_gcs` | Add Relaxe 7j/14j on `export_date` (DATE) |
| `yuman` | Standard `error_after` 36h → 48h |
| `mssql_sage` | Standard `error_after` 36h → 48h ; drop useless `_sdc_received_at` overrides on `dbo_f_ecritureA/C` (profiling showed 0min diff) |
| `nesp_co.nespresso_base_client` | Add Manuel tier (60j/90j) — manual SFTP delivery |
| `oracle_neshu` | Drop 13 redundant `26h/36h` per-table overrides |
| `oracle_lcdp` | Drop 11 redundant per-table overrides |

`freshness: null` kept on stable referential tables (types, codes, labels) — documented as intentional.

### Palier 2 (models.yml — `dbt_expectations` tests)
| Staging model | Tier | Interval |
|---|---|---|
| `stg_nesp_tech__interventions` / `__articles` | Hebdomadaire | 8d warn / 14d error |
| `stg_nesp_co__activite` / `__opportunite` | Standard | 2d warn |
| `stg_oracle_neshu_gcs__stock_theorique` | Relaxe | 7d warn / 14d error |
| `stg_zoho_desk__tickets` | Relaxe | 7d warn / 14d error on `created_time` |

### Conventions
- Updated `CONVENTIONS.md` § Source freshness with the 5 tiers + Method A/B + rules

## Test plan
- [ ] CI `dbt parse` passes (hook already triggered locally — green)
- [ ] `dbt source freshness` returns expected statuses (run after merge on prod)
- [ ] `dbt test --select tag:nesp_tech,tag:nesp_co,tag:oracle_neshu_gcs,tag:zoho_desk` passes — confirms the `dbt_expectations` recency tests fire correctly
- [ ] No regression on existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)