### PR TITLE
feat(freshness): tighten oracle_neshu_gcs to Standard + new Mon-Sat tier for yuman_gcs

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -469,9 +469,10 @@ models:
 | Tier | warn_after | error_after | Sources |
 |------|-----------|-------------|---------|
 | Critique | 26h | 36h | oracle_neshu, oracle_lcdp |
-| Standard | 26h | 48h | yuman, mssql_sage, nesp_co (activite/opportunite) |
+| Standard | 26h | 48h | yuman, mssql_sage, nesp_co (activite/opportunite), oracle_neshu_gcs |
+| Quotidien Mon-Sat | 36h | 80h | yuman_gcs |
 | Hebdomadaire | 8j | 14j | nesp_tech |
-| Relaxe | 7j | 14j | gac, yuman_gcs, oracle_neshu_gcs, zoho_desk |
+| Relaxe | 7j | 14j | gac, zoho_desk |
 | Manuel | 60j | 90j | nesp_co (nespresso_base_client) |
 
 ### Deux mecanismes selon le type de timestamp source

--- a/docs/freshness.md
+++ b/docs/freshness.md
@@ -17,9 +17,10 @@ pour les sources à timestamp STRING.
 | Tier | Cadence typique | `warn_after` | `error_after` | Sources |
 |---|---|---|---|---|
 | **Critique** | quotidien, business-day SLA | 26h | 36h | `oracle_neshu`, `oracle_lcdp` |
-| **Standard** | quotidien tolérant | 26h | 48h | `yuman`, `mssql_sage`, `nesp_co` (activite/opportunite) |
+| **Standard** | quotidien tolérant (tous les jours) | 26h | 48h | `yuman`, `mssql_sage`, `nesp_co` (activite/opportunite), `oracle_neshu_gcs` |
+| **Quotidien Mon-Sat** | extraction Mon-Sat, dimanche skippé + lag snapshot DATE | 36h | 80h | `yuman_gcs` |
 | **Hebdomadaire** | extraction 1×/semaine | 8 jours | 14 jours | `nesp_tech` |
-| **Relaxe** | batch journalier non critique / GCS | 7 jours | 14 jours | `gac`, `oracle_neshu_gcs`, `yuman_gcs`, `zoho_desk` |
+| **Relaxe** | batch journalier non critique | 7 jours | 14 jours | `gac`, `zoho_desk` |
 | **Manuel** | livraison ponctuelle uniquement | 60 jours | 90 jours | `nesp_co.nespresso_base_client` |
 
 > **Principe directeur** : `freshness: null` se justifie *uniquement* sur les
@@ -111,9 +112,13 @@ Symétrique de `oracle_neshu`. Même action : nettoyer les overrides redondants.
 - `loaded_at_field: _sdc_batched_at`
 - Défaut source : **7j / 14j** (à activer, actuellement `null`)
 
-### `yuman_gcs` — tier *Relaxe*, méthode A
+### `yuman_gcs` — tier *Quotidien Mon-Sat*, méthode A
 - `loaded_at_field: export_date` (DATE — dbt accepte)
-- Défaut source : **7j / 14j**
+- Défaut source : **36h warn / 80h error**
+- Pipeline Mon-Sat 06:00 Paris (cron `0 6 * * 1-6`). `export_date` est le
+  snapshot (DATE = minuit), structurellement en retard d'~1 jour. Pire cas
+  observable : lundi matin avant 06:00, max = samedi soir = ~78h d'âge — le
+  seuil 80h absorbe cette fenêtre.
 
 ### `nesp_co.nespresso_base_client` — tier *Manuel*, méthode A
 - `loaded_at_field: _sdc_extracted_at`
@@ -135,10 +140,11 @@ business qui restent peuplées :
 - `stg_nesp_tech__articles` : test sur **`date_intervention`** (DATE)
 - Seuil : **8 jours warn / 14 jours error**
 
-### `oracle_neshu_gcs` — tier *Relaxe*, méthode B
+### `oracle_neshu_gcs` — tier *Standard*, méthode B
 Source brute : `extracted_at` STRING. Test sur
 `stg_oracle_neshu_gcs__stock_theorique`.
-- Seuil : **7 jours warn / 14 jours error**
+- Pipeline quotidien (cron `0 23 * * *`, gap observé 23-24h très régulier).
+- Seuil : **26h warn / 48h error** (en heures via `datepart: hour`).
 
 ### `zoho_desk` — tier *Relaxe*, méthode B
 Source brute : `_dlt_load_id` est un STRING (Unix epoch). Test sur les
