### PR TITLE
feat(lcdp): fct_lcdp__chargement_sortie — Nayax sell-through V1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ keyfile.b64.txt
 keyfile.json
 *-keyfile.json
 *-sa-key.json
+
+# Local working files (not versioned)
+scripts/
+docs/audits/

--- a/data/reference_data/oracle_lcdp/ref_oracle_lcdp__product_group_vendable.csv
+++ b/data/reference_data/oracle_lcdp/ref_oracle_lcdp__product_group_vendable.csv
@@ -1,0 +1,11 @@
+product_group,is_vendable
+BOISSON FROIDE,true
+SNACK,true
+PRODUIT FRAIS,true
+PISCINE,false
+ACCESSOIRE,false
+BOISSON CHAUDE,false
+NESPRESSO,false
+CAFE GRAIN,false
+EMBALLAGE,false
+THE NUNSHEN,false

--- a/data/schema.yml
+++ b/data/schema.yml
@@ -682,3 +682,22 @@ seeds:
           - accepted_values:
               arguments:
                 values: ['Actif', 'Inactif']
+
+#### REFERENCE POUR MODEL ORACLE_LCDP  ####
+
+  - name: ref_oracle_lcdp__product_group_vendable
+    description: "Classification des groupes de produits LCDP : article vendu tel quel (ressort comme une vente) vs intrant/consommable. Clé de filtre pour fct_lcdp__chargement_sortie. Jointure sur product_group trimé."
+    config:
+      column_types:
+        product_group: STRING
+        is_vendable: BOOLEAN
+    columns:
+      - name: product_group
+        description: "Groupe de produit (dim_lcdp__product.product_group, trimé)"
+        tests:
+          - not_null
+          - unique
+      - name: is_vendable
+        description: "TRUE si le groupe correspond à un article vendu à l'unité (comparable au nombre de ventes télémétrie), FALSE pour les intrants/consommables"
+        tests:
+          - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -70,6 +70,18 @@ models:
         description: "Quantité télémétrique (toujours 1 par convention métier)"
         data_type: int64
 
