### PR TITLE
feat(supply_chain): LCDP stock theorique mart + dim_lcdp__resource (+ stock_neshu refacto)

### DIFF
--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -245,6 +245,93 @@ models:
       - name: updated_at
         description: "Date de dernière modification"
 
+  # RESOURCE
+  - name: dim_lcdp__resource
+    description: |
+      [QUOI MÉTIER] Dimension ressource Oracle LCDP : personnes (PERSON) + véhicules (VEHICLE) avec hiérarchie.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp__resources, pivot des labels via stg_oracle_lcdp__label_has_resources : ISACTIVE, Fonction. Miroir de dim_neshu__resource sans l'enrichissement GEA (pas de seed côté LCDP).
+      [GRAIN] 1 ligne par resources_id.
+      [NOTES] Hiérarchie : resources_idresources d'un VEHICLE pointe vers l'ID de la PERSON associée ; NULL pour les personnes. code_status_record conservé (1=actif) sans filtre — filtrage à la volée côté BI. is_active converti en booléen.
+    columns:
+      - name: resources_id
+        description: "Identifiant unique de la ressource dans Oracle"
+        tests:
+          - not_null
+          - unique
+
+      - name: resources_type_id
+        description: "Identifiant du type de ressource (clé vers resources_type)"
+
+      - name: resources_idresources
+        description: >
+          Lien vers la ressource associée. Pour un véhicule (VEHICLE) : pointe vers l'ID de la personne (PERSON) associée.
+          Pour une personne (PERSON) : NULL.
+
+      - name: company_id
+        description: "Identifiant de l'entreprise à laquelle est rattachée la ressource"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__company')
+                field: company_id
+
+      - name: company_storehouse_id
+        description: "Identifiant de l'entreprise entrepôt associée à la ressource"
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__company')
+                field: company_id
+
+      - name: location_id
+        description: "Identifiant de la localisation de la ressource"
+
+      - name: resources_code
+        description: "Code métier de la ressource (ex : code personne ou immatriculation véhicule)"
+        tests:
+          - not_null
+
+      - name: resources_name
+        description: "Nom de la ressource"
+
+      - name: resources_type
+        description: "Type de ressource : PERSON (personne) ou VEHICLE (véhicule)"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['PERSON', 'VEHICLE']
+
+      - name: is_active
+        description: >
+          Indique si la ressource est active (label ISACTIVE).
+          Converti en booléen : TRUE si 'yes', FALSE sinon.
+        tests:
+          - not_null
+
+      - name: fonction
+        description: "Fonction de la personne (label Fonction, ex : APPRO, DIRECT). NULL pour les véhicules."
+
+      - name: cost
+        description: "Coût associé à la ressource"
+
+      - name: arrival
+        description: "Date d'arrivée de la ressource dans l'entreprise"
+
+      - name: departure
+        description: "Date de départ de la ressource (NULL si toujours en poste/en service)"
+
+      - name: code_status_record
+        description: >
+          Code de statut de l'enregistrement Oracle (1 = actif, autre = inactif).
+          Non filtré dans ce modèle — utilisable côté BI pour exclure les inactifs.
+
+      - name: created_at
+        description: "Date de création de la ressource dans Oracle"
+
+      - name: updated_at
+        description: "Date de dernière mise à jour de la ressource dans Oracle"
+
   # CHARGEMENT vs SORTIE (taux d'écoulement Nayax)
   - name: fct_lcdp__chargement_sortie
     description: |

