### PR TITLE
Decouple file_datetime from the GCS filename

### DIFF
--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -46,10 +46,6 @@ models:
         description: "Prix d'achat unitaire"
       - name: extraction_timestamp
         description: "Timestamp d'extraction des données (TIMESTAMP)"
-      - name: file_datetime
-        description: "Date/heure du fichier source (TIMESTAMP)"
-        tests:
-          - not_null
 
   - name: fct_supply_chain__stock_yuman
     description: |

--- a/models/marts/supply_chain/fct_supply_chain__stock_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_neshu.sql
@@ -53,8 +53,7 @@ filtered_stock as (
         coalesce(st.dpa, st.purchase_price) as dpa,
         st.purchase_price,
         st.date_system,
-        st.extracted_at,
-        st.file_datetime
+        st.extracted_at
     from {{ ref('stg_oracle_neshu_gcs__stock_theorique') }} as st
     left join aggregated_labels as al
         on
@@ -96,6 +95,5 @@ select
     dpa,
     purchase_price,
     date_system,
-    extracted_at,
-    file_datetime
+    extracted_at
 from filtered_stock

--- a/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__models.yml
+++ b/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__models.yml
@@ -61,7 +61,3 @@ models:
         description: "Timestamp d'extraction des données (TIMESTAMP)"
       - name: row_count
         description: "Nombre de lignes du fichier CSV source"
-      - name: file_datetime
-        description: "Date/heure du fichier source (TIMESTAMP)"
-        tests:
-          - not_null

--- a/models/staging/oracle_neshu_gcs/stg_oracle_neshu_gcs__stock_theorique.sql
+++ b/models/staging/oracle_neshu_gcs/stg_oracle_neshu_gcs__stock_theorique.sql
@@ -23,6 +23,5 @@ select
     cast(pump as numeric) as pump,
     cast(purchase_price as numeric) as purchase_price,
     cast(extracted_at as timestamp) as extracted_at,
-    row_count,
-    parse_datetime('%Y_%m_%d_%H%M', regexp_extract(_file_name, r'(\d{4}_\d{2}_\d{2}_\d{4})')) as file_datetime
+    row_count
 from {{ source('oracle_neshu_gcs', 'ext_gcs_oracle_neshu__stock_theorique') }}


### PR DESCRIPTION
## Why

The `stg_oracle_neshu_gcs__stock_theorique` model derived `file_datetime` by regex-parsing the `_FILE_NAME` pseudo-column (`YYYY_MM_DD_HHMM`). This coupled the dbt layer to the ingestion filename format: when the ingestion job switched to a date-only filename (`stock_theorique_YYYY_MM_DD.csv`), the regex returned NULL and the `not_null` test failed for the whole file.

`file_datetime` was also **redundant** with `extracted_at` (a precise timestamp already present in the data) and was only ever carried through `fct_supply_chain__stock_neshu` — never used in any join, filter, dedup, or window.

## What

- Remove `file_datetime` from the staging model (`stg_oracle_neshu_gcs__stock_theorique`).
- Remove it from the stock mart (`fct_supply_chain__stock_neshu`) — both the CTE and final select.
- Remove its column docs + `not_null` test from both yml files.
- Downstream consumers use `extracted_at` instead.

## Validation

- No `file_datetime` / `_FILE_NAME` references remain in `models/`.
- Both affected models compile cleanly against prod BigQuery.

## ⚠️ Reviewer check before merge

`fct_supply_chain__stock_neshu` feeds **3 dashboard exposures** (`models/exposures/supply_chain.yml`). dbt can't see inside the BI tool — please confirm none of those dashboards reference a `file_datetime` field. If one does, repoint it to `extracted_at`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)