+      - name: sale_unit_price_eur
+        description: "Prix de vente unitaire HT remonté par Nayax sur l'event (€). Rempli à ~100% sur DA FROID, NULL sur autres catégories."
+        data_type: float64
+
+      - name: sale_amount_net_eur
+        description: "Montant de vente net HT (€) — équivalent à sale_unit_price_eur car telemetry_quantity = 1."
+        data_type: float64
+
+      - name: sale_amount_net_tax_eur
+        description: "Montant de vente net TTC (€) — inclut la TVA applicable au produit."
+        data_type: float64
+
       - name: updated_at
         description: "Timestamp de dernière modification (pour incrément)"
         data_type: timestamp

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__telemetry_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__telemetry_tasks.sql
@@ -54,6 +54,11 @@ telemetry_tasks as (
         -- Métrique business
         cast(1 as int64) as telemetry_quantity,  -- 1 Tâche = 1 unité de télémétrie
 
+        -- Valorisation Nayax (prix de vente remonté par la télémétrie sur l'event)
+        thp.sale_unit_price as sale_unit_price_eur,
+        thp.sale_amount_net as sale_amount_net_eur,
+        thp.sale_amount_net_tax as sale_amount_net_tax_eur,
+
         -- Timestamps techniques pour l'incrément
         t.updated_at,
         t.created_at,

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -244,3 +244,110 @@ models:
 
       - name: updated_at
         description: "Date de dernière modification"
+
+  # CHARGEMENT vs SORTIE (taux d'écoulement Nayax)
+  - name: fct_lcdp__chargement_sortie
+    description: |
+      [QUOI MÉTIER] Taux d'écoulement hebdomadaire des machines LCDP télémétrées Nayax — comparaison entrées (chargements vendables) vs sorties (events Nayax PLANIFIED_SAILS) en volume et en €.
+      [COMMENT CONSTRUITE] Périmètre filtré sur dim_lcdp__device.audit_type='1- AUDIT TELEMETRIE (NAYAX)' AND device_category='DA FROID'. Entrées issues de int_oracle_lcdp__chargement_tasks filtrées sur load_type_code='LOADING' (les REMOVING = retraits de stock sont exclus pour ne pas fausser le flux d'entrée), jointes à dim_lcdp__product et au seed ref_oracle_lcdp__product_group_vendable (filtre is_vendable=true → 3 groupes SNACK / BOISSON FROIDE / PRODUIT FRAIS). Sorties issues de int_oracle_lcdp__telemetry_tasks (1 event = 1 vente, sale_amount_net remonté par Nayax). Agrégation par device × semaine ISO (lundi), FULL OUTER JOIN entre les deux flux. Rolling 4 semaines (W-3 à W incluse) calculé via window function bornée à 21 jours.
+      [GRAIN] 1 ligne par device_id × week_start_date.
+      [NOTES] Hors périmètre V1 : DA CHAUD, DA SEMI-AUTO et BORNE/BROYEUR (chargement non commensurable aux events). Backfill depuis 2025-01-01. taux_ecoulement_volume = NULL si chargement = 0 (vidange de stock historique attendue). taux_marge_brute_apparent = CA HT sortie / coût d'achat chargement, valeur > 1 attendue (marge brute distributeur typique ≈ 2,0-2,1×). Les chargements de type REMOVING (retraits de stock pour audit/fin de contrat) sont exclus pour ne pas fausser les entrées — leur traçabilité reste accessible directement via int_oracle_lcdp__chargement_tasks.
+    config:
+      contract:
+        enforced: false
+    columns:
+      - name: device_id
+        description: "Identifiant de la machine (FK vers dim_lcdp__device)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__device')
+                field: device_id
+
+      - name: week_start_date
+        description: "Lundi de la semaine ISO (date_trunc week monday) de la mesure"
+        tests:
+          - not_null
+
+      - name: qty_vendable_chargee
+        description: "Quantité totale chargée sur la semaine, restreinte aux product_group vendables"
+        tests:
+          - not_null
+
+      - name: cout_achat_chargement_eur
+        description: "Coût d'achat total du chargement vendable de la semaine (€ HT, basé sur purchase_unit_price latest)"
+        tests:
+          - not_null
+
+      - name: nb_chargements
+        description: "Nombre de tâches distinctes de chargement sur la semaine"
+        tests:
+          - not_null
+
+      - name: nb_ventes
+        description: "Nombre d'events télémétrie Nayax (= nombre de ventes) sur la semaine"
+        tests:
+          - not_null
+
+      - name: ca_ht_sortie_eur
+        description: "Chiffre d'affaires HT remonté par les events Nayax sur la semaine (€)"
+        tests:
+          - not_null
+
+      - name: ca_ttc_sortie_eur
+        description: "Chiffre d'affaires TTC remonté par les events Nayax sur la semaine (€)"
+        tests:
+          - not_null
+
+      - name: taux_ecoulement_volume_hebdo
+        description: "Ratio nb_ventes / qty_vendable_chargee sur la semaine. NULL si chargement = 0."
+
+      - name: taux_marge_brute_apparent_hebdo
+        description: "Ratio ca_ht_sortie_eur / cout_achat_chargement_eur sur la semaine. NULL si chargement = 0. Indicateur de marge brute apparente (coefficient distributeur)."
+
+      - name: marge_brute_apparente_hebdo_eur
+        description: "Différence ca_ht_sortie_eur - cout_achat_chargement_eur sur la semaine (€)"
+
+      - name: qty_vendable_chargee_4wk
+        description: "Quantité chargée vendable cumulée sur la fenêtre W-3 à W (4 semaines glissantes)"
+
+      - name: cout_achat_chargement_4wk_eur
+        description: "Coût d'achat chargement cumulé sur la fenêtre W-3 à W (€)"
+
+      - name: nb_ventes_4wk
+        description: "Nombre d'events télémétrie cumulé sur la fenêtre W-3 à W"
+
+      - name: ca_ht_sortie_4wk_eur
+        description: "CA HT cumulé sur la fenêtre W-3 à W (€)"
+
+      - name: ca_ttc_sortie_4wk_eur
+        description: "CA TTC cumulé sur la fenêtre W-3 à W (€)"
+
+      - name: taux_ecoulement_volume_4wk
+        description: "Ratio nb_ventes_4wk / qty_vendable_chargee_4wk. Lisse les décalages chargement → vente."
+
+      - name: taux_marge_brute_apparent_4wk
+        description: "Ratio ca_ht_sortie_4wk_eur / cout_achat_chargement_4wk_eur."
+
+      - name: marge_brute_apparente_4wk_eur
+        description: "Marge brute apparente cumulée sur la fenêtre W-3 à W (€)"
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - device_id
+              - week_start_date
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "qty_vendable_chargee >= 0"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "cout_achat_chargement_eur >= 0"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "nb_ventes >= 0"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "ca_ht_sortie_eur >= 0"

--- a/models/marts/lcdp/fct_lcdp__chargement_sortie.sql
+++ b/models/marts/lcdp/fct_lcdp__chargement_sortie.sql
@@ -1,0 +1,121 @@
+{{
+    config(
+        materialized='table',
+        partition_by={'field': 'week_start_date', 'data_type': 'date'},
+        cluster_by=['device_id']
+    )
+}}
+
+with devices_perimeter as (
+    select device_id
+    from {{ ref('dim_lcdp__device') }}
+    where
+        audit_type = '1- AUDIT TELEMETRIE (NAYAX)'
+        and device_category = 'DA FROID'
+),
+
+vendable_groups as (
+    select trim(product_group) as product_group
+    from {{ ref('ref_oracle_lcdp__product_group_vendable') }}
+    where is_vendable
+),
+
+chargement_weekly as (
+    select
+        c.device_id,
+        date_trunc(date(c.task_start_date), week (monday)) as week_start_date,
+        sum(c.load_quantity) as qty_vendable_chargee,
+        sum(c.load_valuation) as cout_achat_chargement_eur,
+        count(distinct c.task_id) as nb_chargements
+    from {{ ref('int_oracle_lcdp__chargement_tasks') }} as c
+    inner join {{ ref('dim_lcdp__product') }} as p
+        on c.product_id = p.product_id
+    inner join vendable_groups as v
+        on trim(p.product_group) = v.product_group
+    where
+        c.device_id in (select dp.device_id from devices_perimeter as dp)
+        and date(c.task_start_date) >= date('2025-01-01')
+        and c.load_type_code = 'LOADING'
+    group by 1, 2
+),
+
+telemetry_weekly as (
+    select
+        t.device_id,
+        date_trunc(date(t.task_start_date), week (monday)) as week_start_date,
+        count(*) as nb_ventes,
+        sum(t.sale_amount_net_eur) as ca_ht_sortie_eur,
+        sum(t.sale_amount_net_tax_eur) as ca_ttc_sortie_eur
+    from {{ ref('int_oracle_lcdp__telemetry_tasks') }} as t
+    where
+        t.device_id in (select dp.device_id from devices_perimeter as dp)
+        and date(t.task_start_date) >= date('2025-01-01')
+    group by 1, 2
+),
+
+joined as (
+    select
+        coalesce(c.device_id, t.device_id) as device_id,
+        coalesce(c.week_start_date, t.week_start_date) as week_start_date,
+        coalesce(c.qty_vendable_chargee, 0) as qty_vendable_chargee,
+        coalesce(c.cout_achat_chargement_eur, 0) as cout_achat_chargement_eur,
+        coalesce(c.nb_chargements, 0) as nb_chargements,
+        coalesce(t.nb_ventes, 0) as nb_ventes,
+        coalesce(t.ca_ht_sortie_eur, 0) as ca_ht_sortie_eur,
+        coalesce(t.ca_ttc_sortie_eur, 0) as ca_ttc_sortie_eur
+    from chargement_weekly as c
+    full outer join telemetry_weekly as t
+        on
+            c.device_id = t.device_id
+            and c.week_start_date = t.week_start_date
+),
+
+with_rolling as (
+    select
+        device_id,
+        week_start_date,
+        qty_vendable_chargee,
+        cout_achat_chargement_eur,
+        nb_chargements,
+        nb_ventes,
+        ca_ht_sortie_eur,
+        ca_ttc_sortie_eur,
+
+        sum(qty_vendable_chargee) over wk4 as qty_vendable_chargee_4wk,
+        sum(cout_achat_chargement_eur) over wk4 as cout_achat_chargement_4wk_eur,
+        sum(nb_ventes) over wk4 as nb_ventes_4wk,
+        sum(ca_ht_sortie_eur) over wk4 as ca_ht_sortie_4wk_eur,
+        sum(ca_ttc_sortie_eur) over wk4 as ca_ttc_sortie_4wk_eur
+
+    from joined
+    window wk4 as (
+        partition by device_id
+        order by unix_date(week_start_date)
+        range between 21 preceding and current row
+    )
+)
+
+select
+    device_id,
+    week_start_date,
+
+    qty_vendable_chargee,
+    cout_achat_chargement_eur,
+    nb_chargements,
+    nb_ventes,
+    ca_ht_sortie_eur,
+    ca_ttc_sortie_eur,
+    safe_divide(nb_ventes, qty_vendable_chargee) as taux_ecoulement_volume_hebdo,
+    safe_divide(ca_ht_sortie_eur, cout_achat_chargement_eur) as taux_marge_brute_apparent_hebdo,
+    ca_ht_sortie_eur - cout_achat_chargement_eur as marge_brute_apparente_hebdo_eur,
+
+    qty_vendable_chargee_4wk,
+    cout_achat_chargement_4wk_eur,
+    nb_ventes_4wk,
+    ca_ht_sortie_4wk_eur,
+    ca_ttc_sortie_4wk_eur,
+    safe_divide(nb_ventes_4wk, qty_vendable_chargee_4wk) as taux_ecoulement_volume_4wk,
+    safe_divide(ca_ht_sortie_4wk_eur, cout_achat_chargement_4wk_eur) as taux_marge_brute_apparent_4wk,
+    ca_ht_sortie_4wk_eur - cout_achat_chargement_4wk_eur as marge_brute_apparente_4wk_eur
+
+from with_rolling


### PR DESCRIPTION
## Summary

V1 du suivi taux d'écoulement pour les machines télémétrées Nayax du parc LCDP. Compare les chargements vendables (entrées) aux ventes Nayax (sorties) au grain `device × semaine ISO`, en **volume** et en **€**, avec lissage 4 semaines glissantes.

**Périmètre V1** : DA FROID × Nayax (~166 devices). DA CHAUD hors scope (chargement en kg de grains non commensurable aux events de vente — V2 nécessite spec métier dose/grammage).

## Changements principaux

### Nouveau mart `fct_lcdp__chargement_sortie`
- Grain : `(device_id, week_start_date)`
- Entrées : `int_oracle_lcdp__chargement_tasks` filtrées sur `load_type_code='LOADING'` (REMOVING exclu pour ne pas fausser le flux d'entrée) × seed `ref_oracle_lcdp__product_group_vendable` (3 groupes : SNACK / BOISSON FROIDE / PRODUIT FRAIS)
- Sorties : `int_oracle_lcdp__telemetry_tasks` (1 event = 1 PLANIFIED_SAILS = 1 vente, validé statistiquement médiane 0,96)
- Métriques hebdo + rolling 4 sem : volume, CA HT, marge brute apparente
- Partition `week_start_date`, cluster `device_id`
- Backfill depuis 2025-01-01

### Enrichissement `int_oracle_lcdp__telemetry_tasks`
Exposition de 3 colonnes prix Nayax remontées depuis `task_has_product` :
- `sale_unit_price_eur` (prix unitaire HT)
- `sale_amount_net_eur` (CA HT par event)
- `sale_amount_net_tax_eur` (CA TTC par event)

Validation : 99,99 % des events DA FROID Nayax ont `sale_unit_price` rempli.

### Nouveau seed `ref_oracle_lcdp__product_group_vendable`
Classification des 10 product_groups LCDP, 3 marqués `is_vendable=true` (correspondent à ~99,9 % du volume DA FROID).

### Tests
- `unique_combination_of_columns(device_id, week_start_date)`
- `not_null` sur device_id, week_start_date, métriques de base
- `relationships` device_id → `dim_lcdp__device`
- `expression_is_true` : qty / cost / ventes / CA ≥ 0

## Indicateurs clés observés (Jan-May 2026, 164 devices actifs)

| Indicateur | Valeur |
|---|---|
| Médiane taux d'écoulement volume (rolling 4w) | **0,96** |
| Médiane marge brute apparente | **2,09×** |
| Marge globale parc | **2,08×** |
| CA HT total 5 mois | **439 327 €** |

## Test plan

- [x] CI passe (`dbt build` en dev)
- [ ] Une fois mergé, charger le seed en prod : `dbt seed -s ref_oracle_lcdp__product_group_vendable -t prod`
- [ ] Full-refresh requis sur `int_oracle_lcdp__telemetry_tasks` (modèle incremental modifié) : `dbt run -s int_oracle_lcdp__telemetry_tasks --full-refresh -t prod`
- [ ] Build mart en prod : `dbt build -s fct_lcdp__chargement_sortie -t prod`
- [ ] Vérifier volumétrie attendue : ~10k lignes, 166 devices, ~73 semaines de backfill
- [ ] Sanity check médiane volume sur prod : doit retomber proche de 0,95-1,00

## Notes

- `.gitignore` mis à jour pour exclure `scripts/` et `docs/audits/` (travail local non versionné)
- Documentation détaillée et analyses métier conservées en local pour le moment
- Roadmap V1.1 envisagée : intégrer indicateurs cadence (`nb_passages_appro_4wk`, `cadence_moy_jours`, cumul chargement/ventes) après validation métier

🤖 Generated with [Claude Code](https://claude.com/claude-code)