--- a/models/marts/lcdp/dim_lcdp__resource.sql
+++ b/models/marts/lcdp/dim_lcdp__resource.sql
@@ -1,0 +1,101 @@
+{{ config(materialized='table') }}
+
+with resources_labels as (
+    select
+        r.idresources as resources_id,
+        r.idresources_type as resources_type_id,
+        r.resources_idresources,
+        r.idcompany as company_id,
+        r.idcompany_storehouse as company_storehouse_id,
+        r.idlocation as location_id,
+        r.code as resources_code,
+        r.name as resources_name,
+        r.cost,
+        r.arrival,
+        r.departure,
+        r.code_status_record,
+        r.created_at,
+        r.updated_at,
+        rt.code as resources_type,
+        l.code as label_code,
+        lf.code as label_family_code
+    from {{ ref('stg_oracle_lcdp__resources') }} as r
+    inner join {{ ref('stg_oracle_lcdp__resources_type') }} as rt
+        on r.idresources_type = rt.idresources_type
+    left join {{ ref('stg_oracle_lcdp__label_has_resources') }} as lhr
+        on r.idresources = lhr.idresources and lhr.idlabel is not null
+    left join {{ ref('stg_oracle_lcdp__label') }} as l
+        on lhr.idlabel = l.idlabel
+    left join {{ ref('stg_oracle_lcdp__label_family') }} as lf
+        on l.idlabel_family = lf.idlabel_family
+    where rt.code in ('PERSON', 'VEHICLE')
+),
+
+aggregated_labels as (
+    select
+        resources_id,
+        resources_type_id,
+        resources_idresources,
+        company_id,
+        company_storehouse_id,
+        location_id,
+        resources_code,
+        resources_name,
+        resources_type,
+        cost,
+        arrival,
+        departure,
+        code_status_record,
+        created_at,
+        updated_at,
+        max(case when label_family_code = 'ISACTIVE' then label_code end) as is_active,
+        max(case when label_family_code = 'Fonction' then label_code end) as fonction
+    from resources_labels
+    group by
+        resources_id,
+        resources_type_id,
+        resources_idresources,
+        company_id,
+        company_storehouse_id,
+        location_id,
+        resources_code,
+        resources_name,
+        resources_type,
+        cost,
+        arrival,
+        departure,
+        code_status_record,
+        created_at,
+        updated_at
+)
+
+select
+    -- 🔑 Identifiants
+    resources_id,
+    resources_type_id,
+    resources_idresources,
+    company_id,
+    company_storehouse_id,
+    location_id,
+
+    -- 📇 Codes et noms
+    resources_code,
+    resources_name,
+    resources_type,
+
+    -- 🏷️ Caractéristiques
+    coalesce(lower(is_active) = 'yes', false) as is_active,
+    fonction,
+
+    -- 💰 Opérationnel
+    cost,
+    arrival,
+    departure,
+
+    code_status_record,
+
+    -- 🕒 Dates
+    created_at,
+    updated_at
+
+from aggregated_labels

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -47,6 +47,71 @@ models:
       - name: extraction_timestamp
         description: "Timestamp d'extraction des données (TIMESTAMP)"
 
