### PR TITLE
feat(oracle_lcdp): libellés FR des labels device via vue aplatie

### DIFF
--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -143,9 +143,9 @@ models:
   - name: dim_lcdp__device
     description: |
       [QUOI MÉTIER] Dimension machine LCDP enrichie des labels métier (catégorie, état, types fontaine/broyeur/percolateur/SP).
-      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__device joint à stg_oracle_lcdp__company (company_code, company_name) et stg_oracle_lcdp__location (access_info → device_location). Pivot des labels via stg_oracle_lcdp__label_has_device sur les familles : CATMACH, MARQUE, ETAT_MACHINE, STATUT_MATERIEL, TYPEAUDIT, TYDA, LCDPMON, TYPFONT, TYPBROY, TYPPERCO, TYPSP, TYPDASA, MODSP, MARQSP, BADGE, ISACTIVE.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__device joint à stg_oracle_lcdp__company (company_code, company_name) et stg_oracle_lcdp__location (access_info → device_location). Pivot des labels via stg_oracle_lcdp__label_device (vue aplatie lcdp_v_label_device) sur les familles : CATMACH, MARQUE, ETAT_MACHINE, STATUT_MATERIEL, TYPEAUDIT, TYDA, LCDPMON, TYPFONT, TYPBROY, TYPPERCO, TYPSP, TYPDASA, MODSP, MARQSP, BADGE, ISACTIVE.
       [GRAIN] 1 ligne par device_id.
-      [NOTES] device_iddevice = parent device (hiérarchie). is_active converti en booléen.
+      [NOTES] device_iddevice = parent device (hiérarchie). Les attributs label exposent désormais le libellé FR (label_text_fr, ex. "DA CHAUD") au lieu du code (ex. "CATMACH01"). Exception : is_active reste basé sur le code (YES/NO) pour la conversion booléenne. is_active converti en booléen.
     columns:
       - name: device_id
         description: "Identifiant unique du device"

