### PR TITLE
feat(neshu): filter fct_machine_appro_intervention to real interventions only

### DIFF
--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -64,6 +64,14 @@ with appro_context as (
 -- CTE 2 : Interventions Yuman NESHU curatives, normalisées
 -- Grain : 1 ligne par (material, workorder).
 -- ⚠️ serial_clean = jointure fragile vers Neshu device_code.
+--
+-- Périmètre métier : uniquement les "vraies" interventions.
+--   - Closed avec workorder_motif_non_intervention ou
+--     workorder_detail_non_intervention renseigné = déplacement
+--     sans réparation → exclus du fait (~248 lignes).
+--   - In progress avec workorder_raison_mise_en_pause renseigné
+--     = intervention en pause, pas active → exclus du bucket
+--     current (filtré dans le flag is_current_intervention).
 -- ============================================================
 yuman_workorders as (
 
@@ -104,6 +112,7 @@ yuman_workorders as (
             when
                 any_value(workorder_status) = 'In progress'
                 and any_value(demand_status) = 'Accepted'
+                and any_value(workorder_raison_mise_en_pause) is null
                 then 1
             else 0
         end as is_current_intervention,
@@ -121,6 +130,9 @@ yuman_workorders as (
         material_serial_number is not null
         and upper(trim(partner_name)) = 'NESHU'
         and upper(trim(demand_category_name)) like 'CURATIVE%'
+        -- Exclure les déplacements sans réparation (Closed sans intervention réelle)
+        and workorder_motif_non_intervention is null
+        and workorder_detail_non_intervention is null
     group by
         material_id, material_serial_number, serial_clean, workorder_id
 


### PR DESCRIPTION
## Summary

Filtre le périmètre métier du fait `fct_neshu__machine_appro_intervention` aux **seules vraies interventions curatives**, suite à validation analyste (cf. mail PR #102).

- **Closed sans réparation exclus du fait** (~248 lignes NESHU curative) : workorders avec `workorder_motif_non_intervention` ou `workorder_detail_non_intervention` renseigné = déplacement sans réparation effective.
- **In progress en pause exclus du bucket current** : `workorder_raison_mise_en_pause IS NOT NULL` neutralise le flag `is_current_intervention`. Filtre ciblé bucket — les Closed historiquement mis en pause puis repris/clôturés (308 lignes) restent valides et passent.

## Test plan

- [x] `sqlfluff lint` clean
- [x] `dbt build` sur dev : **17/17 PASS, 0 warning** (le warning relationships sur le compte admin manager côté past_technician_id disparaît, filtré par motif/detail)
- [x] Volumétrie dev cohérente : 1823 devices, 36 past, 0 current/future (volumes In progress/Scheduled NESHU très faibles au global)
- [ ] CI dbt build green
- [ ] Validation analyste (option 1 confirmée par mail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)