+  - name: fct_supply_chain__stock_lcdp
+    description: |
+      [QUOI MÉTIER] Stock théorique journalier des produits LCDP, par véhicule et par dépôt.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_lcdp_gcs__stock_theorique (export GCS quotidien Oracle LCDP, 23h15 Paris). Aucun filtre : les 11 dépôts (entity_type='company') et tous les véhicules (entity_type='resource') sont exposés. is_active aplati depuis dim_lcdp__resource pour les véhicules (FALSE si absent de la dim), NULL pour les dépôts. is_out_of_stock dérivé de stock_at_date=0. dpa fallback sur purchase_price si manquant.
+      [GRAIN] 1 ligne par (id_entity, product_code, date_system).
+      [NOTES] Source GCS = export Oracle vers Cloud Storage, démarré le 2026-06-04 (pas d'historique antérieur). plus/moins = écarts d'inventaire vs théorique. Stocks négatifs possibles (stock théorique). date_inventaire NULL ≈ 30 % (entités/produits jamais inventoriés).
+    columns:
+      - name: id_entity
+        description: "Identifiant de l'entité (véhicule ou dépôt)"
+        tests:
+          - not_null
+      - name: entity_type
+        description: "Type de l'entité : company (dépôt) ou resource (véhicule)"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['company', 'resource']
+      - name: entity_code
+        description: "Code de la ressource (immatriculation véhicule), NULL pour les dépôts"
+      - name: entity_name
+        description: "Nom de l'entité (en lowercase)"
+      - name: is_active
+        description: "TRUE si le véhicule porte le label ISACTIVE=YES, FALSE sinon. NULL pour les dépôts"
+      - name: product_code
+        description: "Code du produit"
+        tests:
+          - not_null
+      - name: product_name
+        description: "Nom du produit"
+      - name: stock_at_date
+        description: "Stock théorique à la date donnée"
+      - name: is_out_of_stock
+        description: "Boolean qui vaut TRUE si le stock_at_date est 0 pour un produit, FALSE sinon"
+      - name: date_inventaire
+        description: "Date du dernier inventaire réalisé (TIMESTAMP), NULL si jamais inventorié"
+      - name: stock_inventaire
+        description: "Stock constaté au dernier inventaire"
+      - name: plus
+        description: "Quantité en plus par rapport au stock inventaire"
+      - name: moins
+        description: "Quantité en moins par rapport au stock inventaire"
+      - name: dpa
+        description: "Dernier prix d'achat (fallback purchase_price si manquant)"
+      - name: purchase_price
+        description: "Prix d'achat unitaire"
+      - name: date_system
+        description: "Date du système d'inventaire théorique (TIMESTAMP), colonne de partition"
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction des données (TIMESTAMP)"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - id_entity
+              - product_code
+              - date_system
+      # cohérence : le stock théorique se déduit de l'inventaire et des écarts
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              stock_at_date = coalesce(stock_inventaire, 0) + coalesce(plus, 0) - coalesce(moins, 0)
+
   - name: fct_supply_chain__stock_yuman
     description: |
       [QUOI MÉTIER] Stock journalier des pièces détachées Yuman, par technicien et par dépôt.

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -4,7 +4,7 @@ models:
   - name: fct_supply_chain__stock_neshu
     description: |
       [QUOI MÉTIER] Stock théorique journalier des produits Neshu, par véhicule roadman et par dépôt.
-      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu_gcs__stock_theorique (export GCS quotidien Oracle Neshu), filtré sur les dépôts 01–05, 10, 13 (entity_type='company') et les véhicules actifs (label ISACTIVE='YES' via stg_oracle_neshu__label_has_resources). is_out_of_stock dérivé de stock_at_date=0. dpa fallback sur purchase_price si manquant.
+      [COMMENT CONSTRUITE] Issu de stg_oracle_neshu_gcs__stock_theorique (export GCS quotidien Oracle Neshu), filtré sur les dépôts 01–05, 10, 13 (entity_type='company') et les véhicules actifs (resources_type='VEHICLE' et is_active via dim_neshu__resource). is_out_of_stock dérivé de stock_at_date=0. dpa fallback sur purchase_price si manquant.
       [GRAIN] 1 ligne par (id_entity, product_code, date_system).
       [NOTES] Source GCS = export Oracle vers Cloud Storage. plus/moins = écarts d'inventaire vs théorique.
     columns:

--- a/models/marts/supply_chain/fct_supply_chain__stock_lcdp.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_lcdp.sql
@@ -1,0 +1,33 @@
+{{ config(
+    materialized='table',
+    partition_by={
+        'field': 'date_system',
+        'data_type': 'timestamp'
+    }
+) }}
+
+select
+    st.id_entity,
+    st.entity_type,
+    st.resources_code as entity_code,
+    st.entity_name,
+    case
+        when st.entity_type = 'resource' then coalesce(r.is_active, false)
+    end as is_active,
+    st.product_code,
+    st.product_name,
+    st.stock_at_date,
+    st.stock_at_date = 0 as is_out_of_stock,
+    st.date_inventaire,
+    st.stock_inventaire,
+    st.plus,
+    st.moins,
+    coalesce(st.dpa, st.purchase_price) as dpa,
+    st.purchase_price,
+    st.date_system,
+    st.extracted_at
+from {{ ref('stg_oracle_lcdp_gcs__stock_theorique') }} as st
+left join {{ ref('dim_lcdp__resource') }} as r
+    on
+        st.id_entity = r.resources_id
+        and st.entity_type = 'resource'

--- a/models/marts/supply_chain/fct_supply_chain__stock_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_neshu.sql
@@ -6,37 +6,7 @@
     }
 ) }}
 
