### PR TITLE
feat(neshu): Yuman technician FK + display labels on machine_appro_intervention

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -25,6 +25,9 @@ models:
       - name: company_name
         description: "Nom de la société"
 
+      - name: company_label
+        description: "Libellé d'affichage = concaténation `company_code - company_name`."
+
       - name: region
         description: "Région géographique de la société (label REGION)"
 
@@ -190,6 +193,9 @@ models:
 
       - name: device_name
         description: "Nom de la machine"
+
+      - name: device_label
+        description: "Libellé d'affichage = concaténation `device_code - device_name`."
 
       - name: company_code
         description: "Code client associé à la machine"
@@ -1165,10 +1171,8 @@ models:
                 field: company_id
       - name: device_code
         description: Code interne machine — utilisé pour la jointure cross-source vers Yuman.
-      - name: device_name
-        description: Nom de la machine (display).
-      - name: company_name
-        description: Nom du client (display).
+      - name: company_code
+        description: Code client (display) — issu de dim_neshu__company.
 
       # === Contexte appro ===
       - name: last_appro_date
@@ -1212,6 +1216,15 @@ models:
               arguments:
                 to: ref('dim_technique__material')
                 field: material_id
+      - name: past_technician_id
+        description: FK Yuman vers dim_technique__technician (user_id) — technicien de la dernière intervention 15j (NULL si pas d'intervention 15j).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__technician')
+                field: user_id
+              config:
+                severity: warn
       - name: past_intervention_id
         description: ID Yuman du workorder de la dernière intervention 15j.
       - name: past_intervention_date
@@ -1239,6 +1252,15 @@ models:
               arguments:
                 to: ref('dim_technique__material')
                 field: material_id
+      - name: current_technician_id
+        description: FK Yuman vers dim_technique__technician (user_id) — technicien de l'intervention en cours.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__technician')
+                field: user_id
+              config:
+                severity: warn
       - name: current_intervention_id
         description: ID Yuman du workorder en cours.
       - name: current_demand_description
@@ -1262,6 +1284,15 @@ models:
               arguments:
                 to: ref('dim_technique__material')
                 field: material_id
+      - name: future_technician_id
+        description: FK Yuman vers dim_technique__technician (user_id) — technicien de l'intervention planifiée.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__technician')
+                field: user_id
+              config:
+                severity: warn
       - name: future_intervention_id
         description: ID Yuman du workorder planifié.
       - name: future_intervention_planned_date

--- a/models/marts/neshu/dim_neshu__company.sql
+++ b/models/marts/neshu/dim_neshu__company.sql
@@ -88,6 +88,7 @@ select
     -- 📇 Codes et noms
     company_code,
     company_name,
+    CONCAT(company_code, ' - ', company_name) as company_label,
 
     -- 🏢 Caractéristiques entreprise
     region,

--- a/models/marts/neshu/dim_neshu__device.sql
+++ b/models/marts/neshu/dim_neshu__device.sql
@@ -81,6 +81,7 @@ select
     -- 📇 Codes et noms
     device_code,
     device_name,
+    CONCAT(device_code, ' - ', device_name) as device_label,
     company_code,
     company_name,
 

