### PR TITLE
refactor(mssql_sage): adapt staging to new flat extractor + cb_marq PK & dedupe

### DIFF
--- a/models/staging/mssql_sage/_mssql_sage__models.yml
+++ b/models/staging/mssql_sage/_mssql_sage__models.yml
@@ -118,6 +118,11 @@ models:
   - name: stg_mssql_sage__f_comptet
     description: "Table des comptes clients Nunshen nettoyée et transformée depuis la table source dbo_f_comptet de MSSQL Sage"
     columns:
+      - name: cb_marq
+        description: "Identifiant technique Sage (PK)"
+        tests:
+          - unique
+          - not_null
       - name: ct_num
         description: "Code unique du compte client"
         tests:
@@ -178,6 +183,11 @@ models:
   - name: stg_mssql_sage__f_collaborateur
     description: "Table des collaborateur Nunshen nettoyée et transformée depuis la table source dbo_f_collaborateur de MSSQL Sage"
     columns:
+      - name: cb_marq
+        description: "Identifiant technique Sage (PK)"
+        tests:
+          - unique
+          - not_null
       - name: co_no
         description: "Code unique du collaborateur"
         tests:
@@ -203,6 +213,11 @@ models:
   - name: stg_mssql_sage__f_docligne
     description: "Table des docligne Nunshen nettoyée et transformée depuis la table source dbo_f_docligne de MSSQL Sage"
     columns:
+      - name: cb_marq
+        description: "Identifiant technique Sage (PK)"
+        tests:
+          - unique
+          - not_null
       - name: dl_no
         description: "Code unique de de la transaction"
         tests:

--- a/models/staging/mssql_sage/_mssql_sage__models.yml
+++ b/models/staging/mssql_sage/_mssql_sage__models.yml
@@ -166,11 +166,13 @@ models:
       - name: typologie
         description: "Typologie du compte client"
       - name: created_at
-        description: "Date de création du compte client (cbCreation)"
+        description: "Date de création du compte client (cb_creation)"
       - name: updated_at
-        description: "Date de dernière modification du compte client (cbModification)"
+        description: "Date de dernière modification du compte client (cb_modification)"
       - name: extracted_at
-        description: "Timestamp d'extraction depuis la source Meltano (_sdc_extracted_at)"
+        description: "Timestamp d'extraction depuis la source (_sdc_extracted_at)"
+      - name: deleted_at
+        description: "Timestamp de suppression logique source (_sdc_deleted_at)"
 
   # TABLE COLLABORATEUR NUNSHEN COMMERCE
   - name: stg_mssql_sage__f_collaborateur
@@ -188,11 +190,13 @@ models:
       - name: co_fonction
         description: "Fonction du collaborateur"
       - name: created_at
-        description: "Date de création du collaborateur (cbCreation)"
+        description: "Date de création du collaborateur (cb_creation)"
       - name: updated_at
-        description: "Date de dernière modification du collaborateur (cbModification)"
+        description: "Date de dernière modification du collaborateur (cb_modification)"
       - name: extracted_at
-        description: "Timestamp d'extraction depuis la source Meltano (_sdc_extracted_at)"
+        description: "Timestamp d'extraction depuis la source (_sdc_extracted_at)"
+      - name: deleted_at
+        description: "Timestamp de suppression logique source (_sdc_deleted_at)"
 
 
   # TABLE DOCLIGNE NUNSHEN COMMERCE
@@ -248,8 +252,10 @@ models:
       - name: dl_prix_unitaire
         description: "Prix unitaire du produit"
       - name: created_at
-        description: "Date de création du collaborateur (cbCreation)"
+        description: "Date de création de la ligne document (cb_creation)"
       - name: updated_at
-        description: "Date de dernière modification du collaborateur (cbModification)"
+        description: "Date de dernière modification de la ligne document (cb_modification)"
       - name: extracted_at
-        description: "Timestamp d'extraction depuis la source Meltano (_sdc_extracted_at)"
+        description: "Timestamp d'extraction depuis la source (_sdc_extracted_at)"
+      - name: deleted_at
+        description: "Timestamp de suppression logique source (_sdc_deleted_at)"

--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -239,59 +239,99 @@ sources:
             description: "Numéro de séquence du flux"
 
 
