### PR TITLE
feat(oracle_lcdp): source company & product labels from flattened views, expose FR labels in dims

### DIFF
--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -6,9 +6,9 @@ models:
   - name: dim_lcdp__company
     description: |
       [QUOI MÉTIER] Dimension client (company) LCDP enrichie des labels métier et de la localisation.
-      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__company joint à stg_oracle_lcdp__location pour les coordonnées, et pivot des labels (stg_oracle_lcdp__label_has_company + label + label_family) sur les familles : ZGEO, DOMACT, BUSMOD, GC, ISACTIVE, MODEH, MODEOF, MODER, PROPRIO, REPRES, BL_GRP, MEF, Gestion reliquat.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__company joint à stg_oracle_lcdp__location pour les coordonnées, et pivot des labels via stg_oracle_lcdp__label_company (vue aplatie lcdp_v_label_company) sur les familles : ZGEO, DOMACT, BUSMOD, GC, ISACTIVE, MODEH, MODEOF, MODER, PROPRIO, REPRES, BL_GRP, MEF, Gestion reliquat.
       [GRAIN] 1 ligne par company_id.
-      [NOTES] parent_company_id permet la hiérarchie société-mère/fille. is_active converti en booléen (TRUE si label ISACTIVE='yes').
+      [NOTES] parent_company_id permet la hiérarchie société-mère/fille. Les attributs label exposent désormais le libellé FR (label_text_fr) au lieu du code. Exception : is_active reste basé sur le code (YES/NO) pour la conversion booléenne (TRUE si label ISACTIVE='yes').
     columns:
       - name: company_id
         description: "Identifiant unique de la société"
@@ -94,9 +94,9 @@ models:
   - name: dim_lcdp__product
     description: |
       [QUOI MÉTIER] Dimension produit LCDP enrichie des labels métier (famille, groupe, marque, bio).
-      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__product filtré sur product_type_id IN (1, 5), enrichi par pivot des labels via stg_oracle_lcdp__label_has_product : FAMIPRO, GROUPRO, MARQPRO, BIO, ISACTIVE. created_at corrigé si NULL pour idproduct=1 (fallback updated_at).
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__product filtré sur product_type_id IN (1, 5), enrichi par pivot des labels via stg_oracle_lcdp__label_product (vue aplatie lcdp_v_label_product) : FAMIPRO, GROUPRO, MARQPRO, BIO, ISACTIVE. created_at corrigé si NULL pour idproduct=1 (fallback updated_at).
       [GRAIN] 1 ligne par product_id.
-      [NOTES] product_type_id : 1 = produit, 5 = ligne de prix. is_active converti en booléen.
+      [NOTES] product_type_id : 1 = produit, 5 = ligne de prix. Les attributs label exposent désormais le libellé FR (label_text_fr) au lieu du code. Exception : is_active reste basé sur le code (YES/NO) pour la conversion booléenne.
     columns:
       - name: product_id
         description: "Identifiant unique du produit"

