### PR TITLE
refactor(mssql_sage): align ecriture staging keys with Sage model

### DIFF
--- a/models/staging/mssql_sage/_mssql_sage__models.yml
+++ b/models/staging/mssql_sage/_mssql_sage__models.yml
@@ -2,10 +2,16 @@ version: 2
 
 models:
   - name: stg_mssql_sage__f_ecriturea
-    description: "Écritures analytiques nettoyées issues du système MSSQL Sage"
+    description: "Écritures analytiques nettoyées issues du système MSSQL Sage. Déduplication staging sur (ec_no, n_analytique, ea_ligne) — clé unique métier Sage — en gardant le cb_marq le plus récent."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          combination_of_columns:
+            - ec_no
+            - n_analytique
+            - ea_ligne
     columns:
       - name: cb_marq
-        description: "Identifiant unique de l'écriture analytique"
+        description: "Identifiant technique Sage (PK)"
         tests:
           - unique
           - not_null
@@ -15,10 +21,16 @@ models:
           - not_null
           - relationships:
               arguments:
-                to: ref('stg_mssql_sage__f_ecriturec') 
-                field: ec_no                             
+                to: ref('stg_mssql_sage__f_ecriturec')
+                field: ec_no
+      - name: n_analytique
+        description: "Numéro de plan analytique"
+        tests:
+          - not_null
       - name: ea_ligne
         description: "Numéro de la ligne dans l'écriture analytique"
+        tests:
+          - not_null
       - name: ca_num
         description: "Code analytique"
       - name: ea_montant
@@ -39,16 +51,17 @@ models:
         description: "Timestamp de suppression logique"
 
   - name: stg_mssql_sage__f_ecriturec
-    description: "Écritures comptables nettoyées issues du système MSSQL Sage"
+    description: "Écritures comptables nettoyées issues du système MSSQL Sage. Déduplication staging sur ec_no — clé unique métier Sage — en gardant le cb_marq le plus récent (Sage crée parfois un nouveau cb_marq sur update au lieu de modifier la ligne existante, l'ancien étant supprimé)."
     columns:
       - name: ec_no
-        description: "Numéro de l'écriture comptable (PK)"
+        description: "Numéro de l'écriture comptable (clé unique métier Sage)"
         tests:
           - unique
           - not_null
       - name: cb_marq
-        description: "Identifiant unique de l'écriture comptable"
+        description: "Identifiant technique Sage (PK)"
         tests:
+          - unique
           - not_null
       - name: ec_no_link
         description: "Lien vers l'écriture parent, si existant"
@@ -57,7 +70,12 @@ models:
       - name: cg_num
         description: "Compte général"
       - name: ct_num
-        description: "Compte tiers"
+        description: "Compte tiers (nullable pour les écritures sans tiers)"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_mssql_sage__f_comptet')
+                field: ct_num
       - name: ec_intitule
         description: "Libellé de l'écriture"
       - name: ec_sens

--- a/models/staging/mssql_sage/stg_mssql_sage__f_ecriturea.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_ecriturea.sql
@@ -8,7 +8,7 @@
             "granularity": "day"
         },
         cluster_by=['ec_no'],
-        description='Écritures analytiques nettoyées issues du système MSSQL Sage'
+        description='Écritures analytiques nettoyées issues du système MSSQL Sage. Déduplication par (ec_no, n_analytique, ea_ligne) — unique key Sage — en gardant le cb_marq le plus récent : Sage crée parfois un nouveau cb_marq sur update au lieu de modifier la ligne existante.'
     )
 }}
 
@@ -46,3 +46,7 @@ cleaned_data as (
 
 select *
 from cleaned_data
+qualify row_number() over (
+    partition by ec_no, n_analytique, ea_ligne
+    order by updated_at desc, cb_marq desc
+) = 1

--- a/models/staging/mssql_sage/stg_mssql_sage__f_ecriturec.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_ecriturec.sql
@@ -8,7 +8,7 @@
             "granularity": "day"
         },
         cluster_by=['ec_no','cg_num'],
-        description='Écritures comptables nettoyées issues du système MSSQL Sage (dbo_f_ecriturec)'
+        description='Écritures comptables nettoyées issues du système MSSQL Sage (dbo_f_ecriturec). Déduplication par ec_no (unique key Sage) en gardant le cb_marq le plus récent : Sage crée parfois un nouveau cb_marq sur update au lieu de modifier la ligne existante.'
     )
 }}
 
@@ -58,3 +58,7 @@ cleaned_data as (
 
 select *
 from cleaned_data
+qualify row_number() over (
+    partition by ec_no
+    order by updated_at desc, cb_marq desc
+) = 1


### PR DESCRIPTION
## Summary

- Dedupe `stg_mssql_sage__f_ecriturec` on `ec_no` (Sage unique key) en gardant le `cb_marq` le plus récent. Sage crée parfois un nouveau `cb_marq` sur update au lieu de modifier la ligne existante (l'ancien étant supprimé en base).
- Dedupe `stg_mssql_sage__f_ecriturea` sur `(ec_no, n_analytique, ea_ligne)` selon la même logique.
- Tests d'unicité alignés sur la modélisation Sage : `cb_marq` PK technique unique + `ec_no` (ou triplet) clé métier unique.
- Ajout d'un test `relationships` `f_ecriturec.ct_num` → `f_comptet.ct_num` (0 orphelin en prod, NULL acceptés pour les écritures sans tiers).

## Impact aval

Corrige un fan-out latent dans `int_mssql_sage__pnl_bu` qui joint `ecriturea` à `ecriturec` sur `ec_no` : si Sage avait laissé deux `cb_marq` pour un même `ec_no`, les montants analytiques auraient été dupliqués. Pas de doublon dans le snapshot actuel (304 774 ec / 187 626 ea sans collision), le `qualify` est un filet de sécurité.

## Test plan

- [x] `sqlfluff lint` sur les deux SQL
- [x] `dbt parse`
- [x] `dbt build` dev sur les deux modèles staging + `f_comptet` → 13/13 tests PASS
- [x] Vérification intégrité FK `ct_num` sur prod_staging → 0 orphelin

🤖 Generated with [Claude Code](https://claude.com/claude-code)