-      # NUNSHEN COMMERCE : TABLE COMPTE 
+      # NUNSHEN COMMERCE : TABLE COMPTE (overwrite)
       - name: dbo_f_comptet
-        description: "Table brute des comptes clients de MSSQL Sage importée via Meltano. La colonne 'data' contient le JSON complet des informations clients."
+        description: "Table brute des comptes clients de MSSQL Sage. Colonnes plates (nouvel extracteur, chargement overwrite) — plus de blob JSON."
         columns:
-          - name: data
-            description: "Colonne JSON contenant toutes les informations détaillées du compte client"
+          - name: ct_num
+            description: "Code unique du compte client"
+          - name: ct_intitule
+            description: "Intitulé / nom du compte client"
+          - name: ct_type
+            description: "Type de compte client"
+          - name: co_no
+            description: "Code comptable associé"
+          - name: ct_e_mail
+            description: "Email du compte client"
+          - name: cb_creation
+            description: "Horodatage de création (TIMESTAMP)"
+          - name: cb_modification
+            description: "Horodatage de dernière modification (TIMESTAMP)"
           - name: _sdc_extracted_at
-            description: "Timestamp d'extraction depuis la source Meltano"
+            description: "Timestamp d'extraction depuis la source"
           - name: _sdc_received_at
-            description: "Timestamp de réception dans Meltano"
+            description: "Timestamp de réception"
           - name: _sdc_batched_at
-            description: "Timestamp indiquant quand le batch a été traité"
+            description: "Timestamp de traitement du batch"
           - name: _sdc_deleted_at
-            description: "Timestamp indiquant si la ligne a été supprimée dans la source"
+            description: "Timestamp de suppression logique source"
           - name: _sdc_sequence
-            description: "Identifiant de séquence Meltano pour la réplication"
+            description: "Identifiant de séquence pour la réplication"
           - name: _sdc_table_version
             description: "Version de la table source pour la réplication"
 
-      # NUNSHEN COMMERCE : TABLE COLLABORATEUR 
+      # NUNSHEN COMMERCE : TABLE COLLABORATEUR (overwrite)
       - name: dbo_f_collaborateur
-        description: "Table brute des collaborateur de MSSQL Sage importée via Meltano. La colonne 'data' contient le JSON complet des informations collaborateurs."
+        description: "Table brute des collaborateurs de MSSQL Sage. Colonnes plates (nouvel extracteur, chargement overwrite) — plus de blob JSON."
         columns:
-          - name: data
-            description: "Colonne JSON contenant toutes les informations détaillées du collaborateur"
+          - name: co_no
+            description: "Code unique du collaborateur"
+          - name: co_nom
+            description: "Nom du collaborateur"
+          - name: co_prenom
+            description: "Prénom du collaborateur"
+          - name: co_fonction
+            description: "Fonction du collaborateur"
+          - name: cb_creation
+            description: "Horodatage de création (TIMESTAMP)"
+          - name: cb_modification
+            description: "Horodatage de dernière modification (TIMESTAMP)"
           - name: _sdc_extracted_at
-            description: "Timestamp d'extraction depuis la source Meltano"
+            description: "Timestamp d'extraction depuis la source"
           - name: _sdc_received_at
-            description: "Timestamp de réception dans Meltano"
+            description: "Timestamp de réception"
           - name: _sdc_batched_at
-            description: "Timestamp indiquant quand le batch a été traité"
+            description: "Timestamp de traitement du batch"
           - name: _sdc_deleted_at
-            description: "Timestamp indiquant si la ligne a été supprimée dans la source"
+            description: "Timestamp de suppression logique source"
           - name: _sdc_sequence
-            description: "Identifiant de séquence Meltano pour la réplication"
+            description: "Identifiant de séquence pour la réplication"
           - name: _sdc_table_version
             description: "Version de la table source pour la réplication"
 
-      # NUNSHEN COMMERCE : TABLE DOCLIGNE 
+      # NUNSHEN COMMERCE : TABLE DOCLIGNE (incrémental)
       - name: dbo_f_docligne
