### PR TITLE
feat(commerce): add SCORECARD exposure + skip CI on exposure-only PRs

### DIFF
--- a/.github/workflows/dbt-ci.yml
+++ b/.github/workflows/dbt-ci.yml
@@ -5,7 +5,10 @@ on:
     branches:
       - master
     paths:
-      - 'models/**'
+      # models/** except models/exposures/** (meta objects, not materialized)
+      - 'models/staging/**'
+      - 'models/intermediate/**'
+      - 'models/marts/**'
       - 'data/**'
       - 'snapshots/**'
       - 'macros/**'

--- a/models/exposures/commerce.yml
+++ b/models/exposures/commerce.yml
@@ -22,3 +22,20 @@ exposures:
       email: rim.bouchikhi@evs-pro.com
     depends_on:
       - ref('fct_commerce__machine_intervention')
+
+  - name: scorecard
+    label: "SCORECARD"
+    type: dashboard
+    maturity: high
+    description: >
+      Scorecard commerciale Nespresso : suivi de l'activité des commerciaux
+      (rendez-vous, appels, opportunités) croisée avec le référentiel client
+      et le mapping des commerciaux.
+    owner:
+      name: Etienne Boulinier
+      email: etienne.boulinier@evs-pro.com
+    depends_on:
+      - ref('dim_commerce__client')
+      - ref('fct_commerce__activite')
+      - ref('fct_commerce__opportunite')
+      - ref('ref_nesp_co__commerciaux')


### PR DESCRIPTION
## Summary
- Add the **SCORECARD** exposure (owner: Etienne Boulinier, maturity: high) in \`models/exposures/commerce.yml\`. Dependencies: \`dim_commerce__client\`, \`fct_commerce__activite\`, \`fct_commerce__opportunite\`, \`ref_nesp_co__commerciaux\`.
- Restrict the **PR trigger** in \`dbt-ci.yml\` to \`models/{staging,intermediate,marts}/**\` instead of \`models/**\`, so PRs touching only exposures (meta-only, not materialized) no longer run a dev build.
- Keep \`models/**\` on the **push to master** trigger so the docs deploy still picks up new/updated exposures.

## Test plan
- [x] \`dbt parse\` OK locally
- [ ] This PR itself triggers the CI (because \`.github/workflows/dbt-ci.yml\` is in the watched paths) — expected and useful for validation.
- [ ] Next exposure-only PR should bypass CI entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)