--- a/models/marts/lcdp/dim_lcdp__device.sql
+++ b/models/marts/lcdp/dim_lcdp__device.sql
@@ -15,15 +15,12 @@ with device_labels as (
         c.code as company_code,
         c.name as company_name,
         lo.access_info,
-        l.code as label_code,
-        lf.code as label_family_code
+        ld.label_code,
+        ld.label_text_fr,
+        ld.label_family_code
     from {{ ref('stg_oracle_lcdp__device') }} as d
-    left join {{ ref('stg_oracle_lcdp__label_has_device') }} as lhd
-        on d.iddevice = lhd.iddevice and lhd.idlabel is not null
-    left join {{ ref('stg_oracle_lcdp__label') }} as l
-        on lhd.idlabel = l.idlabel
-    left join {{ ref('stg_oracle_lcdp__label_family') }} as lf
-        on l.idlabel_family = lf.idlabel_family
+    left join {{ ref('stg_oracle_lcdp__label_device') }} as ld
+        on d.iddevice = ld.device_id
     left join {{ ref('stg_oracle_lcdp__company') }} as c
         on d.idcompany_customer = c.idcompany
     left join {{ ref('stg_oracle_lcdp__location') }} as lo
@@ -46,22 +43,23 @@ aggregated_labels as (
         last_installation_date,
         created_at,
         updated_at,
-        MAX(case when label_family_code = 'CATMACH' then label_code end) as device_category,
-        MAX(case when label_family_code = 'STATUT_MATERIEL' then label_code end) as device_material_status,
-        MAX(case when label_family_code = 'TYPEAUDIT' then label_code end) as audit_type,
-        MAX(case when label_family_code = 'TYPFONT' then label_code end) as fountain_type,
-        MAX(case when label_family_code = 'TYPSP' then label_code end) as type_sp,
-        MAX(case when label_family_code = 'TYPBROY' then label_code end) as grinder_type,
-        MAX(case when label_family_code = 'ETAT_MACHINE' then label_code end) as device_state,
-        MAX(case when label_family_code = 'TYDA' then label_code end) as typology_da,
-        MAX(case when label_family_code = 'BADGE' then label_code end) as badge,
-        MAX(case when label_family_code = 'MARQUE' then label_code end) as device_brand,
-        MAX(case when label_family_code = 'MODSP' then label_code end) as model_sp,
+        MAX(case when label_family_code = 'CATMACH' then label_text_fr end) as device_category,
+        MAX(case when label_family_code = 'STATUT_MATERIEL' then label_text_fr end) as device_material_status,
+        MAX(case when label_family_code = 'TYPEAUDIT' then label_text_fr end) as audit_type,
+        MAX(case when label_family_code = 'TYPFONT' then label_text_fr end) as fountain_type,
+        MAX(case when label_family_code = 'TYPSP' then label_text_fr end) as type_sp,
+        MAX(case when label_family_code = 'TYPBROY' then label_text_fr end) as grinder_type,
+        MAX(case when label_family_code = 'ETAT_MACHINE' then label_text_fr end) as device_state,
+        MAX(case when label_family_code = 'TYDA' then label_text_fr end) as typology_da,
+        MAX(case when label_family_code = 'BADGE' then label_text_fr end) as badge,
+        MAX(case when label_family_code = 'MARQUE' then label_text_fr end) as device_brand,
+        MAX(case when label_family_code = 'MODSP' then label_text_fr end) as model_sp,
+        -- is_active conservé sur le code (YES/NO) pour le test lower(...) = 'yes' ci-dessous
         MAX(case when label_family_code = 'ISACTIVE' then label_code end) as is_active,
-        MAX(case when label_family_code = 'TYPDASA' then label_code end) as type_dasa,
-        MAX(case when label_family_code = 'MARQSP' then label_code end) as brand_sp,
-        MAX(case when label_family_code = 'TYPPERCO' then label_code end) as percolator_type,
-        MAX(case when label_family_code = 'LCDPMON' then label_code end) as currency_mode
+        MAX(case when label_family_code = 'TYPDASA' then label_text_fr end) as type_dasa,
+        MAX(case when label_family_code = 'MARQSP' then label_text_fr end) as brand_sp,
+        MAX(case when label_family_code = 'TYPPERCO' then label_text_fr end) as percolator_type,
+        MAX(case when label_family_code = 'LCDPMON' then label_text_fr end) as currency_mode
     from device_labels
     group by
         device_id,

--- a/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
@@ -178,6 +178,32 @@ models:
       - name: code
         description: "Code de la famille de labels"
 
+  - name: stg_oracle_lcdp__label_device
+    description: "Labels device nettoyés depuis la vue aplatie lcdp_v_label_device (1 ligne par device/label). Porte code, famille et libellé FR du label, prêt pour le pivot dans dim_lcdp__device."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - device_id
+              - idlabel
+    columns:
+      - name: device_id
+        description: "Identifiant de la machine (FK vers stg_oracle_lcdp__device.iddevice)"
+        tests:
+          - not_null
+      - name: idlabel
+        description: "Identifiant du label"
+        tests:
+          - not_null
+      - name: idlabel_family
+        description: "Identifiant de la famille de label"
+      - name: label_code
+        description: "Code du label (ex. CATMACH01)"
+      - name: label_family_code
+        description: "Code de la famille de label, clé de pivot dans le mart (ex. CATMACH)"
+      - name: label_text_fr
+        description: "Libellé français du label, valeur d'affichage (ex. DA CHAUD)"
+
   # LABEL_HAS_COMPANY
   - name: stg_oracle_lcdp__label_has_company
     description: "Association entre les labels et les entreprises"

--- a/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
@@ -355,6 +355,24 @@ sources:
           - name: code
             description: "Code du label family"
 
+      - name: lcdp_v_label_device
+        description: "Vue aplatie device × label × label_family (1 ligne par iddevice/idlabel) — porte le code (l_code), la famille (lf_code) et le libellé FR (l_text_fr)"
+        config:
+          freshness: null
+        columns:
+          - name: iddevice
+            description: "Identifiant de la machine (FK vers lcdp_device)"
+          - name: idlabel
+            description: "Identifiant du label"
+          - name: idlabel_family
+            description: "Identifiant de la famille de label"
+          - name: lf_code
+            description: "Code de la famille de label (clé de pivot)"
+          - name: l_code
+            description: "Code du label"
+          - name: l_text_fr
+            description: "Libellé français du label (valeur d'affichage)"
+
       - name: lcdp_product_type
         description: "Types de produit"
         config:

--- a/models/staging/oracle_lcdp/stg_oracle_lcdp__label_device.sql
+++ b/models/staging/oracle_lcdp/stg_oracle_lcdp__label_device.sql
@@ -1,0 +1,48 @@
+{{
+    config(
+        materialized='table',
+        description='Labels device LCDP nettoyés depuis la vue aplatie lcdp_v_label_device (1 ligne par device/label). Porte le code, la famille et le libellé FR du label, prêt pour le pivot dans dim_lcdp__device.'
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('oracle_lcdp', 'lcdp_v_label_device') }}
+),
+
+cleaned_data as (
+    select
+        -- IDs convertis en BIGINT
+        cast(iddevice as int64) as device_id,
+        cast(idlabel as int64) as idlabel,
+        cast(idlabel_family as int64) as idlabel_family,
+
+        -- Identifiants techniques (string)
+        l_idstring as label_idstring,
+        lf_idstring as label_family_idstring,
+
+        -- Codes et libellés
+        l_code as label_code,
+        lf_code as label_family_code,
+        l_text_fr as label_text_fr,
+
+        -- Booléens label
+        cast(l_system as boolean) as is_system,
+        cast(l_enabled as boolean) as is_enabled,
+        cast(l_isdefault as boolean) as is_default,
+
+        -- Booléens famille de label
+        cast(lf_exclus as boolean) as is_family_exclusive,
+        cast(lf_system as boolean) as is_family_system,
+        cast(lf_required as boolean) as is_family_required,
+        cast(lf_export_mobile as boolean) as is_family_export_mobile,
+
+        -- Timestamps harmonisés
+        -- La vue ne porte aucune date métier (création/modification) : seuls les timestamps techniques sont disponibles
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+
+    from source_data
+)
+
+select * from cleaned_data


### PR DESCRIPTION
## Contexte

Nouvelle table `prod_raw.lcdp_v_label_device` : vue **déjà aplatie** `device × label × label_family` (grain 1 ligne par `device/label`), portant le code (`l_code`), la famille (`lf_code`) et le libellé FR (`l_text_fr`).

Objectif : exposer le **libellé FR** (ex. `DA CHAUD`) au lieu du code (ex. `CATMACH01`) dans `dim_lcdp__device`, et simplifier la mécanique de pivot.

## Changements

### Staging — `stg_oracle_lcdp__label_device` (nouveau)
- Source sur `lcdp_v_label_device`, casts int64/booléens, expose `label_code` / `label_family_code` / `label_text_fr` + colonnes techniques.
- Pas de `created_at`/`updated_at` (absents de la vue) ; `extracted_at`/`deleted_at` réels.
- Déclaration source (`freshness: null`) + entrée YAML avec `unique_combination_of_columns (device_id, idlabel)` et `not_null` sur les clés.

### Mart — `dim_lcdp__device`
- Remplacement des **3 jointures** (`label_has_device` + `label` + `label_family`) par **un seul `ref()`** vers le nouveau staging.
- Valeurs des pivots : `label_code` → **`label_text_fr`** pour tous les attributs d'affichage.
- **Exception `is_active`** : conservé sur `label_code` (YES/NO) pour ne pas casser la conversion booléenne `lower(...) = 'yes'`.
- YAML `[COMMENT CONSTRUITE]` / `[NOTES]` mis à jour.

## Validation (dev)
- `sqlfluff lint` : clean.
- `dbt build` : 9/9 tests PASS, dim stable à 2,7k lignes (aucun fan-out introduit par le changement de jointure).
- Contrôle des valeurs : libellés FR bien rendus (`DA CHAUD`, `NECTA`, `FONTAINE`…), `is_active` OK.

## ⚠️ Impact BI
Les valeurs des attributs label de `dim_lcdp__device` passent des **codes** aux **libellés FR**. Tout rapport Power BI / mesure DAX filtrant sur les anciens codes (`CATMACH01`, `MARQ01`…) doit être adapté. À coordonner avec le Data Analyst avant merge prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)