### PR TITLE
feat(technique): dim_technique__product + fct_technique__workorder_product

### DIFF
--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -358,6 +358,187 @@ models:
         description: "Code postal du site associé à la machine"
 
 
+  - name: dim_technique__product
+    description: |
+      [QUOI MÉTIER]
+      Catalogue des produits / articles Yuman (pièces détachées, consommables)
+      utilisables lors des interventions. Appelé « Article » côté métier
+      (renommage fait dans le modèle sémantique Power BI).
+
+      [COMMENT CONSTRUITE]
+      Lecture directe de `stg_yuman__products` (catalogue API Yuman), sans
+      transformation.
+
+      [GRAIN]
+      1 ligne par `product_id` (PK).
+
+      [NOTES]
+      Dimension conforme : sert aux analyses technique (consommation
+      d'articles via `fct_technique__workorder_product`) et supply_chain
+      (le stock `fct_supply_chain__stock_yuman` se joint via
+      `product_code` = `reference`). Les prix achat/vente sont les prix
+      courants Yuman, sans historique — toute valorisation est indicative.
+    columns:
+      - name: product_id
+        description: Identifiant unique du produit dans Yuman (PK).
+        tests:
+          - not_null
+          - unique
+
+      - name: product_code
+        description: >
+          Référence article (clé de jointure avec la colonne `reference` de
+          `fct_supply_chain__stock_yuman`). Rares cas null côté Yuman.
+
+      - name: product_name
+        description: Désignation de l'article.
+
+      - name: product_type
+        description: Type de produit Yuman (quasi-constant `product`).
+
+      - name: product_brand
+        description: Marque de l'article.
+
+      - name: product_unit
+        description: Unité de mesure (pièce, litre, etc.).
+
+      - name: product_purchase_price
+        description: Prix d'achat courant (sans historique).
+
+      - name: product_sale_price
+        description: Prix de vente courant (sans historique).
+
+      - name: is_active
+        description: Article actif dans le catalogue Yuman.
+
+      - name: created_at
+        description: Date de création de l'article dans Yuman.
+
+      - name: updated_at
+        description: Date de dernière modification dans Yuman.
+
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 3000
+            max_value: 20000
+          config:
+            severity: warn
+
+  - name: fct_technique__workorder_product
+    description: |
+      [QUOI MÉTIER]
+      Consommation d'articles (pièces détachées, consommables) par
+      intervention Yuman. Permet l'analyse des pièces consommées par client /
+      site / machine / technicien, et le rapprochement avec les stocks
+      théoriques (`fct_supply_chain__stock_yuman`).
+
+      [COMMENT CONSTRUITE]
+      Agrégation de `stg_yuman__workorder_products` (lignes de saisie) au
+      grain workorder x produit (`sum(quantity)`), enrichie via
+      `int_yuman__demands_workorders_enriched` (dédupliqué par workorder)
+      pour porter les FK client / site / matériel / technicien et la date
+      d'intervention.
+
+      [GRAIN]
+      1 ligne par couple (`workorder_id`, `product_id`).
+
+      [NOTES]
+      Les workorders hors flux demande (~6) ont leurs FK et `date_done` null
+      (left join sur l'intermediate). Pas de valorisation dans le fait : les
+      prix Yuman sont courants, sans historique — valoriser une consommation
+      passée au prix du jour serait faux (calcul indicatif possible côté PBI
+      via `dim_technique__product`).
+    columns:
+      - name: workorder_id
+        description: Identifiant du bon de travail (dimension dégénérée).
+        tests:
+          - not_null
+
+      - name: product_id
+        description: Identifiant de l'article consommé (FK).
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_technique__product')
+                field: product_id
+              config:
+                severity: warn
+
+      - name: material_id
+        description: Identifiant du matériel concerné par l'intervention (FK).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__material')
+                field: material_id
+              config:
+                severity: warn
+
+      - name: site_id
+        description: Identifiant du site client (FK).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__site')
+                field: site_id
+              config:
+                severity: warn
+
+      - name: client_id
+        description: Identifiant du client (FK).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__client')
+                field: client_id
+              config:
+                severity: warn
+
+      - name: technician_id
+        description: Identifiant du technicien associé (FK).
+
+      - name: partner_name
+        description: Partenaire client de l'intervention (attribut d'affichage).
+
+      - name: workorder_status
+        description: Statut du bon de travail (attribut d'affichage).
+
+      - name: date_done
+        description: >
+          Date de réalisation de l'intervention (partition). Null pour les
+          workorders hors flux demande ou non terminés.
+
+      - name: quantity
+        description: Quantité totale consommée du produit sur le workorder.
+        tests:
+          - not_null
+
+      - name: first_recorded_at
+        description: Première saisie du produit sur le workorder.
+
+      - name: last_updated_at
+        description: Dernière mise à jour d'une ligne produit du workorder.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - workorder_id
+              - product_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "quantity > 0"
+          config:
+            severity: warn
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 10000
+            max_value: 200000
+          config:
+            severity: warn
+
   - name: fct_technique__workorder_pricing
     description: |
       [QUOI MÉTIER]

--- a/models/marts/technique/dim_technique__product.sql
+++ b/models/marts/technique/dim_technique__product.sql
@@ -1,0 +1,18 @@
+{{ config(
+    materialized='table'
+) }}
+
+select
+    product_id,
+    product_code,
+    product_name,
+    product_type,
+    product_brand,
+    product_unit,
+    product_purchase_price,
+    product_sale_price,
+    is_active,
+    created_at,
+    updated_at
+
+from {{ ref('stg_yuman__products') }}

--- a/models/marts/technique/fct_technique__workorder_product.sql
+++ b/models/marts/technique/fct_technique__workorder_product.sql
@@ -1,0 +1,51 @@
+{{ config(
+    materialized='table',
+    partition_by={"field": "date_done", "data_type": "timestamp"},
+    cluster_by=['product_id', 'client_id', 'site_id']
+) }}
+
+with consumed_products as (
+    -- Grain source = ligne de saisie (workorder_product_id) : un même produit
+    -- peut être saisi plusieurs fois sur un workorder. On agrège au grain
+    -- analytique workorder x produit.
+    select
+        workorder_id,
+        product_id,
+        sum(product_quantity) as quantity,
+        min(product_created_at) as first_recorded_at,
+        max(product_updated_at) as last_updated_at
+    from {{ ref('stg_yuman__workorder_products') }}
+    group by workorder_id, product_id
+),
+
+workorders as (
+    select
+        workorder_id,
+        material_id,
+        site_id,
+        client_id,
+        technician_id,
+        partner_name,
+        workorder_status,
+        date_done
+    from {{ ref('int_yuman__demands_workorders_enriched') }}
+    where workorder_id is not null
+    qualify row_number() over (partition by workorder_id order by date_done desc) = 1
+)
+
+select
+    cp.workorder_id,
+    cp.product_id,
+    w.material_id,
+    w.site_id,
+    w.client_id,
+    w.technician_id,
+    w.partner_name,
+    w.workorder_status,
+    w.date_done,
+    cp.quantity,
+    cp.first_recorded_at,
+    cp.last_updated_at
+from consumed_products as cp
+left join workorders as w
+    on cp.workorder_id = w.workorder_id


### PR DESCRIPTION
## Objectif

Permettre l'analyse des articles / pièces consommés lors des interventions Yuman, et préparer le rapprochement avec les stocks théoriques (`fct_supply_chain__stock_yuman`).

## Modèles

**`dim_technique__product`** — catalogue des articles Yuman (lecture directe de `stg_yuman__products`, 1 ligne par `product_id`, ~4 000 produits). Dimension conforme : sert au fait technique ci-dessous **et** au stock supply_chain via `product_code` = `reference` (1 208/1 209 références du stock matchent). Affichage métier « Article » à gérer dans le modèle sémantique PBI.

**`fct_technique__workorder_product`** — consommation d'articles par intervention :
- Grain : 1 ligne par (`workorder_id`, `product_id`) — les lignes de saisie source sont agrégées (`sum(quantity)`, 18 cas de doubles saisies absorbés)
- FK étoile portées par le fait depuis `int_yuman__demands_workorders_enriched` : `client_id`, `site_id`, `material_id`, `technician_id` + `date_done` → croisement avec les coûts d'intervention via les dims partagées, sans join fait-à-fait
- Dedup défensif de l'intermediate (1 ligne par workorder, 0 doublon actuel) : protège contre un fan-out si un workorder se rattachait à 2 demandes
- Partition `date_done` (timestamp), cluster `product_id` / `client_id` / `site_id`
- Workorders hors flux demande (~6) : FK et `date_done` null, documenté dans le YAML

## Profil données (prod)

- 16 037 lignes / 8 551 workorders (déc. 2023 → auj.), couverture 100 % du staging
- 0 FK orpheline produit, 0 quantité nulle ou négative
- Pas de valorisation dans le fait : prix Yuman courants sans historique (calcul indicatif possible côté PBI via la dim)

## Tests & validation

- Dim : `unique` + `not_null` PK, row count 3 000–20 000 (warn)
- Fait : `unique_combination(workorder_id, product_id)`, `not_null` (workorder_id, product_id, quantity), `relationships` sur les 4 FK (warn), `quantity > 0` (warn), row count 10 000–200 000 (warn)
- Build dev : 27/27 PASS, 0 warn · SQLFluff clean

Pas d'exposure pour l'instant — à déclarer quand un rapport PBI consommera ces tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)