### PR TITLE
feat(lcdp): int_oracle_lcdp__comptage_tasks — CA cash des machines à monnayeur

### DIFF
--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1019,3 +1019,68 @@ models:
           Timestamp du pointage
         tests:
           - not_null
+
+  - name: int_oracle_lcdp__comptage_tasks
+    description: >
+      Comptages de caisse (REGL COMPTAGE, idtask_type=30) : CA encaissé en espèces
+      (pièces + billets) par machine et par date de comptage. Sert à compléter le CA
+      des machines à monnayeur (ventes en pièces invisibles côté télémétrie Nayax).
+      1 ligne par comptage (task_id). Montants = argent physique relevé (TTC par nature,
+      tax_rate=0). Cadence ~1 comptage / 1-2 semaines → analyser à un grain >= mensuel.
+    columns:
+      - name: task_id
+        description: "Identifiant de la tâche de comptage (clé primaire)."
+        data_type: int64
+        tests:
+          - unique
+          - not_null
+      - name: device_id
+        description: "ID de la machine comptée (NULL pour de rares comptages orphelins non rattachés à une machine — anomalie source immatérielle)."
+        data_type: int64
+        tests:
+          - not_null:
+              config:
+                severity: warn
+      - name: company_id
+        description: "ID de l'entreprise cliente (peer)."
+        data_type: int64
+      - name: location_id
+        description: "ID de la localisation."
+        data_type: int64
+      - name: device_code
+        description: "Code métier de la machine."
+        data_type: string
+      - name: company_code
+        description: "Code client."
+        data_type: string
+      - name: company_name
+        description: "Nom du client."
+        data_type: string
+      - name: task_location_info
+        description: "Informations d'accès de la localisation."
+        data_type: string
+      - name: task_start_date
+        description: "Date et heure du comptage (récupération des espèces)."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: ca_pieces_eur
+        description: "CA encaissé en pièces sur la période depuis le dernier comptage (€, code PIECES / Total Cash)."
+        data_type: float64
+      - name: ca_billets_eur
+        description: "CA encaissé en billets (€, code BILLET)."
+        data_type: float64
+      - name: ca_cash_eur
+        description: "CA cash total encaissé = pièces + billets (€). Complément du CA Nayax pour les machines à monnayeur. TTC par nature (tax_rate=0)."
+        data_type: float64
+      - name: updated_at
+        description: "Timestamp de dernière modification (pour incrément)."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création."
+        data_type: timestamp
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__comptage_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__comptage_tasks.sql
@@ -1,0 +1,72 @@
+{{
+    config(
+        materialized='incremental',
+        unique_key='task_id',
+        partition_by={'field': 'task_start_date', 'data_type': 'timestamp'},
+        incremental_strategy='merge',
+        cluster_by=['company_id', 'device_id'],
+        description='Table intermédiaire des comptages de caisse (REGL COMPTAGE, idtask_type=30) - CA cash (pièces + billets) par machine et par date de comptage. Sert à compléter le CA des machines équipées d''un monnayeur (ventes pièces invisibles côté télémétrie Nayax).'
+    )
+}}
+
+with comptage_base as (
+
+    select
+        -- Identifiants
+        t.idtask as task_id,
+        t.iddevice as device_id,
+        t.idcompany_peer as company_id,
+        t.idlocation as location_id,
+
+        -- Codes / infos métier
+        d.code as device_code,
+        c.code as company_code,
+        c.name as company_name,
+        l.access_info as task_location_info,
+
+        -- Date du comptage (récupération des pièces)
+        t.real_start_date as task_start_date,
+
+        -- Montants encaissés (argent physique relevé au comptage).
+        -- sale_amount_net = sale_amount_net_tax et tax_rate = 0 → montant brut encaissé,
+        -- donc TTC par nature (ce que le client a payé). À combiner au CA Nayax TTC.
+        sum(case when thp.code = 'PIECES' then thp.sale_amount_net else 0 end) as ca_pieces_eur,
+        sum(case when thp.code = 'BILLET' then thp.sale_amount_net else 0 end) as ca_billets_eur,
+        sum(
+            case when thp.code in ('PIECES', 'BILLET') then thp.sale_amount_net else 0 end
+        ) as ca_cash_eur,
+
+        -- Timestamps techniques
+        t.updated_at,
+        t.created_at,
+        t.extracted_at
+
+    from {{ ref('stg_oracle_lcdp__task') }} as t
+    inner join {{ ref('stg_oracle_lcdp__task_has_product') }} as thp
+        on t.idtask = thp.idtask
+    left join {{ ref('stg_oracle_lcdp__device') }} as d on t.iddevice = d.iddevice
+    left join {{ ref('stg_oracle_lcdp__company') }} as c on t.idcompany_peer = c.idcompany
+    left join {{ ref('stg_oracle_lcdp__location') }} as l on t.idlocation = l.idlocation
+
+    where
+        1 = 1
+        and t.idtask_type = 30  -- REGL COMPTAGE
+        and t.code_status_record = '1'
+        and t.real_start_date is not null
+        and thp.code in ('PIECES', 'BILLET')
+
+    group by
+        t.idtask, t.iddevice, t.idcompany_peer, t.idlocation,
+        d.code, c.code, c.name, l.access_info,
+        t.real_start_date,
+        t.updated_at, t.created_at, t.extracted_at
+)
+
+select * from comptage_base
+
+{% if is_incremental() %}
+    where comptage_base.updated_at >= (
+        select max(t.updated_at) - interval 1 day
+        from {{ this }} as t
+    )
+{% endif %}


