### PR TITLE
feat(neshu): expose current_date_started on machine_appro_intervention

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1242,6 +1242,8 @@ models:
         description: Titre du workorder en cours.
       - name: current_intervention_report
         description: Rapport (peut être vide si pas encore renseigné).
+      - name: current_date_started
+        description: Date de démarrage de l'intervention en cours (date_started Yuman). Renseignée dès que le technicien démarre l'intervention, contrairement à current_date_done qui reste NULL tant que l'intervention n'est pas terminée.
       - name: current_date_done
         description: Date done (normalement NULL si en cours, valeur si transition).
 

--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -95,6 +95,7 @@ yuman_workorders as (
         -- Statuts (pour les flags)
         any_value(demand_status) as demand_status,
         any_value(workorder_status) as intervention_status,
+        max(date_started) as date_started,
         max(date_done) as date_done,
         min(date_planned) as date_planned,
 
@@ -208,6 +209,7 @@ current_ranked as (
         demand_category_name,
         intervention_title,
         intervention_report,
+        date_started,
         date_done,
         row_number() over (
             partition by serial_clean
@@ -229,6 +231,7 @@ current_inter as (
         demand_category_name as current_demand_category_name,
         intervention_title as current_intervention_title,
         intervention_report as current_intervention_report,
+        date_started as current_date_started,
         date_done as current_date_done
     from current_ranked
     where rn = 1
@@ -322,6 +325,7 @@ select
     ci.current_demand_category_name,
     ci.current_intervention_title,
     ci.current_intervention_report,
+    ci.current_date_started,
     ci.current_date_done,
 
     -- Bucket : prochaine intervention planifiée


### PR DESCRIPTION
## Contexte

Le fait `fct_neshu__machine_appro_intervention` exposait `current_date_done` (date de fin d'intervention, NULL tant que non terminée) mais pas la date de **démarrage**. Cette PR ajoute `current_date_started` pour suivre les interventions dès leur lancement.

## Changement

Propagation de `date_started` (source Yuman) à travers les CTE :
`yuman_workorders` (`max(date_started)`) → `current_ranked` → `current_inter` (`current_date_started`) → select final.

- `models/marts/neshu/fct_neshu__machine_appro_intervention.sql` : +`date_started` / `current_date_started`
- `_neshu__marts_models.yml` : colonne `current_date_started` documentée

## Validation

- ✅ `sqlfluff lint` clean
- ✅ `dbt build --select fct_neshu__machine_appro_intervention` sur dev : **PASS=17, ERROR=0**
- ✅ Branche rebasée sur `master` à jour (#115 inclus), pas de conflit

🤖 Generated with [Claude Code](https://claude.com/claude-code)