-with resources_labels as (
-    select
-        r.idresources,
-        r.idresources_type,
-        r.code as resources_code,
-        r.name as resources_name,
-        lh.idlabel,
-        l.code as label_code,
-        lf.code as label_family_code
-    from {{ ref('stg_oracle_neshu__resources') }} as r
-    left join {{ ref('stg_oracle_neshu__label_has_resources') }} as lh
-        on r.idresources = lh.idresources
-    left join {{ ref('stg_oracle_neshu__label') }} as l
-        on lh.idlabel = l.idlabel
-    left join {{ ref('stg_oracle_neshu__label_family') }} as lf
-        on l.idlabel_family = lf.idlabel_family
-),
-
-aggregated_labels as (
-    select
-        idresources,
-        idresources_type,
-        resources_code,
-        resources_name,
-        max(case when label_family_code = 'ISACTIVE' then label_code end) as is_active
-    from resources_labels
-    where idresources_type = 3  -- type vehicule
-    group by 1, 2, 3, 4
-),
-
-filtered_stock as (
+with filtered_stock as (
     select
         st.id_entity,
         st.entity_type,
@@ -55,9 +25,9 @@ filtered_stock as (
         st.date_system,
         st.extracted_at
     from {{ ref('stg_oracle_neshu_gcs__stock_theorique') }} as st
-    left join aggregated_labels as al
+    left join {{ ref('dim_neshu__resource') }} as r
         on
-            st.id_entity = al.idresources
+            st.id_entity = r.resources_id
             and st.entity_type = 'resource'
     where
         (
@@ -75,7 +45,8 @@ filtered_stock as (
         or
         (
             st.entity_type = 'resource'
-            and al.is_active = 'YES'
+            and r.resources_type = 'VEHICLE'  -- exclut la PERSON présente dans le stock
+            and r.is_active
         )
 )
 


### PR DESCRIPTION
## Summary

Follow-up to #110 (LCDP stock theorique staging): expose the LCDP theoretical stock in `prod_marts`, mirroring the NESHU stock mart, and align both stock facts on the dim-based `is_active` pattern.

### New models

**`dim_lcdp__resource`** — mirror of `dim_neshu__resource` (no GEA seed on the LCDP perimeter): PERSON + VEHICLE, EAV label pivot for `is_active` and `fonction`. Tests: PK `unique`/`not_null`, `relationships` to `dim_lcdp__company` (0 orphans verified in prod), `accepted_values` on `resources_type`.

**`fct_supply_chain__stock_lcdp`** — LCDP counterpart of `fct_supply_chain__stock_neshu`. Business choices (validated with owner):
- No depot whitelist: all 11 LCDP depots exposed
- No active-vehicle filter: all 16 vehicles kept, `is_active` exposed as a boolean column (NULL for depots) so residual stock on inactive vehicles stays visible in BI

Tests: `not_null` on grain columns, `accepted_values` on `entity_type`, `unique_combination_of_columns` (id_entity, product_code, date_system), `expression_is_true` on `stock_at_date = stock_inventaire + plus - moins` (holds at 100% on current data).

### Refactor

**`fct_supply_chain__stock_neshu`** — replaces the inline EAV label pivot with a left join on `dim_neshu__resource` (same pattern as `flux_neshu` / `chargement_consommation`). The explicit `resources_type = 'VEHICLE'` guard replicates the old `idresources_type = 3` restriction (one inactive PERSON entity exists in the stock data, excluded either way).

## Validation

| Check | Result |
|---|---|
| `stock_lcdp` old vs new logic (dev) | 1,922 rows both, EXCEPT DISTINCT empty both ways |
| `stock_neshu` old vs new logic (prod data) | 449,620 rows both, EXCEPT DISTINCT empty both ways |
| `dbt build` dev | 3 models, 18 tests — all PASS |
| sqlfluff | clean |

## Notes

- LCDP extract started 2026-06-04 → 1 day of history for now
- No exposure update: no Power BI report consumes these models yet
- 157 LCDP rows (8%) have both `dpa` and `purchase_price` NULL → incomplete valuation on those products

🤖 Generated with [Claude Code](https://claude.com/claude-code)