-        description: "Table brute des ventes de MSSQL Sage importée via Meltano. La colonne 'data' contient le JSON complet des informations docligne."
+        description: "Table brute des lignes de documents (ventes/achats/stock) de MSSQL Sage. Colonnes plates (nouvel extracteur, chargement incrémental) — plus de blob JSON."
         columns:
-          - name: data
-            description: "Colonne JSON contenant toutes les informations détaillées des ventes docligne"
+          - name: dl_no
+            description: "Identifiant unique de la ligne de document"
+          - name: cb_co_no
+            description: "Code du collaborateur associé (FK vers f_collaborateur)"
+          - name: do_domaine
+            description: "Domaine Sage (0 = ventes, 1 = achats/autre, 2 = stock interne)"
+          - name: do_type
+            description: "Type de document Sage à l'intérieur d'un domaine"
+          - name: ct_num
+            description: "Code du compte client (ventes) ou code dépôt (stock)"
+          - name: do_date
+            description: "Date du document (TIMESTAMP)"
+          - name: dl_montant_ht
+            description: "Montant HT de la ligne"
+          - name: dl_montant_ttc
+            description: "Montant TTC de la ligne"
+          - name: cb_creation
+            description: "Horodatage de création (TIMESTAMP)"
+          - name: cb_modification
+            description: "Horodatage de dernière modification (TIMESTAMP)"
           - name: _sdc_extracted_at
-            description: "Timestamp d'extraction depuis la source Meltano"
+            description: "Timestamp d'extraction depuis la source"
           - name: _sdc_received_at
-            description: "Timestamp de réception dans Meltano"
+            description: "Timestamp de réception"
           - name: _sdc_batched_at
-            description: "Timestamp indiquant quand le batch a été traité"
+            description: "Timestamp de traitement du batch"
           - name: _sdc_deleted_at
-            description: "Timestamp indiquant si la ligne a été supprimée dans la source"
+            description: "Timestamp de suppression logique source"
           - name: _sdc_sequence
-            description: "Identifiant de séquence Meltano pour la réplication"
+            description: "Identifiant de séquence pour la réplication"
           - name: _sdc_table_version
             description: "Version de la table source pour la réplication"

--- a/models/staging/mssql_sage/stg_mssql_sage__f_collaborateur.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_collaborateur.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        description='Table des collaborateur Nunshen nettoyée et transformée depuis la table source dbo_f_collaborateur de MSSQL Sage',
+        description='Table des collaborateur Nunshen nettoyée et transformée depuis la table source dbo_f_collaborateur de MSSQL Sage. Source désormais en colonnes plates (nouvel extracteur, overwrite) — plus de blob JSON.'
     )
 }}
 
