### PR TITLE
refactor(oracle_lcdp): pivot telemetry labels in int_telemetry_tasks

### DIFF
--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__telemetry_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__telemetry_tasks.sql
@@ -9,7 +9,21 @@
     )
 }}
 
-with telemetry_tasks as (
+with task_label_pivot as (
+    select
+        lht.idtask,
+        max(case when lf.code = 'TELEM_SOURCE' then la.code end) as telemetry_source,
+        max(case when lf.code = 'TELEM_SEND_CAUSE' then la.code end) as telemetry_send_cause
+    from {{ ref('stg_oracle_lcdp__label_has_task') }} as lht
+    inner join {{ ref('stg_oracle_lcdp__label') }} as la
+        on lht.idlabel = la.idlabel
+    inner join {{ ref('stg_oracle_lcdp__label_family') }} as lf
+        on la.idlabel_family = lf.idlabel_family
+    where lf.code in ('TELEM_SOURCE', 'TELEM_SEND_CAUSE')
+    group by lht.idtask
+),
+
+telemetry_tasks as (
     select
         -- PK naturelle de task_has_product
         thp.idtask_has_product as task_product_id,
@@ -30,6 +44,10 @@ with telemetry_tasks as (
         c.name as company_name,
         l.access_info as task_location_info,
 
+        -- Attributs télémétrie (labels pivotés)
+        tlp.telemetry_source,
+        tlp.telemetry_send_cause,
+
         -- Dates business
         t.real_start_date as task_start_date,
 
@@ -47,6 +65,12 @@ with telemetry_tasks as (
     inner join {{ ref('stg_oracle_lcdp__task_has_product') }} as thp
         on t.idtask = thp.idtask
 
+    -- Filtrage sur la présence d'un label TELEM_SOURCE + récupération des valeurs
+    inner join task_label_pivot as tlp
+        on
+            t.idtask = tlp.idtask
+            and tlp.telemetry_source is not null
+
     -- Jointures pour enrichissement
     left join {{ ref('stg_oracle_lcdp__company') }} as c
         on t.idcompany_peer = c.idcompany
@@ -57,22 +81,11 @@ with telemetry_tasks as (
     left join {{ ref('stg_oracle_lcdp__location') }} as l
         on t.idlocation = l.idlocation
 
-    -- Jointures pour le filtrage sur labels télémétrie
-    inner join {{ ref('stg_oracle_lcdp__label_has_task') }} as lht
-        on t.idtask = lht.idtask
-
-    inner join {{ ref('stg_oracle_lcdp__label') }} as la
-        on lht.idlabel = la.idlabel
-
-    inner join {{ ref('stg_oracle_lcdp__label_family') }} as lf
-        on la.idlabel_family = lf.idlabel_family
-
     where 1 = 1
     -- Filtres business critiques
     and t.idtask_status in (1, 4)  -- FAIT et VALIDE uniquement
     and t.code_status_record = '1'   -- Enregistrement actif (string)
     and t.idtask_type = 3           -- Type télémétrie
-    and lf.code = 'TELEM_SOURCE'    -- Label famille télémétrie source
 
     -- Filtre qualité données
     and t.real_start_date is not null  -- Éviter les tâches sans date de début


### PR DESCRIPTION
## Summary
- Remplace les inner joins `label_has_task → label → label_family` (filtre sur `lf.code = 'TELEM_SOURCE'`) par un CTE pré-agrégé qui pivote les labels EAV en colonnes explicites.
- Ajoute deux nouvelles colonnes au modèle : `telemetry_source` et `telemetry_send_cause` (valeurs `label.code`), exploitables directement en aval (marts / Power BI).
- Sécurise le grain (`task_product_id`) contre une éventuelle multiplicité de labels dans la même famille — le pivot par `max(case when ...)` garantit 1 ligne par task.

## Contexte
Investigation MCP BigQuery du système EAV LCDP (familles de labels rattachées aux tasks) :
- 29 familles de labels au total, 1,83 famille/task en moyenne (max 5).
- Pour les tasks de télémétrie : `TELEM_SOURCE = TELEM_NAYAX` + `TELEM_SEND_CAUSE = PLANIFIED_SAILS` aujourd'hui (1 seul label par famille).
- Avant le pivot, le modèle filtrait correctement les tasks de télémétrie mais ne remontait pas la valeur du label — impossible de distinguer la source en BI.

## Test plan
- [x] `dbt build -s int_oracle_lcdp__telemetry_tasks --full-refresh` sur `dev` → 4,2M lignes, 8 tests PASS.
- [x] Contrôle de cohérence sur `dev_intermediate` : toutes les lignes portent `telemetry_source=TELEM_NAYAX` + `telemetry_send_cause=PLANIFIED_SAILS` (cohérent avec la source).
- [ ] Full-refresh à prévoir en prod au merge pour backfiller les colonnes sur l'historique.

🤖 Generated with [Claude Code](https://claude.com/claude-code)