@@ -156,11 +162,11 @@ staging zoho_desk qui exposent un timestamp cast.
 | `yuman` | Standard | A | source | 26h / 48h |
 | `mssql_sage` | Standard | A | source | 26h / 48h |
 | `gac` | Relaxe | A | source | 7j / 14j |
-| `yuman_gcs` | Relaxe | A | source | 7j / 14j |
+| `yuman_gcs` | Quotidien Mon-Sat | A | source | 36h / 80h |
 | `nesp_co.base_client` | Manuel | A | table | 60j / 90j |
 | `nesp_co.activite/opp` | Standard | B | staging | 2j |
 | `nesp_tech` | Hebdomadaire | B | staging | 8j / 14j |
-| `oracle_neshu_gcs` | Relaxe | B | staging | 7j / 14j |
+| `oracle_neshu_gcs` | Standard | B | staging | 26h / 48h |
 | `zoho_desk` | Relaxe | B | staging | 7j / 14j |
 
 **Toutes les sources sont désormais monitorées**, soit nativement, soit via

--- a/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__models.yml
+++ b/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__models.yml
@@ -4,19 +4,20 @@ models:
   - name: stg_oracle_neshu_gcs__stock_theorique
     description: "Table staging des fichiers CSV quotidiens de stock théorique Oracle Neshu depuis GCS. Les colonnes sont typées et les dates converties en TIMESTAMP."
     tests:
-      # Freshness fallback (tier Relaxe — source STRING timestamp, cf. docs/freshness.md)
+      # Freshness fallback (tier Standard — extract quotidien 23:00 Paris, gap typique
+      # observé 23-24h ; source STRING timestamp cf. docs/freshness.md)
       - dbt_expectations.expect_row_values_to_have_recent_data:
           arguments:
             column_name: extracted_at
-            datepart: day
-            interval: 7
+            datepart: hour
+            interval: 26
           config:
             severity: warn
       - dbt_expectations.expect_row_values_to_have_recent_data:
           arguments:
             column_name: extracted_at
-            datepart: day
-            interval: 14
+            datepart: hour
+            interval: 48
           config:
             severity: error
     columns:

--- a/models/staging/yuman_gcs/_yuman_gcs__sources.yml
+++ b/models/staging/yuman_gcs/_yuman_gcs__sources.yml
@@ -5,12 +5,16 @@ sources:
     schema: "prod_raw"
     config:
       tags: ['yuman_gcs', 'source']
-      # Freshness: tier Relaxe — 7j warn / 14j error
+      # Freshness: tier Quotidien Mon-Sat — 36h warn / 80h error
+      # Pipeline Mon-Sat 06:00 Paris (cron `0 6 * * 1-6`), dimanche skippé.
+      # export_date est la date du snapshot (DATE = minuit), structurellement
+      # en retard d'~1 jour. Pire cas observable : lundi matin avant 06:00,
+      # max(export_date) = samedi = ~78h d'âge.
       # Cf. docs/freshness.md
       loaded_at_field: export_date
       freshness:
-        warn_after: {count: 7, period: day}
-        error_after: {count: 14, period: day}
+        warn_after: {count: 36, period: hour}
+        error_after: {count: 80, period: hour}
     tables:
       - name: ext_gcs_yuman__stock_theorique
         description: "External table pointing to JSON extracts from Yuman SFTP"


### PR DESCRIPTION
## Summary

Follow-up to #95. After observing that the GCS sources actually run every day (or Mon-Sat for yuman), tightens their freshness from the conservative *Relaxe* (7d/14d) to more meaningful thresholds — validated by 14d of historical profiling via BigQuery MCP.

### Changes

| Source | Before | After | Why |
|---|---|---|---|
| `oracle_neshu_gcs` | Relaxe 7d/14d | **Standard 26h/48h** (hour unit) | Daily extract 23:00 Paris, consistent 23-24h gap |
| `yuman_gcs` | Relaxe 7d/14d | **Quotidien Mon-Sat 36h/80h** (new tier) | Mon-Sat cron + `export_date` is DATE with 1-day snapshot lag → Monday morning peak ~78h |

The 5th tier *Quotidien Mon-Sat* is added to handle the Sunday-skip + DATE-lag combo cleanly without false positives every weekend.

### Doc updates
- `docs/freshness.md` — tier table + per-source state updated
- `CONVENTIONS.md` — § Source freshness tier table updated

## Test plan
- [ ] CI `dbt build` passes
- [ ] `dbt source freshness` on `yuman_gcs` returns *pass* or *warn* depending on day-of-week
- [ ] `dbt_expectations` recency test on `stg_oracle_neshu_gcs__stock_theorique` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)