### PR TITLE
feat(supply_chain): taux de disponibilité mensuel par article et dépôt

### DIFF
--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -134,6 +134,61 @@ models:
         tests:
           - not_null
 
+  - name: fct_supply_chain__disponibilite_article_neshu_mensuel
+    description: |
+      [QUOI MÉTIER] Taux de disponibilité mensuel des articles dans les dépôts Neshu : part des jours du mois où l'article était en stock (> 0).
+      [COMMENT CONSTRUITE] Agrégation mensuelle de fct_supply_chain__stock_neshu filtré sur les dépôts (entity_type='company'). jours_observes = nb de jours où le couple dépôt/article est référencé dans les données ; jours_disponibles = nb de jours référencés où is_out_of_stock=false. taux = jours_disponibles / jours_observes. mois = date_trunc à month.
+      [GRAIN] 1 ligne par (mois, dépôt, article).
+      [NOTES] Le taux est calculé depuis le 1er référencement de l'article dans le dépôt (dénominateur = jours référencés), pas sur le mois calendaire : un article arrivé en cours de mois et jamais en rupture affiche 100 %, sans pénalité pour les jours antérieurs à son arrivée. Le mois en cours est partiel (taux à interpréter avec jours_observes). Clé métier = product_code ; entity_name/entity_code/product_name reflètent le libellé du snapshot le plus récent du mois (un article peut être renommé en cours de mois sans changer de code).
+    columns:
+      - name: mois
+        description: "Premier jour du mois (DATE)"
+        tests:
+          - not_null
+      - name: company_id
+        description: "Identifiant du dépôt (FK vers dim_neshu__company)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
+              config:
+                severity: warn
+      - name: entity_code
+        description: "Code du dépôt"
+      - name: entity_name
+        description: "Nom du dépôt (en lowercase)"
+      - name: product_code
+        description: "Code du produit"
+        tests:
+          - not_null
+      - name: product_name
+        description: "Nom du produit"
+      - name: jours_observes
+        description: "Nombre de jours du mois où le couple dépôt/article est référencé dans les données"
+      - name: jours_disponibles
+        description: "Nombre de jours référencés du mois où l'article était en stock (is_out_of_stock=false)"
+      - name: taux_disponibilite_pct
+        description: "Taux de disponibilité mensuel en % : jours_disponibles / jours_observes * 100"
+        tests:
+          - not_null
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois
+              - company_id
+              - product_code
+      # cohérence : on ne peut pas être disponible plus de jours que de jours observés
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "jours_disponibles <= jours_observes"
+      # cohérence : un taux est un pourcentage
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "taux_disponibilite_pct between 0 and 100"
+
   - name: fct_supply_chain__flux_neshu
     description: |
       [QUOI MÉTIER] Flux supply Neshu mensuels (stocks dépôts/véhicules + réceptions/livraisons/chargements).

--- a/models/marts/supply_chain/fct_supply_chain__disponibilite_article_neshu_mensuel.sql
+++ b/models/marts/supply_chain/fct_supply_chain__disponibilite_article_neshu_mensuel.sql
@@ -1,0 +1,33 @@
+{{ config(
+    materialized='table',
+    cluster_by=['company_id']
+) }}
+
+with monthly as (
+    select
+        date_trunc(date(date_system), month) as mois,
+        id_entity as company_id,
+        product_code,
+        any_value(entity_code having max date_system) as entity_code,
+        any_value(entity_name having max date_system) as entity_name,
+        any_value(product_name having max date_system) as product_name,
+        count(distinct date(date_system)) as jours_observes,
+        count(distinct case
+            when is_out_of_stock = false then date(date_system)
+        end) as jours_disponibles
+    from {{ ref('fct_supply_chain__stock_neshu') }}
+    where entity_type = 'company'
+    group by 1, 2, 3
+)
+
+select
+    mois,
+    company_id,
+    entity_code,
+    entity_name,
+    product_code,
+    product_name,
+    jours_observes,
+    jours_disponibles,
+    round(safe_divide(jours_disponibles, jours_observes) * 100, 1) as taux_disponibilite_pct
+from monthly


### PR DESCRIPTION
## Quoi

Nouveau fait agrégé **`fct_supply_chain__disponibilite_article_neshu_mensuel`** : taux de disponibilité mensuel des articles dans les dépôts Neshu.

**Grain : 1 ligne par (mois, dépôt, article).** `taux_disponibilite_pct` = % des jours référencés du mois où l'article était en stock (> 0).

Répond à une demande métier (nouveau dashboard + correction du rapport 360° articles) : démontrer chiffres à l'appui que les dépôts ne sont pas « toujours vides » (disponibilité moyenne 82–100 % selon le dépôt sur mai).

## Décisions de modélisation

- **Construit par rollup** de `fct_supply_chain__stock_neshu` filtré sur `entity_type='company'` (agrégat sur un seul fait, pas de fact-to-fact join).
- **Dénominateur = jours où l'article est référencé** dans le dépôt, pas les jours calendaires (validé métier) : un article arrivé en cours de mois et jamais en rupture affiche 100 %, sans pénalité pour les jours antérieurs à son référencement.
- **Numérateur** en `count(distinct jour disponible)`, symétrique au dénominateur et insensible à un éventuel doublon d'extraction.
- **`product_code` = clé métier** ; libellés (`product_name`/`entity_*`) pris sur le snapshot le plus récent du mois (un article peut être renommé sans changer de code — cas réel `MATEPOMPOTE90` en janvier).
- `id_entity` renommé en **`company_id`** (FK propre vers `dim_neshu__company`, la table étant company-only).
- Produit laissé en **dimension dégénérée** (pas de FK vers `dim_neshu__product`) — pas de besoin d'attributs produit aujourd'hui.

## Tests (9/9 verts sur dev)

- `unique_combination_of_columns` (mois, company_id, product_code)
- `not_null` sur mois, company_id, product_code, taux
- `relationships` company_id → `dim_neshu__company` (warn)
- `expression_is_true` : `jours_disponibles <= jours_observes` et `taux between 0 and 100`

## Hors scope

- Exposure : à ajouter quand le rapport PBI aura un nom.
- Lien `product_id` (sur stock_neshu, + qualification des 52 codes absents de la dim) : PR dédiée si le métier demande des attributs produit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)