### PR DESCRIPTION
## Contexte

Les machines DA FROID télémétrées Nayax équipées d'un **monnayeur** (58 / 164, repérables via `dim_lcdp__device.currency_mode = 'AVEC MONNAIE'`) encaissent aussi des ventes en **espèces**, **invisibles côté télémétrie Nayax**. Conséquence : le CA de ces machines était **sous-estimé d'environ 17 %** sur 2026.

Le CA cash est récupéré dans Oracle via les tâches **REGL COMPTAGE** (`idtask_type = 30`), réalisées ~1 fois toutes les 1-2 semaines (relevé des espèces).

## Ce que fait ce modèle

`int_oracle_lcdp__comptage_tasks` — grain : **1 ligne par comptage** (`task_id`) :

| Colonne | Contenu |
|---|---|
| `ca_pieces_eur` | espèces (code `PIECES` / Total Cash) |
| `ca_billets_eur` | billets (code `BILLET`) |
| `ca_cash_eur` | total cash = pièces + billets |

- Montants = **argent encaissé brut (TTC par nature**, `tax_rate = 0`).
- Filtré sur les codes `PIECES` / `BILLET` uniquement → **aucun double comptage** avec les ventes Nayax / CB.
- Enrichi device / company / location (codes + noms).

## Validation (dev)

- `dbt build` : **PASS = 5, WARN = 1** (warn attendu : voir ci-dessous).
- CA cash 2026 sur les 58 machines à monnayeur = **28 238 €** (pièces 23 458 + billets 4 780), 758 comptages, cadence ~10,7 jours → cohérent avec le métier.

## Points d'attention

- **`device_id` parfois NULL** : 10 comptages orphelins (ni machine ni client, ~690 € sur 2025, immatériel) → test `not_null` en **severity warn** (non bloquant, anomalie source surfacée).
- **Timing** : cadence ~1-2 semaines → le CA cash doit s'analyser à un grain **≥ mensuel** (à intégrer plus tard côté mart, avec `taux_ecoulement_volume = NULL` pour ces machines puisque le volume des ventes pièces est inconnu).
- **HT / TVA en follow-up** : le détail HT/TVA existe en source dans la table `TASK_HAS_AMOUNT` (`AMOUNT_WITHOUT_TAX`, `TAX_AMOUNT`, `TAX_RATE`), **pas encore extraite** par le tap. Une fois ajoutée → staging + enrichissement `ca_cash_ht_eur` / `ca_cash_tva_eur` dans une 2e PR.

## Test plan post-merge

- [ ] `dbt run -s int_oracle_lcdp__comptage_tasks -t prod` (modèle incremental → 1er run = full)
- [ ] Vérifier la réconciliation cash vs ERP sur quelques comptages

🤖 Generated with [Claude Code](https://claude.com/claude-code)