--- a/models/marts/lcdp/dim_lcdp__company.sql
+++ b/models/marts/lcdp/dim_lcdp__company.sql
@@ -9,20 +9,17 @@ with company_labels as (
         c.name as company_name,
         c.created_at,
         c.updated_at,
-        l.code as label_code,
-        lf.code as label_family_code,
+        lc.label_code,
+        lc.label_text_fr,
+        lc.label_family_code,
         loc.address1,
         loc.address2,
         loc.city,
         loc.postal as postal_code,
         loc.country
     from {{ ref('stg_oracle_lcdp__company') }} as c
-    left join {{ ref('stg_oracle_lcdp__label_has_company') }} as lhc
-        on c.idcompany = lhc.idcompany and lhc.idlabel is not null
-    left join {{ ref('stg_oracle_lcdp__label') }} as l
-        on lhc.idlabel = l.idlabel
-    left join {{ ref('stg_oracle_lcdp__label_family') }} as lf
-        on l.idlabel_family = lf.idlabel_family
+    left join {{ ref('stg_oracle_lcdp__label_company') }} as lc
+        on c.idcompany = lc.company_id
     left join {{ ref('stg_oracle_lcdp__company_has_location') }} as chl
         on c.idcompany = chl.idcompany and chl.idlocation_type = 1
     left join {{ ref('stg_oracle_lcdp__location') }} as loc
@@ -44,19 +41,20 @@ aggregated_labels as (
         city,
         postal_code,
         country,
-        MAX(case when label_family_code = 'BL_GRP' then label_code end) as bl_group,
-        MAX(case when label_family_code = 'BUSMOD' then label_code end) as business_model,
-        MAX(case when label_family_code = 'DOMACT' then label_code end) as activity_domain,
-        MAX(case when label_family_code = 'GC' then label_code end) as key_account,
-        MAX(case when label_family_code = 'Gestion reliquat' then label_code end) as remainder_management,
+        MAX(case when label_family_code = 'BL_GRP' then label_text_fr end) as bl_group,
+        MAX(case when label_family_code = 'BUSMOD' then label_text_fr end) as business_model,
+        MAX(case when label_family_code = 'DOMACT' then label_text_fr end) as activity_domain,
+        MAX(case when label_family_code = 'GC' then label_text_fr end) as key_account,
+        MAX(case when label_family_code = 'Gestion reliquat' then label_text_fr end) as remainder_management,
+        -- is_active conservé sur le code (YES/NO) pour le test lower(...) = 'yes' ci-dessous
         MAX(case when label_family_code = 'ISACTIVE' then label_code end) as is_active,
-        MAX(case when label_family_code = 'MEF' then label_code end) as invoice_delivery_mode,
-        MAX(case when label_family_code = 'MODEH' then label_code end) as model_horeca,
-        MAX(case when label_family_code = 'MODEOF' then label_code end) as model_office,
-        MAX(case when label_family_code = 'MODER' then label_code end) as model_revendeur,
-        MAX(case when label_family_code = 'PROPRIO' then label_code end) as owner,
-        MAX(case when label_family_code = 'REPRES' then label_code end) as representative,
-        MAX(case when label_family_code = 'ZGEO' then label_code end) as geo_zone
+        MAX(case when label_family_code = 'MEF' then label_text_fr end) as invoice_delivery_mode,
+        MAX(case when label_family_code = 'MODEH' then label_text_fr end) as model_horeca,
+        MAX(case when label_family_code = 'MODEOF' then label_text_fr end) as model_office,
+        MAX(case when label_family_code = 'MODER' then label_text_fr end) as model_revendeur,
+        MAX(case when label_family_code = 'PROPRIO' then label_text_fr end) as owner,
+        MAX(case when label_family_code = 'REPRES' then label_text_fr end) as representative,
+        MAX(case when label_family_code = 'ZGEO' then label_text_fr end) as geo_zone
     from company_labels
     group by
         company_id,

--- a/models/marts/lcdp/dim_lcdp__product.sql
+++ b/models/marts/lcdp/dim_lcdp__product.sql
@@ -9,21 +9,16 @@ with product_labels as (
         p.purchase_unit_price,
         -- Correction de created_at si idproduct = 1
         p.updated_at,
-        l.code as label_code,
-        lf.code as label_family_code,
+        lp.label_code,
+        lp.label_text_fr,
+        lp.label_family_code,
         case
             when p.idproduct = 1 and p.created_at is null then p.updated_at
             else p.created_at
         end as created_at
     from {{ ref('stg_oracle_lcdp__product') }} as p
-    left join {{ ref('stg_oracle_lcdp__label_has_product') }} as lhp
-        on
-            p.idproduct = lhp.idproduct
-            and lhp.idlabel is not null
-    left join {{ ref('stg_oracle_lcdp__label') }} as l
-        on lhp.idlabel = l.idlabel
-    left join {{ ref('stg_oracle_lcdp__label_family') }} as lf
-        on l.idlabel_family = lf.idlabel_family
+    left join {{ ref('stg_oracle_lcdp__label_product') }} as lp
+        on p.idproduct = lp.product_id
     where
         p.idproduct_type in (1, 5)
         and (
@@ -43,11 +38,12 @@ aggregated_labels as (
         purchase_unit_price,
         created_at,
         updated_at,
-        MAX(case when label_family_code = 'FAMIPRO' then label_code end) as product_family,
-        MAX(case when label_family_code = 'GROUPRO' then label_code end) as product_group,
-        MAX(case when label_family_code = 'BIO' then label_code end) as product_bio,
+        MAX(case when label_family_code = 'FAMIPRO' then label_text_fr end) as product_family,
+        MAX(case when label_family_code = 'GROUPRO' then label_text_fr end) as product_group,
+        MAX(case when label_family_code = 'BIO' then label_text_fr end) as product_bio,
+        -- is_active conservé sur le code (YES/NO) pour le test lower(...) = 'yes' ci-dessous
         MAX(case when label_family_code = 'ISACTIVE' then label_code end) as is_active,
-        MAX(case when label_family_code = 'MARQPRO' then label_code end) as product_brand
+        MAX(case when label_family_code = 'MARQPRO' then label_text_fr end) as product_brand
     from product_labels
     group by
         product_id,

--- a/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
@@ -204,6 +204,58 @@ models:
       - name: label_text_fr
         description: "Libellé français du label, valeur d'affichage (ex. DA CHAUD)"
 
+  - name: stg_oracle_lcdp__label_company
+    description: "Labels company nettoyés depuis la vue aplatie lcdp_v_label_company (1 ligne par company/label). Porte code, famille et libellé FR du label, prêt pour le pivot dans dim_lcdp__company."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - company_id
+              - idlabel
+    columns:
+      - name: company_id
+        description: "Identifiant de l'entreprise (FK vers stg_oracle_lcdp__company.idcompany)"
+        tests:
+          - not_null
+      - name: idlabel
+        description: "Identifiant du label"
+        tests:
+          - not_null
+      - name: idlabel_family
+        description: "Identifiant de la famille de label"
+      - name: label_code
+        description: "Code du label (ex. BUSMOD01)"
+      - name: label_family_code
+        description: "Code de la famille de label, clé de pivot dans le mart (ex. BUSMOD)"
+      - name: label_text_fr
+        description: "Libellé français du label, valeur d'affichage"
+
+  - name: stg_oracle_lcdp__label_product
+    description: "Labels product nettoyés depuis la vue aplatie lcdp_v_label_product (1 ligne par product/label). Porte code, famille et libellé FR du label, prêt pour le pivot dans dim_lcdp__product."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - product_id
+              - idlabel
+    columns:
+      - name: product_id
+        description: "Identifiant du produit (FK vers stg_oracle_lcdp__product.idproduct)"
+        tests:
+          - not_null
+      - name: idlabel
+        description: "Identifiant du label"
+        tests:
+          - not_null
+      - name: idlabel_family
+        description: "Identifiant de la famille de label"
+      - name: label_code
+        description: "Code du label (ex. FAMIPRO01)"
+      - name: label_family_code
+        description: "Code de la famille de label, clé de pivot dans le mart (ex. FAMIPRO)"
+      - name: label_text_fr
+        description: "Libellé français du label, valeur d'affichage"
+
   # LABEL_HAS_COMPANY
   - name: stg_oracle_lcdp__label_has_company
     description: "Association entre les labels et les entreprises"

--- a/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
@@ -373,6 +373,42 @@ sources:
           - name: l_text_fr
             description: "Libellé français du label (valeur d'affichage)"
 
+      - name: lcdp_v_label_company
+        description: "Vue aplatie company × label × label_family (1 ligne par idcompany/idlabel) — porte le code (l_code), la famille (lf_code) et le libellé FR (l_text_fr)"
+        config:
+          freshness: null
+        columns:
+          - name: idcompany
+            description: "Identifiant de l'entreprise (FK vers lcdp_company)"
+          - name: idlabel
+            description: "Identifiant du label"
+          - name: idlabel_family
+            description: "Identifiant de la famille de label"
+          - name: lf_code
+            description: "Code de la famille de label (clé de pivot)"
+          - name: l_code
+            description: "Code du label"
+          - name: l_text_fr
+            description: "Libellé français du label (valeur d'affichage)"
+
+      - name: lcdp_v_label_product
+        description: "Vue aplatie product × label × label_family (1 ligne par idproduct/idlabel) — porte le code (l_code), la famille (lf_code) et le libellé FR (l_text_fr)"
+        config:
+          freshness: null
+        columns:
+          - name: idproduct
+            description: "Identifiant du produit (FK vers lcdp_product)"
+          - name: idlabel
+            description: "Identifiant du label"
+          - name: idlabel_family
+            description: "Identifiant de la famille de label"
+          - name: lf_code
+            description: "Code de la famille de label (clé de pivot)"
+          - name: l_code
+            description: "Code du label"
+          - name: l_text_fr
+            description: "Libellé français du label (valeur d'affichage)"
+
       - name: lcdp_product_type
         description: "Types de produit"
         config:

--- a/models/staging/oracle_lcdp/stg_oracle_lcdp__label_company.sql
+++ b/models/staging/oracle_lcdp/stg_oracle_lcdp__label_company.sql
@@ -1,0 +1,48 @@
+{{
+    config(
+        materialized='table',
+        description='Labels company LCDP nettoyés depuis la vue aplatie lcdp_v_label_company (1 ligne par company/label). Porte le code, la famille et le libellé FR du label, prêt pour le pivot dans dim_lcdp__company.'
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('oracle_lcdp', 'lcdp_v_label_company') }}
+),
+
+cleaned_data as (
+    select
+        -- IDs convertis en BIGINT
+        cast(idcompany as int64) as company_id,
+        cast(idlabel as int64) as idlabel,
+        cast(idlabel_family as int64) as idlabel_family,
+
+        -- Identifiants techniques (string)
+        l_idstring as label_idstring,
+        lf_idstring as label_family_idstring,
+
+        -- Codes et libellés
+        l_code as label_code,
+        lf_code as label_family_code,
+        l_text_fr as label_text_fr,
+
+        -- Booléens label
+        cast(l_system as boolean) as is_system,
+        cast(l_enabled as boolean) as is_enabled,
+        cast(l_isdefault as boolean) as is_default,
+
+        -- Booléens famille de label
+        cast(lf_exclus as boolean) as is_family_exclusive,
+        cast(lf_system as boolean) as is_family_system,
+        cast(lf_required as boolean) as is_family_required,
+        cast(lf_export_mobile as boolean) as is_family_export_mobile,
+
+        -- Timestamps harmonisés
+        -- La vue ne porte aucune date métier (création/modification) : seuls les timestamps techniques sont disponibles
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+
+    from source_data
+)
+
+select * from cleaned_data

--- a/models/staging/oracle_lcdp/stg_oracle_lcdp__label_product.sql
+++ b/models/staging/oracle_lcdp/stg_oracle_lcdp__label_product.sql
@@ -1,0 +1,48 @@
+{{
+    config(
+        materialized='table',
+        description='Labels product LCDP nettoyés depuis la vue aplatie lcdp_v_label_product (1 ligne par product/label). Porte le code, la famille et le libellé FR du label, prêt pour le pivot dans dim_lcdp__product.'
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('oracle_lcdp', 'lcdp_v_label_product') }}
+),
+
+cleaned_data as (
+    select
+        -- IDs convertis en BIGINT
+        cast(idproduct as int64) as product_id,
+        cast(idlabel as int64) as idlabel,
+        cast(idlabel_family as int64) as idlabel_family,
+
+        -- Identifiants techniques (string)
+        l_idstring as label_idstring,
+        lf_idstring as label_family_idstring,
+
+        -- Codes et libellés
+        l_code as label_code,
+        lf_code as label_family_code,
+        l_text_fr as label_text_fr,
+
+        -- Booléens label
+        cast(l_system as boolean) as is_system,
+        cast(l_enabled as boolean) as is_enabled,
+        cast(l_isdefault as boolean) as is_default,
+
+        -- Booléens famille de label
+        cast(lf_exclus as boolean) as is_family_exclusive,
+        cast(lf_system as boolean) as is_family_system,
+        cast(lf_required as boolean) as is_family_required,
+        cast(lf_export_mobile as boolean) as is_family_export_mobile,
+
+        -- Timestamps harmonisés
+        -- La vue ne porte aucune date métier (création/modification) : seuls les timestamps techniques sont disponibles
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+
+    from source_data
+)
+
+select * from cleaned_data


### PR DESCRIPTION
## Contexte

Réplique du pattern #103 (device) pour les dimensions **company** et **product** : sourcer les labels depuis les vues aplaties `prod_raw.lcdp_v_label_*` et exposer les libellés FR à la place des codes.

## Changements

**Nouveaux staging** (sur les vues pré-aplaties `entity × label × label_family`, grain entité/label) :
- `stg_oracle_lcdp__label_company` → `lcdp_v_label_company`
- `stg_oracle_lcdp__label_product` → `lcdp_v_label_product`

Chacun porte `label_code`, `label_family_code`, `label_text_fr`.

**Dims `dim_lcdp__company` / `dim_lcdp__product`** :
- jointure 3-way (`label_has_*` + `label` + `label_family`) remplacée par un seul `ref()` vers le nouveau staging
- valeurs pivotées : `label_code` → `label_text_fr` pour tous les attributs d'affichage
- `is_active` conservé sur `label_code` (YES/NO) pour préserver la conversion booléenne

**YAML** : déclarations de sources (freshness `null`), entrées staging avec `unique_combination_of_columns (entity_id, idlabel)` + clés `not_null`, blocs `[COMMENT CONSTRUITE]`/`[NOTES]` des marts mis à jour.

## Validation

- Lint clean
- `dbt build` + tests OK sur dev (**15/15**)
- Row counts dims stables (company 909, product 633, pas de fan-out)
- `l_text_fr` rempli à 100 % sur toutes les familles pivotées (aucun null introduit)

## Notes

- **resources écarté** : aucune `dim_lcdp__resource` n'existe encore. La vue `lcdp_v_label_resources` est disponible si on crée la dim plus tard.
- Aucun impact BI : les attributs passent des codes aux libellés FR, mais aucun rapport ne consomme ces marts à ce stade (phase build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)