### PR TITLE
refactor(neshu): status-first bucket logic + uniform dates on machine_appro_intervention

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1082,7 +1082,7 @@ models:
       Vue cross-source Neshu × Yuman par machine en appro : pour chaque
       device Neshu ayant au moins un passage appro, expose son contexte appro
       (dernier FAIT, prochain PRÉVU, compteurs) et ses interventions curatives
-      Yuman dans 3 buckets (récente 15j, en cours, prochaine planifiée).
+      Yuman dans 3 buckets (clôturée ≤15j, en cours, planifiée — à venir ou en retard).
 
       [COMMENT CONSTRUITE]
       Joint `int_oracle_neshu__appro_machine_context` (intermediate
@@ -1090,7 +1090,13 @@ models:
       `dim_neshu__company` (attributs display). Côté Yuman, filtre
       `int_yuman__demands_workorders_enriched` sur partenaire NESHU et
       catégorie CURATIVE*, puis dispatch en 3 buckets selon le statut
-      (workorder_status + demand_status). Cross-source join sur
+      (logique statut-d'abord, buckets mutuellement exclusifs) :
+        - past    : workorder_status='Closed'      + demand Accepted + date_done dans [J-15 ; aujourd'hui]
+        - current : workorder_status='In progress'  + demand Accepted (toute date)
+        - future  : workorder_status='Scheduled'    + demand Accepted (toute date, planifié à venir OU en retard)
+      Chaque workorder a un statut unique → au plus un bucket, pas de doublon
+      (ex. une In progress avec date_done renseignée reste en 'current', pas en 'past').
+      Cross-source join sur
       `UPPER(TRIM(device_code))` = `serial_clean` (normalisation Yuman :
       strip 'NESH_' prefix).
 
@@ -1184,7 +1190,7 @@ models:
         tests:
           - not_null
 
-      # === Bucket : intervention curative récente (15j) ===
+      # === Bucket : intervention curative clôturée (≤15j) ===
       - name: past_material_id
         description: FK Yuman vers dim_technique__material — material concerné par la dernière intervention 15j (NULL si pas d'intervention 15j).
         tests:
@@ -1205,8 +1211,12 @@ models:
         description: ID Yuman du workorder de la dernière intervention 15j.
       - name: past_intervention_number
         description: Numéro unique du bon de travail Yuman de la dernière intervention 15j.
-      - name: past_intervention_date
-        description: Date de la dernière intervention curative dans les 15 derniers jours.
+      - name: past_date_started
+        description: Date de démarrage (date_started Yuman) de la dernière intervention clôturée 15j.
+      - name: past_date_planned
+        description: Date planifiée (date_planned Yuman) de la dernière intervention clôturée 15j.
+      - name: past_date_done
+        description: Date de clôture (date_done Yuman) de la dernière intervention curative clôturée dans les 15 derniers jours. C'est la date qui définit l'appartenance au bucket.
       - name: past_demand_description
         description: Description de la demande Yuman (texte libre).
       - name: past_demand_created_at
@@ -1255,8 +1265,10 @@ models:
         description: Rapport (peut être vide si pas encore renseigné).
       - name: current_date_started
         description: Date de démarrage de l'intervention en cours (date_started Yuman). Renseignée dès que le technicien démarre l'intervention, contrairement à current_date_done qui reste NULL tant que l'intervention n'est pas terminée.
+      - name: current_date_planned
+        description: Date planifiée (date_planned Yuman) de l'intervention en cours.
       - name: current_date_done
-        description: Date done (normalement NULL si en cours, valeur si transition).
+        description: Date de clôture (date_done Yuman). Normalement NULL pour une In progress, mais peut être renseignée si le technicien a saisi une date de fin sans changer le statut — l'intervention reste classée 'current' tant que workorder_status = 'In progress'.
       - name: current_is_workorder_paused
         description: >
           TRUE si l'intervention en cours est actuellement en pause (au moins un
@@ -1270,7 +1282,7 @@ models:
       - name: current_workorder_explication_mise_en_pause
         description: Explication libre de la mise en pause de l'intervention en cours (NULL si non renseignée ou non en pause).
 
-      # === Bucket : prochaine intervention planifiée ===
+      # === Bucket : intervention planifiée (à venir ou en retard) ===
       - name: future_material_id
         description: FK Yuman vers dim_technique__material — material de l'intervention planifiée.
         tests:
@@ -1291,8 +1303,12 @@ models:
         description: ID Yuman du workorder planifié.
       - name: future_intervention_number
         description: Numéro unique du bon de travail Yuman de l'intervention planifiée.
-      - name: future_intervention_planned_date
-        description: Date planifiée du workorder.
+      - name: future_date_started
+        description: Date de démarrage (date_started Yuman) de l'intervention planifiée — normalement NULL tant qu'elle n'a pas démarré.
+      - name: future_date_planned
+        description: Date planifiée (date_planned Yuman) du workorder. Peut être dans le passé (intervention Scheduled en retard, jamais démarrée) — le bucket future n'exige plus une date strictement future.
+      - name: future_date_done
+        description: Date de clôture (date_done Yuman) de l'intervention planifiée — normalement NULL pour un Scheduled.
       - name: future_demand_description
         description: Description de la demande Yuman planifiée.
       - name: future_demand_created_at

--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -73,6 +73,13 @@ with appro_context as (
 --     suspendue. Le bucket current les expose avec is_workorder_paused
 --     + les motifs de pause pour que le métier les repère (cf. Closed
 --     en pause = pause historique, déjà reprise et clôturée).
+--
+-- Logique des buckets (statut-d'abord, mutuellement exclusifs) :
+--   - past    : workorder_status = 'Closed'      + demand Accepted + date_done dans [J-15 ; aujourd'hui]
+--   - current : workorder_status = 'In progress' + demand Accepted (toute date)
+--   - future  : workorder_status = 'Scheduled'   + demand Accepted (toute date, y compris planifié en retard)
+-- Chaque WO réel a un statut unique → tombe dans au plus un bucket
+-- (pas de doublon, ex. In progress avec date_done reste en 'current').
 -- ============================================================
 yuman_workorders as (
 
@@ -107,10 +114,12 @@ yuman_workorders as (
         max(date_done) as date_done,
         min(date_planned) as date_planned,
 
-        -- Flags bucket
+        -- Flags bucket (logique statut-d'abord, buckets mutuellement exclusifs)
         case
             when
-                max(date_done) is not null
+                any_value(workorder_status) = 'Closed'
+                and any_value(demand_status) = 'Accepted'
+                and max(date_done) is not null
                 and date(max(date_done))
                 between date_sub(current_date(), interval 15 day)
                 and current_date()
@@ -128,8 +137,6 @@ yuman_workorders as (
             when
                 any_value(workorder_status) = 'Scheduled'
                 and any_value(demand_status) = 'Accepted'
-                and min(date_planned) is not null
-                and min(date_planned) > current_timestamp()
                 then 1
             else 0
         end as is_future_intervention
@@ -170,6 +177,8 @@ past_15d_ranked as (
         technician_id,
         intervention_id,
         intervention_number,
+        date_started,
+        date_planned,
         date_done,
         demand_description,
         demand_created_at,
@@ -192,7 +201,9 @@ past_15d as (
         technician_id as past_technician_id,
         intervention_id as past_intervention_id,
         intervention_number as past_intervention_number,
-        date_done as past_intervention_date,
+        date_started as past_date_started,
+        date_planned as past_date_planned,
+        date_done as past_date_done,
         demand_description as past_demand_description,
         demand_created_at as past_demand_created_at,
         demand_category_name as past_demand_category_name,
@@ -219,6 +230,7 @@ current_ranked as (
         intervention_title,
         intervention_report,
         date_started,
+        date_planned,
         date_done,
         is_workorder_currently_paused,
         workorder_raison_mise_en_pause,
@@ -245,6 +257,7 @@ current_inter as (
         intervention_title as current_intervention_title,
         intervention_report as current_intervention_report,
         date_started as current_date_started,
+        date_planned as current_date_planned,
         date_done as current_date_done,
         is_workorder_currently_paused as current_is_workorder_paused,
         workorder_raison_mise_en_pause as current_workorder_raison_mise_en_pause,
@@ -265,7 +278,9 @@ future_ranked as (
         technician_id,
         intervention_id,
         intervention_number,
+        date_started,
         date_planned,
+        date_done,
         demand_description,
         demand_created_at,
         demand_category_name,
@@ -287,7 +302,9 @@ future_inter as (
         technician_id as future_technician_id,
         intervention_id as future_intervention_id,
         intervention_number as future_intervention_number,
-        date_planned as future_intervention_planned_date,
+        date_started as future_date_started,
+        date_planned as future_date_planned,
+        date_done as future_date_done,
         demand_description as future_demand_description,
         demand_created_at as future_demand_created_at,
         demand_category_name as future_demand_category_name,
@@ -328,7 +345,9 @@ select
     p15.past_technician_id,
     p15.past_intervention_id,
     p15.past_intervention_number,
-    p15.past_intervention_date,
+    p15.past_date_started,
+    p15.past_date_planned,
+    p15.past_date_done,
     p15.past_demand_description,
     p15.past_demand_created_at,
     p15.past_demand_category_name,
@@ -347,6 +366,7 @@ select
     ci.current_intervention_title,
     ci.current_intervention_report,
     ci.current_date_started,
+    ci.current_date_planned,
     ci.current_date_done,
     coalesce(ci.current_is_workorder_paused, false) as current_is_workorder_paused,
     ci.current_workorder_raison_mise_en_pause,
@@ -357,7 +377,9 @@ select
     fi.future_technician_id,
     fi.future_intervention_id,
     fi.future_intervention_number,
-    fi.future_intervention_planned_date,
+    fi.future_date_started,
+    fi.future_date_planned,
+    fi.future_date_done,
     fi.future_demand_description,
     fi.future_demand_created_at,
     fi.future_demand_category_name,


### PR DESCRIPTION
## Contexte

Diagnostic suite à un signalement DA : des interventions curatives n'apparaissaient pas dans le dashboard (ex. workorder **17984**, `Scheduled` planifié au 30/04 mais non démarré → tombait dans aucun bucket). Analyse → la logique des 3 buckets était **asymétrique** : `past` 100 % date, `current` 100 % statut, `future` statut **+** date. Cette asymétrie créait un angle mort (Scheduled en retard) et un risque de doublon (In progress avec `date_done`).

## Changements

### 1. Logique des buckets → statut-d'abord, mutuellement exclusifs

| Bucket | Statut WO | demand | Date |
|---|---|---|---|
| past | `Closed` | `Accepted` | `date_done` ∈ [J‑15 ; auj.] |
| current | `In progress` | `Accepted` | — (inchangé) |
| future | `Scheduled` | `Accepted` | — (toute date, à venir **ou en retard**) |

- **Comble l'angle mort** : les `Scheduled` en retard reviennent dans `future` (7 devices en appro affichent enfin leur intervention planifiée, auparavant masquée).
- **Supprime le doublon** : un `In progress` portant une `date_done` reste en `current` uniquement (avant : présent en `past` **et** `current`).
- Les Rejected / statut NULL restent exclus à juste titre.

### 2. Trio de dates uniforme par bucket (demande DA)

Chaque bucket expose désormais `*_date_started`, `*_date_planned`, `*_date_done`.

⚠️ **BREAKING pour Power BI** — 2 colonnes renommées (nommage uniforme validé) :
- `past_intervention_date` → `past_date_done`
- `future_intervention_planned_date` → `future_date_planned`

Le DA doit remapper ces 2 champs dans le rapport.

## Validation (dev)

- `sqlfluff lint` ✅ · `dbt build` + 17 tests ✅ (PASS=18)
- 0 chevauchement entre buckets (exclusivité par statut vérifiée)
- 17984 confirmé en bucket `future` ; `unique` sur `device_id` OK (grain préservé)

> Note ordering : `future` trie par `date_planned asc` (rn=1 = le plus en retard d'abord). Comportement souhaité (priorité au retard) — ajustable si le métier préfère le prochain à venir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)