### PR TITLE
feat(technique): consommation d'articles par intervention — dim_technique__product + fct_technique__workorder_product

### DIFF
--- a/models/intermediate/yuman/_yuman__intermediate_models.yml
+++ b/models/intermediate/yuman/_yuman__intermediate_models.yml
@@ -66,6 +66,16 @@ models:
         description: Raison de mise en pause du bon de travail.
       - name: workorder_explication_mise_en_pause
         description: Explications détaillées concernant la mise en pause.
+      - name: is_workorder_paused
+        description: >
+          True si l'intervention est en pause (au moins un des champs
+          workorder_raison_mise_en_pause / workorder_explication_mise_en_pause
+          renseigné).
+      - name: is_workorder_not_done
+        description: >
+          True si l'intervention n'a pas été réalisée (au moins un des champs
+          workorder_motif_non_intervention / workorder_detail_non_intervention
+          renseigné). Recoupe la logique de non-facturation du mart pricing.
       - name: workorder_necessite_intervenir
         description: Indique si une intervention est nécessaire.
       - name: workorder_si_non_pourquoi

--- a/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
+++ b/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
@@ -158,6 +158,21 @@ select
     wo.workorder_detail_non_intervention,
     wo.workorder_raison_mise_en_pause,
     wo.workorder_explication_mise_en_pause,
+
+    -- Intervention mise en pause : au moins un des deux champs de pause renseigne
+    coalesce(
+        trim(wo.workorder_raison_mise_en_pause) != ''
+        or trim(wo.workorder_explication_mise_en_pause) != '',
+        false
+    ) as is_workorder_paused,
+
+    -- Intervention non realisee : au moins un des deux champs de non-intervention renseigne
+    coalesce(
+        trim(wo.workorder_motif_non_intervention) != ''
+        or trim(wo.workorder_detail_non_intervention) != '',
+        false
+    ) as is_workorder_not_done,
+
     wo.workorder_necessite_intervenir,
     wo.workorder_si_non_pourquoi,
     wo.date_planned,

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -455,6 +455,11 @@ models:
         tests:
           - not_null
 
+      - name: demand_id
+        description: >
+          Identifiant de la demande d'intervention rattachée (dimension
+          dégénérée). Null pour les interventions hors flux demande.
+
       - name: product_id
         description: Identifiant de l'article consommé (FK).
         tests:
@@ -502,8 +507,42 @@ models:
       - name: partner_name
         description: Partenaire client de l'intervention (attribut d'affichage).
 
