### PR TITLE
Add oracle_lcdp_gcs staging for LCDP stock theorique

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ Le projet integre **9 sources** couvrant l'ensemble des operations EVS :
 | **mssql_sage** | MSSQL Sage | Comptabilite : ecritures, comptes tiers, collaborateurs |
 | **gac** | SFTP CSV | Assurance flotte, sinistres vehicules |
 | **yuman_gcs** | GCS JSON | Stock theorique Yuman |
-| **oracle_neshu_gcs** | GCS CSV | Stock theorique Oracle |
+| **oracle_neshu_gcs** | GCS CSV | Stock theorique Oracle NESHU |
+| **oracle_lcdp_gcs** | GCS CSV | Stock theorique Oracle LCDP |
 
 > Les sources suffixees `_gcs` (et `nesp_tech`, `nesp_co`) transitent par GCS avant d'etre lues par dbt via table externe BigQuery.
 > C'est le cas quand Meltano ne peut pas extraire la donnee directement vers BigQuery (API specifique, Excel, PL/SQL, parsing XML…).
@@ -71,7 +72,7 @@ models/
 └── marts/            Dimensions + facts pour Power BI
 ```
 
-**6 domaines metier :** Operations (oracle_neshu), Service Technique (yuman, nesp_tech), Finance (mssql_sage), Flotte (gac), Stock (yuman_gcs, oracle_neshu_gcs), Commercial Nespresso (nesp_co - WIP).
+**6 domaines metier :** Operations (oracle_neshu), Service Technique (yuman, nesp_tech), Finance (mssql_sage), Flotte (gac), Stock (yuman_gcs, oracle_neshu_gcs, oracle_lcdp_gcs), Commercial Nespresso (nesp_co - WIP).
 
 Voir la [documentation dbt generee](https://cebrailevs.github.io/dbt_transform/) pour le detail de chaque modele, colonne et test.
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -58,6 +58,9 @@ models:
       oracle_neshu_gcs:
         +tags: ['staging', 'oracle_neshu_gcs']
 
+      oracle_lcdp_gcs:
+        +tags: ['staging', 'oracle_lcdp_gcs']
+
       mssql_sage:
         +tags: ['staging', 'mssql_sage']
 

--- a/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__models.yml
+++ b/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__models.yml
@@ -1,0 +1,63 @@
+version: 2
+
+models:
+  - name: stg_oracle_lcdp_gcs__stock_theorique
+    description: "Table staging des fichiers CSV quotidiens de stock théorique Oracle LCDP depuis GCS. Les colonnes sont typées et les dates converties en TIMESTAMP."
+    tests:
+      # Freshness fallback (tier Standard — extract quotidien 23:15 Paris, gap typique
+      # observé 23-24h ; source STRING timestamp cf. docs/freshness.md)
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: hour
+            interval: 26
+          config:
+            severity: warn
+      - dbt_expectations.expect_row_values_to_have_recent_data:
+          arguments:
+            column_name: extracted_at
+            datepart: hour
+            interval: 48
+          config:
+            severity: error
+    columns:
+      - name: id_entity
+        description: "Identifiant de l'entité (ressource ou dépôt)"
+        tests:
+          - not_null
+      - name: entity_name
+        description: "Nom de l'entité (en lowercase)"
+      - name: entity_type
+        description: "Type de l'entité (en lowercase)"
+      - name: date_system
+        description: "Date du système d'inventaire théorique (TIMESTAMP)"
+        tests:
+          - not_null
+      - name: resources_code
+        description: "Code de la ressource"
+      - name: product_code
+        description: "Code du produit"
+        tests:
+          - not_null
+      - name: product_name
+        description: "Nom du produit"
+      - name: date_inventaire
+        description: "Date du dernier inventaire réalisé (TIMESTAMP)"
+      - name: stock_inventaire
+        description: "Stock inventaire réel ou théorique à la date donnée"
+      - name: plus
+        description: "Quantité en plus par rapport au stock théorique"
+      - name: moins
+        description: "Quantité en moins par rapport au stock théorique"
+      - name: stock_at_date
+        description: "Stock théorique à la date donnée"
+      - name: dpa
+        description: "Dernier prix d'achat"
+      - name: pump
+        description: "Prix moyen pondéré ou autre information de prix"
+      - name: purchase_price
+        description: "Prix d'achat unitaire"
+      - name: extracted_at
+        description: "Timestamp d'extraction des données (TIMESTAMP)"
+      - name: row_count
+        description: "Nombre de lignes du fichier CSV source"

--- a/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__sources.yml
+++ b/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__sources.yml
@@ -1,0 +1,8 @@
+version: 2
+
+sources:
+  - name: oracle_lcdp_gcs
+    schema: "prod_raw"
+    tables:
+      - name: ext_gcs_oracle_lcdp__stock_theorique
+        description: "External table pointing to nightly CSV extracts from Oracle LCDP"

--- a/models/staging/oracle_lcdp_gcs/stg_oracle_lcdp_gcs__stock_theorique.sql
+++ b/models/staging/oracle_lcdp_gcs/stg_oracle_lcdp_gcs__stock_theorique.sql
@@ -1,0 +1,27 @@
+{{
+    config(
+        materialized = 'table',
+        partition_by = {"field": "date_system", "data_type": "timestamp"},
+        description = 'Table des stocks théoriques depuis les fichiers GCS Oracle LCDP'
+    )
+}}
+
+select
+    cast(id_entity as int64) as id_entity,
+    lower(entity_name) as entity_name,
+    lower(entity_type) as entity_type,
+    cast(date_system as timestamp) as date_system,
+    resources_code,
+    code_source as product_code,
+    code_name as product_name,
+    safe.parse_timestamp('%d/%m/%Y %H:%M', date_inventaire) as date_inventaire,
+    cast(stock_inventaire as numeric) as stock_inventaire,
+    cast(plus as numeric) as plus,
+    cast(moins as numeric) as moins,
+    cast(stock_at_date as numeric) as stock_at_date,
+    cast(dpa as numeric) as dpa,
+    cast(pump as numeric) as pump,
+    cast(purchase_price as numeric) as purchase_price,
+    cast(extracted_at as timestamp) as extracted_at,
+    row_count
+from {{ source('oracle_lcdp_gcs', 'ext_gcs_oracle_lcdp__stock_theorique') }}


### PR DESCRIPTION
## Why

Second ERP (LCDP — Les Cafés du Phare) now feeds daily stock theorique CSVs to GCS via the multi-source `ingest_oracle_stock_theorique` pipeline (`ORACLE_SOURCE=lcdp`). This PR adds the dbt side: source + staging model + tag, consumed by the new Cloud Workflow `pipeline-oracle-lcdp-stock-theorique` (23:15 Paris).

## What

- `models/staging/oracle_lcdp_gcs/` : source `oracle_lcdp_gcs` (external table `prod_raw.ext_gcs_oracle_lcdp__stock_theorique`), `stg_oracle_lcdp_gcs__stock_theorique`, yml docs + tests (mirror of the NESHU staging — same 17-column contract, no `_FILE_NAME` parsing)
- `dbt_project.yml` : folder tag `oracle_lcdp_gcs`
- `README.md` : sources table + stock domain

## Validation

- sqlfluff clean
- `dbt build --target dev -s stg_oracle_lcdp_gcs__stock_theorique` : 1 model + 5 tests PASS against the live external table (1,922 rows, file of 2026-06-05)

## Next (separate PR)

LCDP mart (`models/marts/lcdp/`) once the métier needs it — staging only for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)