### PR TITLE
test(mssql_sage): source PK test on cb_marq only (all tables)

### DIFF
--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -80,9 +80,7 @@ sources:
               - unique
               - not_null
           - name: ec_no
-            description: "Numéro de l’écriture comptable (clé métier ; unicité gérée au staging après dédup)"
-            tests:
-              - not_null
+            description: "Numéro de l’écriture comptable (clé métier ; unicité et non-nullité gérées au staging)"
 
           - name: jo_num
             description: "Code du journal comptable"
@@ -242,6 +240,11 @@ sources:
       - name: dbo_f_comptet
         description: "Table brute des comptes clients de MSSQL Sage. Colonnes plates (nouvel extracteur, chargement overwrite) — plus de blob JSON."
         columns:
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne). Unicité garantie par l'overwrite (full refresh) du loader."
+            tests:
+              - unique
+              - not_null
           - name: ct_num
             description: "Code unique du compte client"
           - name: ct_intitule
@@ -273,6 +276,11 @@ sources:
       - name: dbo_f_collaborateur
         description: "Table brute des collaborateurs de MSSQL Sage. Colonnes plates (nouvel extracteur, chargement overwrite) — plus de blob JSON."
         columns:
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne). Unicité garantie par l'overwrite (full refresh) du loader."
+            tests:
+              - unique
+              - not_null
           - name: co_no
             description: "Code unique du collaborateur"
           - name: co_nom
@@ -302,6 +310,11 @@ sources:
       - name: dbo_f_docligne
         description: "Table brute des lignes de documents (ventes/achats/stock) de MSSQL Sage. Colonnes plates (nouvel extracteur, chargement incrémental) — plus de blob JSON."
         columns:
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne). Unicité garantie par l'upsert (MERGE sur cbMarq) du loader."
+            tests:
+              - unique
+              - not_null
           - name: dl_no
             description: "Identifiant unique de la ligne de document"
           - name: cb_co_no

--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -37,7 +37,7 @@ sources:
           - name: cb_prot
             description: "Indicateur de protection (technique Sage)"
           - name: cb_marq
-            description: "Identifiant unique de l'écriture analytique"
+            description: "Identifiant technique Sage (PK ligne). Unicité garantie par l'upsert (MERGE sur cbMarq) du loader."
             tests:
               - unique
               - not_null
@@ -66,23 +66,22 @@ sources:
           - name: _sdc_sequence
             description: "Numéro de séquence du flux pour suivi d’ordre"
 
-        tests:
-          - dbt_utils.unique_combination_of_columns:
-              arguments:
-                combination_of_columns:
-                  - ec_no
-                  - n_analytique
-                  - ea_ligne
+        # PK testée sur cb_marq (cf. colonne). L'unicité de la clé métier
+        # (ec_no, n_analytique, ea_ligne) reste testée au staging après dédup.
 
       # TABLE ECRITURE COMPTABLE
       - name: dbo_f_ecriturec
         description: "Table des écritures comptables (f_ecriturec) — enregistre les mouvements comptables avec leurs montants, comptes, dates et statuts"
 
         columns:
-          - name: ec_no
-            description: "Identifiant unique de l’écriture comptable (clé primaire)"
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne). Unicité garantie par l'upsert (MERGE sur cbMarq) du loader."
             tests:
               - unique
+              - not_null
+          - name: ec_no
+            description: "Numéro de l’écriture comptable (clé métier ; unicité gérée au staging après dédup)"
+            tests:
               - not_null
 
           - name: jo_num


### PR DESCRIPTION
## Contexte

Suite au passage du loader Meltano en **upsert** (MERGE sur `cbMarq`) pour les tables fact `mssql_sage`, `cb_marq` est désormais garanti **unique** dans `prod_raw` (plus de doublons dus au ré-append de frontière). On aligne donc les tests de sources sur cette garantie.

## Changements (`_mssql_sage__sources.yml`)

- **`cb_marq` = PK testée** (`unique` + `not_null`) sur les **5 tables** : `dbo_f_comptet`, `dbo_f_collaborateur`, `dbo_f_docligne`, `dbo_f_ecriturea`, `dbo_f_ecriturec`.
- **Suppression de tous les autres tests au niveau source** (ec_no unique, combinaison ec_no/n_analytique/ea_ligne, etc.).
- L'unicité des clés métier et le reste de la qualité restent gérés **au staging** (dédup `qualify` déjà en place).

Rationale : au niveau source on veut une garantie minimale et fiable que l'extract/load est propre sur la PK. Le reste appartient au staging.

## Dépendance / ordre de déploiement

Cette PR suppose que le changement EL (upsert sur `cbMarq` + `dedupe_before_upsert`) est **déjà déployé** et que le raw a été rechargé proprement. Vérifié via MCP : `cb_marq` INT64, 0 doublon, 0 null sur les 5 tables.

⚠️ **Réserve complétude** : au moment de l'ouverture, les volumes `docligne` (21 lignes) et `ecriturea` (~129k) semblent incomplets vs l'historique attendu (~330k / ~189k). À confirmer côté EL (full-load des streams incrémentaux) avant de s'appuyer sur les marts en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)