### PR TITLE
refactor(neshu): use dim_neshu__resource in fct_neshu__chargement_consommation

### DIFF
--- a/models/marts/neshu/fct_neshu__chargement_consommation.sql
+++ b/models/marts/neshu/fct_neshu__chargement_consommation.sql
@@ -17,7 +17,7 @@ with passage_avec_suivant as (
     select
         ta.device_id,
         ta.task_start_date,
-        rm.roadman_code,
+        rm.resources_name as roadman_code,
         ta.product_source_id,
         ta.product_source_type,
         lag(ta.task_start_date) over (
@@ -25,8 +25,10 @@ with passage_avec_suivant as (
             order by ta.task_start_date
         ) as date_passage_precedent
     from {{ ref('int_oracle_neshu__appro_tasks') }} as ta
-    left join {{ ref('dim_neshu__vehicule_roadman') }} as rm
-        on ta.product_source_id = rm.resources_vehicule_id
+    left join {{ ref('dim_neshu__resource') }} as rm
+        on
+            ta.product_source_id = rm.resources_id
+            and rm.resources_type = 'VEHICLE'
     where
         ta.task_start_date >= '2025-01-01'
         and ta.task_status_code = 'FAIT'


### PR DESCRIPTION
## Summary
- Replaces `dim_neshu__vehicule_roadman` with `dim_neshu__resource` (filtered `resources_type='VEHICLE'`) in `fct_neshu__chargement_consommation`.
- `rm.roadman_code` → `rm.resources_name as roadman_code` (sémantique identique : `r.name` du véhicule dans `stg_oracle_neshu__resources`).
- Aucun usage de `gea_code` dans ce fact → le différentiel sémantique sur `gea_code` entre les deux dims n'a pas d'impact ici.

## Test plan
- [x] SQLFluff lint OK
- [x] `dbt build` en dev OK (modèle + 7 tests passent)
- [x] Comparaison byte-by-byte vs ancienne version sur le même snapshot dev (1 409 628 rows) :
  - PK match : 100 %
  - Diff `roadman_code` : 0
  - Diff `product_source_id` : 0
  - Diff `q_consommee` / `q_chargee` : 0
- [ ] Build prod après merge

## Suite
- `dim_neshu__vehicule_roadman` n'a plus de consommateur après ce merge → suppression possible dans un PR ultérieur (SQL + YAML + drop BQ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)