--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -31,8 +31,7 @@ with appro_context as (
 
         -- Display attributes via conformed dims
         d.device_code,
-        d.device_name,
-        c.company_name,
+        c.company_code,
 
         -- Appro context (depuis l'intermediate)
         ctx.last_appro_task_id,
@@ -81,6 +80,9 @@ yuman_workorders as (
         any_value(demand_category_name) as demand_category_name,
         any_value(workorder_title) as intervention_title,
         any_value(workorder_report) as intervention_report,
+
+        -- Technicien Yuman (FK vers dim_technique__technician.user_id)
+        any_value(technician_id) as technician_id,
 
         -- Statuts (pour les flags)
         any_value(demand_status) as demand_status,
@@ -146,6 +148,7 @@ past_15d_ranked as (
     select
         serial_clean,
         material_id,
+        technician_id,
         intervention_id,
         date_done,
         demand_description,
@@ -166,6 +169,7 @@ past_15d as (
     select
         serial_clean,
         material_id as past_material_id,
+        technician_id as past_technician_id,
         intervention_id as past_intervention_id,
         date_done as past_intervention_date,
         demand_description as past_demand_description,
@@ -185,6 +189,7 @@ current_ranked as (
     select
         serial_clean,
         material_id,
+        technician_id,
         intervention_id,
         demand_description,
         demand_created_at,
@@ -205,6 +210,7 @@ current_inter as (
     select
         serial_clean,
         material_id as current_material_id,
+        technician_id as current_technician_id,
         intervention_id as current_intervention_id,
         demand_description as current_demand_description,
         demand_created_at as current_demand_created_at,
@@ -224,6 +230,7 @@ future_ranked as (
     select
         serial_clean,
         material_id,
+        technician_id,
         intervention_id,
         date_planned,
         demand_description,
@@ -244,6 +251,7 @@ future_inter as (
     select
         serial_clean,
         material_id as future_material_id,
+        technician_id as future_technician_id,
         intervention_id as future_intervention_id,
         date_planned as future_intervention_planned_date,
         demand_description as future_demand_description,
@@ -265,8 +273,7 @@ select
 
     -- Display attributes (1-3 par dim parente)
     ac.device_code,
-    ac.device_name,
-    ac.company_name,
+    ac.company_code,
 
     -- Contexte appro
     ac.last_appro_date,
@@ -284,6 +291,7 @@ select
 
     -- Bucket : intervention curative récente (15j)
     p15.past_material_id,
+    p15.past_technician_id,
     p15.past_intervention_id,
     p15.past_intervention_date,
     p15.past_demand_description,
@@ -295,6 +303,7 @@ select
 
     -- Bucket : intervention en cours
     ci.current_material_id,
+    ci.current_technician_id,
     ci.current_intervention_id,
     ci.current_demand_description,
     ci.current_demand_created_at,
@@ -305,6 +314,7 @@ select
 
     -- Bucket : prochaine intervention planifiée
     fi.future_material_id,
+    fi.future_technician_id,
     fi.future_intervention_id,
     fi.future_intervention_planned_date,
     fi.future_demand_description,


### PR DESCRIPTION
## Contexte

Permettre la jointure star-schema depuis Power BI entre `fct_neshu__machine_appro_intervention` et `dim_technique__technician`, pour récupérer les attributs technicien Yuman. + ajout de libellés d'affichage normalisés sur les dims Neshu.

## Changements

### `fct_neshu__machine_appro_intervention`
- **Remonte `technician_id` par bucket** (`past_`/`current_`/`future_`), en FK vers `dim_technique__technician.user_id` (via `any_value(technician_id)` dans `yuman_workorders`, propagé dans les chaînes `*_ranked`).
- Tests `relationships` en **severity `warn`** (conforme convention Fact → FK warn). 1 écart légitime : un compte manager admin enregistré comme technicien sur un workorder clos de 2024 (`is_manager_as_technician = false` → exclu de la dim). Décision : laisser en warn.
- **Remplace `device_name`/`company_name` par `company_code`** (`device_code` conservé) : les libellés d'affichage se résolvent via jointure star-schema côté BI, pas par aplatissement dans le fait.

### Dims
- `dim_neshu__company` : ajout `company_label` = `concat(company_code - company_name)`.
- `dim_neshu__device` : ajout `device_label` = `concat(device_code - device_name)`.

### YAML
- Documentation à jour pour toutes les colonnes ajoutées/modifiées (descriptions + tests).

## Validation
- `sqlfluff lint` : clean sur les 3 modèles SQL.
- `dbt build` (dev) : 34/34 puis 10/10 tests PASS.

## Hors scope (discuté, reporté)
Colonnes Yuman supplémentaires candidates (`workorder_number`, `date_started`, `workorder_time_taken`, etc.) — laissées de côté pour ne pas élargir le fait ; à rouvrir si besoin métier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)