+      - name: workorder_number
+        description: Numéro lisible du bon de travail (drill vers Yuman).
+
+      - name: workorder_type
+        description: >
+          Type d'intervention : Reactive (curatif) / Preventive /
+          Installation. Axe d'analyse principal de la consommation de pièces.
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Reactive', 'Preventive', 'Installation']
+              config:
+                severity: warn
+
+      - name: workorder_category
+        description: >
+          Catégorie libre du bon de travail (complément de workorder_type,
+          plus granulaire mais non normalisé).
+
       - name: workorder_status
         description: Statut du bon de travail (attribut d'affichage).
+
+      - name: demand_category_name
+        description: Catégorie métier de la demande d'intervention.
+
+      - name: demand_status
+        description: >
+          Statut de la demande rattachée. Toujours « Accepted » sur les
+          interventions du flux normal ; null pour les interventions hors
+          flux demande (contrôle qualité : permet d'isoler ces cas).
+
+      - name: is_workorder_not_done
+        description: >
+          True si l'intervention n'a pas été réalisée (motif/détail de
+          non-intervention renseigné). Des pièces consommées sur un workorder
+          à true sont une anomalie à surveiller.
 
       - name: date_done
         description: >

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -472,7 +472,10 @@ models:
                 severity: warn
 
       - name: material_id
-        description: Identifiant du matériel concerné par l'intervention (FK).
+        description: >
+          Identifiant du matériel concerné par l'intervention (FK).
+          Nullable : null quand le workorder n'a pas de machine rattachée
+          (interventions hors flux demande). Pas de not_null volontairement.
         tests:
           - relationships:
               arguments:
@@ -482,7 +485,9 @@ models:
                 severity: warn
 
       - name: site_id
-        description: Identifiant du site client (FK).
+        description: >
+          Identifiant du site client (FK). Nullable (idem material_id :
+          interventions hors flux demande).
         tests:
           - relationships:
               arguments:
@@ -492,7 +497,9 @@ models:
                 severity: warn
 
       - name: client_id
-        description: Identifiant du client (FK).
+        description: >
+          Identifiant du client (FK). Nullable (idem material_id :
+          interventions hors flux demande).
         tests:
           - relationships:
               arguments:
@@ -502,7 +509,16 @@ models:
                 severity: warn
 
       - name: technician_id
-        description: Identifiant du technicien associé (FK).
+        description: >
+          Identifiant du technicien associé (FK vers dim_technique__technician,
+          PK user_id). Nullable pour les interventions hors flux demande.
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__technician')
+                field: user_id
+              config:
+                severity: warn
 
       - name: partner_name
         description: Partenaire client de l'intervention (attribut d'affichage).

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -358,6 +358,187 @@ models:
         description: "Code postal du site associé à la machine"
 
 
+  - name: dim_technique__product
+    description: |
+      [QUOI MÉTIER]
+      Catalogue des produits / articles Yuman (pièces détachées, consommables)
+      utilisables lors des interventions. Appelé « Article » côté métier
+      (renommage fait dans le modèle sémantique Power BI).
+
+      [COMMENT CONSTRUITE]
+      Lecture directe de `stg_yuman__products` (catalogue API Yuman), sans
+      transformation.
+
+      [GRAIN]
+      1 ligne par `product_id` (PK).
+
+      [NOTES]
+      Dimension conforme : sert aux analyses technique (consommation
+      d'articles via `fct_technique__workorder_product`) et supply_chain
+      (le stock `fct_supply_chain__stock_yuman` se joint via
+      `product_code` = `reference`). Les prix achat/vente sont les prix
+      courants Yuman, sans historique — toute valorisation est indicative.
+    columns:
+      - name: product_id
+        description: Identifiant unique du produit dans Yuman (PK).
+        tests:
+          - not_null
+          - unique
+
+      - name: product_code
+        description: >
+          Référence article (clé de jointure avec la colonne `reference` de
+          `fct_supply_chain__stock_yuman`). Rares cas null côté Yuman.
+
+      - name: product_name
+        description: Désignation de l'article.
+
+      - name: product_type
+        description: Type de produit Yuman (quasi-constant `product`).
+
+      - name: product_brand
+        description: Marque de l'article.
+
+      - name: product_unit
+        description: Unité de mesure (pièce, litre, etc.).
+
+      - name: product_purchase_price
+        description: Prix d'achat courant (sans historique).
+
+      - name: product_sale_price
+        description: Prix de vente courant (sans historique).
+
+      - name: is_active
+        description: Article actif dans le catalogue Yuman.
+
+      - name: created_at
+        description: Date de création de l'article dans Yuman.
+
+      - name: updated_at
+        description: Date de dernière modification dans Yuman.
+
+    tests:
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 3000
+            max_value: 20000
+          config:
+            severity: warn
+
+  - name: fct_technique__workorder_product
+    description: |
+      [QUOI MÉTIER]
+      Consommation d'articles (pièces détachées, consommables) par
+      intervention Yuman. Permet l'analyse des pièces consommées par client /
+      site / machine / technicien, et le rapprochement avec les stocks
+      théoriques (`fct_supply_chain__stock_yuman`).
+
+      [COMMENT CONSTRUITE]
+      Agrégation de `stg_yuman__workorder_products` (lignes de saisie) au
+      grain workorder x produit (`sum(quantity)`), enrichie via
+      `int_yuman__demands_workorders_enriched` (dédupliqué par workorder)
+      pour porter les FK client / site / matériel / technicien et la date
+      d'intervention.
+
+      [GRAIN]
+      1 ligne par couple (`workorder_id`, `product_id`).
+
+      [NOTES]
+      Les workorders hors flux demande (~6) ont leurs FK et `date_done` null
+      (left join sur l'intermediate). Pas de valorisation dans le fait : les
+      prix Yuman sont courants, sans historique — valoriser une consommation
+      passée au prix du jour serait faux (calcul indicatif possible côté PBI
+      via `dim_technique__product`).
+    columns:
+      - name: workorder_id
+        description: Identifiant du bon de travail (dimension dégénérée).
+        tests:
+          - not_null
+
+      - name: product_id
+        description: Identifiant de l'article consommé (FK).
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_technique__product')
+                field: product_id
+              config:
+                severity: warn
+
+      - name: material_id
+        description: Identifiant du matériel concerné par l'intervention (FK).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__material')
+                field: material_id
+              config:
+                severity: warn
+
+      - name: site_id
+        description: Identifiant du site client (FK).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__site')
+                field: site_id
+              config:
+                severity: warn
+
+      - name: client_id
+        description: Identifiant du client (FK).
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__client')
+                field: client_id
+              config:
+                severity: warn
+
+      - name: technician_id
+        description: Identifiant du technicien associé (FK).
+
+      - name: partner_name
+        description: Partenaire client de l'intervention (attribut d'affichage).
+
+      - name: workorder_status
+        description: Statut du bon de travail (attribut d'affichage).
+
+      - name: date_done
+        description: >
+          Date de réalisation de l'intervention (partition). Null pour les
+          workorders hors flux demande ou non terminés.
+
+      - name: quantity
+        description: Quantité totale consommée du produit sur le workorder.
+        tests:
+          - not_null
+
+      - name: first_recorded_at
+        description: Première saisie du produit sur le workorder.
+
+      - name: last_updated_at
+        description: Dernière mise à jour d'une ligne produit du workorder.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - workorder_id
+              - product_id
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "quantity > 0"
+          config:
+            severity: warn
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 10000
+            max_value: 200000
+          config:
+            severity: warn
+
   - name: fct_technique__workorder_pricing
     description: |
       [QUOI MÉTIER]

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -538,6 +538,11 @@ models:
           interventions du flux normal ; null pour les interventions hors
           flux demande (contrôle qualité : permet d'isoler ces cas).
 
+      - name: is_workorder_paused
+        description: >
+          True si l'intervention est en pause (raison/explication de mise en
+          pause renseignée).
+
       - name: is_workorder_not_done
         description: >
           True si l'intervention n'a pas été réalisée (motif/détail de

--- a/models/marts/technique/dim_technique__product.sql
+++ b/models/marts/technique/dim_technique__product.sql
@@ -1,0 +1,18 @@
+{{ config(
+    materialized='table'
+) }}
+
+select
+    product_id,
+    product_code,
+    product_name,
+    product_type,
+    product_brand,
+    product_unit,
+    product_purchase_price,
+    product_sale_price,
+    is_active,
+    created_at,
+    updated_at
+
+from {{ ref('stg_yuman__products') }}

--- a/models/marts/technique/fct_technique__workorder_product.sql
+++ b/models/marts/technique/fct_technique__workorder_product.sql
@@ -33,6 +33,7 @@ workorders as (
         workorder_status,
         demand_category_name,
         demand_status,
+        is_workorder_paused,
         is_workorder_not_done,
         date_done
     from {{ ref('int_yuman__demands_workorders_enriched') }}
@@ -55,6 +56,7 @@ select
     w.workorder_status,
     w.demand_category_name,
     w.demand_status,
+    w.is_workorder_paused,
     w.is_workorder_not_done,
     w.date_done,
     cp.quantity,

--- a/models/marts/technique/fct_technique__workorder_product.sql
+++ b/models/marts/technique/fct_technique__workorder_product.sql
@@ -21,12 +21,19 @@ with consumed_products as (
 workorders as (
     select
         workorder_id,
+        demand_id,
         material_id,
         site_id,
         client_id,
         technician_id,
         partner_name,
+        workorder_number,
+        workorder_type,
+        workorder_category,
         workorder_status,
+        demand_category_name,
+        demand_status,
+        is_workorder_not_done,
         date_done
     from {{ ref('int_yuman__demands_workorders_enriched') }}
     where workorder_id is not null
@@ -35,13 +42,20 @@ workorders as (
 
 select
     cp.workorder_id,
+    w.demand_id,
     cp.product_id,
     w.material_id,
     w.site_id,
     w.client_id,
     w.technician_id,
     w.partner_name,
+    w.workorder_number,
+    w.workorder_type,
+    w.workorder_category,
     w.workorder_status,
+    w.demand_category_name,
+    w.demand_status,
+    w.is_workorder_not_done,
     w.date_done,
     cp.quantity,
     cp.first_recorded_at,

--- a/models/marts/technique/fct_technique__workorder_product.sql
+++ b/models/marts/technique/fct_technique__workorder_product.sql
@@ -1,0 +1,51 @@
+{{ config(
+    materialized='table',
+    partition_by={"field": "date_done", "data_type": "timestamp"},
+    cluster_by=['product_id', 'client_id', 'site_id']
+) }}
+
+with consumed_products as (
+    -- Grain source = ligne de saisie (workorder_product_id) : un même produit
+    -- peut être saisi plusieurs fois sur un workorder. On agrège au grain
+    -- analytique workorder x produit.
+    select
+        workorder_id,
+        product_id,
+        sum(product_quantity) as quantity,
+        min(product_created_at) as first_recorded_at,
+        max(product_updated_at) as last_updated_at
+    from {{ ref('stg_yuman__workorder_products') }}
+    group by workorder_id, product_id
+),
+
+workorders as (
+    select
+        workorder_id,
+        material_id,
+        site_id,
+        client_id,
+        technician_id,
+        partner_name,
+        workorder_status,
+        date_done
+    from {{ ref('int_yuman__demands_workorders_enriched') }}
+    where workorder_id is not null
+    qualify row_number() over (partition by workorder_id order by date_done desc) = 1
+)
+
+select
+    cp.workorder_id,
+    cp.product_id,
+    w.material_id,
+    w.site_id,
+    w.client_id,
+    w.technician_id,
+    w.partner_name,
+    w.workorder_status,
+    w.date_done,
+    cp.quantity,
+    cp.first_recorded_at,
+    cp.last_updated_at
+from consumed_products as cp
+left join workorders as w
+    on cp.workorder_id = w.workorder_id


### PR DESCRIPTION
## Objectif métier

Permettre l'analyse des **pièces / articles consommés lors des interventions Yuman** : suivi des consommations, rotation des pièces, et croisement avec les stocks (`fct_supply_chain__stock_yuman`) pour aider la logistique à optimiser les dotations techniciens.

## Contenu

**Nouveaux marts (technique)**
- `dim_technique__product` — catalogue des articles Yuman (~4 000 réf., PK `product_id`). Dimension **conforme** : sert au fait technique ci-dessous et au stock supply_chain via `product_code` = `reference` (1208/1209 réf. stock matchent). Affichage « Article » géré côté Power BI.
- `fct_technique__workorder_product` — **1 ligne = 1 article consommé sur une intervention** (grain `workorder_id` × `product_id`). Lignes de saisie source agrégées (`sum(quantity)`, 18 doubles saisies absorbées). FK étoile portées depuis `int_yuman__demands_workorders_enriched`. Partition `date_done`, cluster `product_id`/`client_id`/`site_id`.

**Intermediate enrichi**
- `int_yuman__demands_workorders_enriched` — 2 flags qualité réutilisables : `is_workorder_paused` (raison/explication de mise en pause renseignée) et `is_workorder_not_done` (motif/détail de non-intervention renseigné). Prédicat `OR` nécessaire (les paires ne sont pas remplies ensemble) et `trim(...) != ''` car les champs portent des chaînes vides en plus des null.

## Choix de modélisation (à relire)

- **Schéma étoile strict** : le CTE `workorders` lit l'**intermediate** (pas un fait) → aucune jointure fait-à-fait. `workorder_id` et `demand_id` sont des **dimensions dégénérées** ; leurs attributs descriptifs (type, catégorie, statut, numéro) sont portés sur le fait, ce qui est légitime faute de `dim_workorder`.
- **FK nullables volontairement** : `material_id`, `site_id`, `client_id`, `demand_id`, `technician_id` n'ont **pas** de `not_null`. Justification : une intervention **hors flux demande** (~6 workorders / 10 lignes) n'a ni demande, ni machine, ni site/client rattachés. Ce ne sont pas des FK obligatoires. Le test `relationships` ignore les NULL (`where column is not null`), donc ces lignes ne le font pas échouer — chaque nullabilité est documentée dans le YAML.
- **Déviation assumée** : la convention recommande `not_null` sur la colonne de partition. `date_done` est laissée **nullable** (10 lignes off-flow rangées dans la partition `__NULL__`, impact négligeable sur 16 037 lignes). Documenté dans la description de la colonne.
- **Dedup défensif** : `qualify row_number() over (partition by workorder_id ...)` garantit 1 ligne par workorder (0 doublon aujourd'hui) et protège d'un fan-out si un workorder se rattachait à 2 demandes.

## Tests (build dev : 13/13 PASS, SQLFluff clean)

- **dim** : `unique` + `not_null` sur PK ; row count 3 000–20 000 (warn)
- **fact** : `unique_combination(workorder_id, product_id)` ; `not_null` sur `workorder_id`/`product_id`/`quantity` ; `relationships` (warn) sur les **5 FK** (product, material, site, client, technician → `dim_technique__technician.user_id`, 0 orphelin vérifié) ; `accepted_values` sur `workorder_type` ; `quantity > 0` ; row count 10 000–200 000

## Profil données (prod)

- 16 037 lignes / 8 551 interventions / 604 articles, déc. 2023 → auj.
- 0 FK produit orpheline, 0 quantité ≤ 0
- Cohérence métier validée : articles/intervention par type (Préventif 2,3 / Curatif 1,5 / Installation 5,4), top articles = vrais consommables, marque article ↔ partenaire cohérente

## Points connus (non bloquants, pour info)

- **820 lignes sans `material_id`** (5 %) — interventions sans machine rattachée en source
- Articles inactifs encore consommés (catalogue à nettoyer côté ops), pièces sur intervention non réalisée (9) — désormais isolables via les flags
- Lien stock = match string `reference`/`product_code` ; FK `product_id` propre dans le stock à ajouter dans une étape ultérieure

## Pas d'exposure

Aucun rapport Power BI rattaché pour l'instant — exposure à déclarer quand le rapport consommera ces tables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)