### PR TITLE
feat(runner): exclude snapshots from dbt build (Option C prep)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,7 +11,10 @@
 # Injected by Cloud Workflow at runtime:
 #   DBT_COMMAND                 — dbt command to run: "build" (default) or "snapshot"
 #   DBT_SOURCE_SELECTOR         — e.g. "source:yuman_api" (skipped if empty)
-#   DBT_TAG_SELECTOR            — e.g. "tag:yuman" (used for build only)
+#   DBT_TAG_SELECTOR            — build node selector, e.g. "tag:yuman" or
+#                                 "source:yuman_api+" (source + all descendants).
+#                                 Snapshots are always excluded from build — they
+#                                 run via DBT_COMMAND=snapshot only.
 # =============================================================================
 
 set -euo pipefail
@@ -35,7 +38,7 @@ else
     FULL_REFRESH_FLAG="--full-refresh"
   fi
   echo "[dbt] Building models: ${DBT_TAG_SELECTOR}${FULL_REFRESH_FLAG:+ (full-refresh)}"
-  dbt build --select "${DBT_TAG_SELECTOR}" --target "${DBT_TARGET:-prod}" ${FULL_REFRESH_FLAG}
+  dbt build --select "${DBT_TAG_SELECTOR}" --exclude resource_type:snapshot --target "${DBT_TARGET:-prod}" ${FULL_REFRESH_FLAG}
 fi
 
 echo "[dbt] Done."


### PR DESCRIPTION
## Contexte

Bascule vers l'**Option C** : les pipelines EL passent de `tag:<source>` à `source:<source>+` comme sélecteur de build, pour que les marts d'une BU se reconstruisent automatiquement dès qu'une de leurs sources est chargée (fan-out résolu par le lignage dbt, zéro matrice source→BU à maintenir).

## Changement

`source:<source>+` sélectionne aussi les snapshots qui descendent des dims de staging. Or les snapshots ne doivent **jamais** passer par `dbt build` (SCD2 géré séparément via `DBT_COMMAND=snapshot` dans `transform-snapshots-daily`).

→ Ajout de `--exclude resource_type:snapshot` sur le chemin `dbt build` de `entrypoint.sh`. Comportement inchangé pour les anciens sélecteurs `tag:` (les snapshots n'y étaient déjà pas inclus).

## Déploiement

⚠️ **Ordre critique** : merger cette PR + **rebuild/redeploy de l'image `dbt-runner`** AVANT le `terraform apply` qui bascule les workflows EL sur `source:X+`. Sinon un build pourrait exécuter les snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)