@@ -13,15 +13,16 @@ with source_data as (
 cleaned_data as (
     select
         -- Champs principaux
-        cast(json_value(data, '$.CO_No') as int64) as co_no,
-        json_value(data, '$.CO_Nom') as co_nom,
-        json_value(data, '$.CO_Prenom') as co_prenom,
-        json_value(data, '$.CO_Fonction') as co_fonction,
+        co_no,
+        co_nom,
+        co_prenom,
+        co_fonction,
 
         -- Metadata
-        timestamp(json_value(data, '$.cbCreation')) as created_at,
-        timestamp(json_value(data, '$.cbModification')) as updated_at,
-        _sdc_extracted_at as extracted_at
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _sdc_extracted_at as extracted_at,
+        _sdc_deleted_at as deleted_at
 
     from source_data
 )

--- a/models/staging/mssql_sage/stg_mssql_sage__f_collaborateur.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_collaborateur.sql
@@ -12,6 +12,9 @@ with source_data as (
 
 cleaned_data as (
     select
+        -- Identifiant technique Sage (PK)
+        cb_marq,
+
         -- Champs principaux
         co_no,
         co_nom,
@@ -29,3 +32,7 @@ cleaned_data as (
 
 select *
 from cleaned_data
+qualify row_number() over (
+    partition by co_no
+    order by updated_at desc, cb_marq desc
+) = 1

--- a/models/staging/mssql_sage/stg_mssql_sage__f_comptet.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_comptet.sql
@@ -12,6 +12,9 @@ with source_data as (
 
 cleaned_data as (
     select
+        -- Identifiant technique Sage (PK)
+        cb_marq,
+
         -- Champs principaux
         ct_num,
         ct_intitule,
@@ -48,3 +51,7 @@ cleaned_data as (
 
 select *
 from cleaned_data
+qualify row_number() over (
+    partition by ct_num
+    order by updated_at desc, cb_marq desc
+) = 1

--- a/models/staging/mssql_sage/stg_mssql_sage__f_comptet.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_comptet.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        description='Table des comptes clients Nunshen nettoyée et transformée depuis la table source dbo_f_comptet de MSSQL Sage',
+        description='Table des comptes clients Nunshen nettoyée et transformée depuis la table source dbo_f_comptet de MSSQL Sage. Source désormais en colonnes plates (nouvel extracteur, overwrite) — plus de blob JSON.'
     )
 }}
 
@@ -13,36 +13,35 @@ with source_data as (
 cleaned_data as (
     select
         -- Champs principaux
-        json_value(data, '$.CT_Num') as ct_num,
-        json_value(data, '$.CT_Intitule') as ct_intitule,
-        cast(json_value(data, '$.CT_Type') as int64) as ct_type,
-        json_value(data, '$.CT_Contact') as ct_contact,
-        json_value(data, '$.CT_Adresse') as ct_adresse,
-        json_value(data, '$.CT_Complement') as ct_complement,
-        json_value(data, '$.CT_CodePostal') as ct_codepostal,
-        json_value(data, '$.CT_Ville') as ct_ville,
-        json_value(data, '$.CT_Pays') as ct_pays,
-        json_value(data, '$.CT_Siret') as ct_siret,
-        json_value(data, '$.CT_NumPayeur') as ct_numpayeur,
-        cast(json_value(data, '$.CO_No') as int64) as co_no,
-        json_value(data, '$.CT_Telephone') as ct_telephone,
-        json_value(data, '$.CT_EMail') as ct_email,
+        ct_num,
+        ct_intitule,
+        ct_type,
+        ct_contact,
+        ct_adresse,
+        ct_complement,
+        ct_code_postal as ct_codepostal,
+        ct_ville,
+        ct_pays,
+        ct_siret,
+        ct_num_payeur as ct_numpayeur,
+        co_no,
+        ct_telephone,
+        ct_e_mail as ct_email,
 
-        -- Champs avec espaces
-        json_value(data, '$."CATEGORISATION NIV 1"') as categorisation_niv_1,
-        json_value(data, '$."CATEGORISATION NIV 2"') as categorisation_niv_2,
-        json_value(data, '$."CATEGORISATION NIV 3"') as categorisation_niv_3,
-        json_value(data, '$."LIGNE DE SERVICE"') as ligne_de_service,
-        json_value(data, '$."ANNEE ORIGINE"') as annee_origine,
-        json_value(data, '$."CLIENT PERDU"') as client_perdu,
-
-        -- Champs divers
-        json_value(data, '$.TYPOLOGIE') as typologie,
+        -- Catégorisation métier
+        categorisation_niv_1,
+        categorisation_niv_2,
+        categorisation_niv_3,
+        ligne_de_service,
+        annee_origine,
+        client_perdu,
+        typologie,
 
         -- Metadata
-        timestamp(json_value(data, '$.cbCreation')) as created_at,
-        timestamp(json_value(data, '$.cbModification')) as updated_at,
-        _sdc_extracted_at as extracted_at
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _sdc_extracted_at as extracted_at,
+        _sdc_deleted_at as deleted_at
 
     from source_data
 )

--- a/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
@@ -17,8 +17,11 @@ with source_data as (
 
 cleaned_data as (
     select
-        -- Identifiant unique de la ligne
-        dl_no, -- PK
+        -- Identifiant technique Sage (PK)
+        cb_marq,
+
+        -- Identifiant de la ligne de document (clé métier)
+        dl_no,
         cb_co_no as cbco_no, -- FK pour table collaborateur
 
         -- Domaine et type Sage (filtrage métier en aval)
@@ -50,3 +53,7 @@ cleaned_data as (
 
 select *
 from cleaned_data
+qualify row_number() over (
+    partition by dl_no
+    order by updated_at desc, cb_marq desc
+) = 1

--- a/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
@@ -6,7 +6,7 @@
             "data_type": "timestamp",
             "granularity": "day"
         },
-        description='Table des documents Sage Nunshen (ventes, achats, stock) nettoyée et transformée depuis dbo_f_docligne. Filtrer do_domaine = 0 pour ne garder que les ventes.'
+        description='Table des documents Sage Nunshen (ventes, achats, stock) nettoyée et transformée depuis dbo_f_docligne. Source désormais en colonnes plates (nouvel extracteur, chargement incrémental) — plus de blob JSON. Filtrer do_domaine = 0 pour ne garder que les ventes.'
     )
 }}
 
@@ -18,32 +18,33 @@ with source_data as (
 cleaned_data as (
     select
         -- Identifiant unique de la ligne
-        cast(json_value(data, '$.DL_No') as int64) as dl_no, -- PK
-        cast(json_value(data, '$.cbCO_No') as int64) as cbco_no, -- FK pour table collaborateur
+        dl_no, -- PK
+        cb_co_no as cbco_no, -- FK pour table collaborateur
 
         -- Domaine et type Sage (filtrage métier en aval)
         -- DO_Domaine : 0 = Ventes, 1 = Achats/autre, 2 = Stock interne
-        cast(json_value(data, '$.DO_Domaine') as int64) as do_domaine,
-        cast(json_value(data, '$.DO_Type') as int64) as do_type,
+        do_domaine,
+        do_type,
 
         -- Champs principaux
-        json_value(data, '$.CT_Num') as ct_num,
-        json_value(data, '$.DO_Piece') as do_piece,
-        json_value(data, '$.DL_Design') as dl_design,
-        json_value(data, '$.AR_Ref') as ar_ref,
+        ct_num,
+        do_piece,
+        dl_design,
+        ar_ref,
 
         -- Dates & montants
-        timestamp(json_value(data, '$.DO_Date')) as do_date,
-        cast(json_value(data, '$.DL_Qte') as float64) as dl_qte,
-        cast(json_value(data, '$.DL_MontantHT') as float64) as dl_montant_ht,
-        cast(json_value(data, '$.DL_MontantTTC') as float64) as dl_montant_ttc,
-        cast(json_value(data, '$.DL_PrixUnitaire') as float64) as dl_prix_unitaire,
-        cast(json_value(data, '$.DL_Valorise') as int64) as dl_valorise,
+        do_date,
+        dl_qte,
+        dl_montant_ht,
+        dl_montant_ttc,
+        dl_prix_unitaire,
+        dl_valorise,
 
         -- Metadata
-        timestamp(json_value(data, '$.cbCreation')) as created_at,
-        timestamp(json_value(data, '$.cbModification')) as updated_at,
-        _sdc_extracted_at as extracted_at
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _sdc_extracted_at as extracted_at,
+        _sdc_deleted_at as deleted_at
     from source_data
 )
 

--- a/models/staging/mssql_sage/stg_mssql_sage__f_ecriturea.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_ecriturea.sql
@@ -19,11 +19,11 @@ with source_data as (
 
 cleaned_data as (
     select
-        -- IDs et numéro convertis en BIGINT
-        cast(cb_marq as int64) as cb_marq,
-        cast(ec_no as int64) as ec_no,
-        cast(n_analytique as int64) as n_analytique,
-        cast(ea_ligne as int64) as ea_ligne,
+        -- IDs et numéros (colonnes désormais INT64 natifs)
+        cb_marq,
+        ec_no,
+        n_analytique,
+        ea_ligne,
 
         -- Colonnes texte
         ca_num,
@@ -34,12 +34,12 @@ cleaned_data as (
         ea_montant,
         ea_quantite,
 
-        -- Timestamps harmonisés
-        timestamp(cb_creation) as created_at,
+        -- Timestamps harmonisés (colonnes désormais TIMESTAMP natifs)
+        cb_creation as created_at,
         -- Fallback to cb_creation when cb_modification is null
-        timestamp(coalesce(cb_modification, cb_creation)) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _sdc_extracted_at as extracted_at,
+        _sdc_deleted_at as deleted_at
 
     from source_data
 )

--- a/models/staging/mssql_sage/stg_mssql_sage__f_ecriturec.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_ecriturec.sql
@@ -20,9 +20,9 @@ with source_data as (
 cleaned_data as (
     select
         -- Identifiants
-        cast(ec_no as int64) as ec_no,
-        cast(ec_no_link as int64) as ec_no_link,
-        cast(cb_marq as int64) as cb_marq,
+        ec_no,
+        ec_no_link,
+        cb_marq,
 
         -- Journal et comptes
         jo_num,
@@ -37,21 +37,21 @@ cleaned_data as (
         ec_devise,
         n_devise,
 
-        -- Dates
-        timestamp(ec_date) as ec_date,
-        timestamp(jm_date) as jm_date,
+        -- Dates (colonnes désormais TIMESTAMP natifs ; placeholder Sage 1753-01-01 -> NULL)
+        ec_date,
+        jm_date,
         ec_jour,
-        case when ec_echeance = '1753-01-01' then null else timestamp(ec_echeance) end as ec_echeance,
-        case when ec_date_rappro = '1753-01-01' then null else timestamp(ec_date_rappro) end as ec_date_rappro,
-        case when ec_date_regle = '1753-01-01' then null else timestamp(ec_date_regle) end as ec_date_regle,
+        case when date(ec_echeance) = date '1753-01-01' then null else ec_echeance end as ec_echeance,
+        case when date(ec_date_rappro) = date '1753-01-01' then null else ec_date_rappro end as ec_date_rappro,
+        case when date(ec_date_regle) = date '1753-01-01' then null else ec_date_regle end as ec_date_regle,
 
         -- Métadonnées
         cb_createur,
         cb_creation_user,
-        timestamp(cb_creation) as created_at,
-        timestamp(coalesce(cb_modification, cb_creation)) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _sdc_extracted_at as extracted_at,
+        _sdc_deleted_at as deleted_at
 
     from source_data
 )


### PR DESCRIPTION
## Contexte

L'extracteur `mssql_sage` a changé. Conséquences sur `prod_raw` :
- **comptet / collaborateur / docligne** : ne sont plus des blobs JSON `data` mais des **colonnes plates snake_case**.
- **ecriturea / ecriturec** : colonnes passées de STRING à **types natifs** (TIMESTAMP / INT64 / FLOAT64).

Les modèles staging existants (`json_value(data, …)`, `timestamp(ec_date)`, `ec_echeance = '1753-01-01'`) étaient donc cassés contre le nouveau schéma.

## Changements

**Adaptation au nouvel extracteur**
- comptet / collaborateur / docligne : `json_value(data, …)` → références de colonnes directes (noms de sortie préservés).
- ecriturea / ecriturec : suppression des `timestamp()` / `cast()` devenus invalides ; placeholder Sage `1753-01-01` géré via `date(...) = date '1753-01-01'`.
- Ajout de `deleted_at` (`_sdc_deleted_at`) aux 3 modèles dim/fact (convention staging).
- YAML sources : colonne `data` JSON obsolète remplacée par les colonnes plates réelles.

**PK + dedupe défensif (alignement sur ecriturea/ecriturec)**
- `cb_marq` exposé comme PK technique Sage (`unique` + `not_null`) sur les 3 modèles.
- Dedupe sur la clé métier en gardant le dernier modifié : `qualify row_number() over (partition by <clé> order by updated_at desc, cb_marq desc)` — `ct_num` (comptet), `co_no` (collaborateur), `dl_no` (docligne).
- Clés `cb`-préfixées (cbct_num, cbco_nom/cbco_prenom) volontairement écartées : redondantes (encodées) / fragiles.

## Matérialisation

Staging conservé en `table` malgré le chargement incrémental en EL : la dédup cross-historique du churn `cb_marq` de Sage nécessite un scan complet ; un `incremental merge` la casserait.

## Validation (target dev)

- 5 staging + 1 intermédiaire (`int_mssql_sage__pnl_bu`) buildés sans erreur.
- Tous les tests verts (`unique` / `not_null` / `relationships` / `unique_combination_of_columns`).
- Volumes : comptet 12,2k · collaborateur 167 · ecriturea 189k · ecriturec 308,6k · docligne 330,5k · pnl_bu 189,1k.

🤖 Generated with [Claude Code](https://claude.com/claude-code)