### PR TITLE
fix(neshu): remove telemetry/chargement double counting in fct_neshu__consommation

### DIFF
--- a/models/marts/neshu/fct_neshu__consommation.sql
+++ b/models/marts/neshu/fct_neshu__consommation.sql
@@ -215,8 +215,15 @@ combined_and_filtered_data as (
     where
         device_serial_number = 'AS00446'
         and company_code = 'CN1046'
-        and consumption_date < '2025-08-28'
-        and product_type in ('THE', 'CAFE CAPS', 'CHOCOLATS VAN HOUTEN')
+        and (
+            (
+                consumption_date < '2025-08-28'
+                and product_type in ('THE', 'CAFE CAPS', 'CHOCOLATS VAN HOUTEN')
+            )
+            -- Les accessoires ne sont pas couverts par la télémétrie :
+            -- toujours comptés via CHARGEMENT, sans borne de date
+            or product_type = 'ACCESSOIRES'
+        )
 
     union all
 
@@ -246,6 +253,27 @@ combined_and_filtered_data as (
                 or device_economic_model is null
             )
             and product_type = 'THE'
+        )
+        -- Miroir de l'inclusion CHARGEMENT NESPRESSO : les machines à capsules
+        -- gratuites sont comptées via CHARGEMENT, jamais via TELEMETRIE
+        and not (
+            device_brand = 'NESPRESSO'
+            and (
+                device_economic_model not in (
+                    'Participatif valeurs', 'Participatif unités', 'Payant'
+                )
+                or device_economic_model is null
+            )
+            and product_type in ('THE', 'CAFE CAPS')
+            and (
+                company_code <> 'CN1070'
+                or consumption_date >= '2025-03-01'
+            )
+        )
+        -- Miroir de l'inclusion CHARGEMENT chocolats : comptés via CHARGEMENT
+        and not (
+            device_brand in ('NESPRESSO', 'NESTLE', 'ANIMO')
+            and product_type = 'CHOCOLATS VAN HOUTEN'
         )
         and not (company_code = 'CN1071' and product_type = 'THE')
         and not (
@@ -288,9 +316,11 @@ combined_and_filtered_data as (
         )
         or (product_type = 'ACCESSOIRES')
         or (company_code = 'CN1071' and product_type = 'THE')
-        and not (
-            device_serial_number = 'AS00446' and company_code = 'CN1046'
-        )
+    )
+    -- Exclusion appliquée à toutes les branches ci-dessus (le cas AS00446
+    -- est géré par le bloc dédié en tête de union)
+    and not (
+        device_serial_number = 'AS00446' and company_code = 'CN1046'
     )
 
     union all


### PR DESCRIPTION
## Problem

NESPRESSO free machines that emit telemetry (reported: **MA00133 / MA00134**, GEMINI dispensers @ CN1003) were counted via **both** CHARGEMENT and TELEMETRIE. Prod impact: **~423k units over-counted** across **38 devices** (CN1070, CN1046, CN1003, CN1027…), all on CAFE CAPS.

**Root cause:** the chargement block includes NESPRESSO free machines (THE/CAFE CAPS), but the telemetry block had no mirror-exclusion for that branch — it only mirrored the NESTLE/ANIMO one. The model assumed NESPRESSO machines never emit telemetry.

## Fixes

1. **Telemetry block** — add the mirror-exclusion of the NESPRESSO chargement inclusion (THE/CAFE CAPS, free economic models), preserving the CN1070 cutover (telemetry < 2025-03-01, chargement after).
2. **Telemetry block** — exclude CHOCOLATS VAN HOUTEN on NESPRESSO/NESTLE/ANIMO (same structural hole; no actual overlap in prod yet, preventive).
3. **Chargement block** — fix `or`/`and not` precedence: the AS00446 exclusion only applied to the last CN1071 branch. Now applies to all branches. AS00446 ACCESSOIRES (26,400 units, previously leaking through the bug) are intentionally kept via the dedicated special-case block.

## Validation (dev_marts, full upstream rebuild)

- MA00133/MA00134: telemetry CAFE CAPS removed, CHARGEMENT only ✅
- Day-level overlap between sources (NESPRESSO free): **0 rows** ✅
- CN1070 cutover: telemetry ends 2025-02-28, chargement starts 2025-03-01 ✅
- AS00446: chargement → 2025-08-27, telemetry from 2025-09-01, accessories 26,400 = prod ✅
- `dbt build`: 20/20 pass · sqlfluff clean
- Global delta vs prod: TELEMETRIE −423k (the double counting), LIVRAISON unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)