### PR TITLE
feat(lcdp): HT/TVA du CA cash — stg task_has_amount + enrichissement comptage

### DIFF
--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1073,6 +1073,12 @@ models:
       - name: ca_cash_eur
         description: "CA cash total encaissé = pièces + billets (€). Complément du CA Nayax pour les machines à monnayeur. TTC par nature (tax_rate=0)."
         data_type: float64
+      - name: ca_cash_ht_eur
+        description: "CA cash HT (€) = somme des AMOUNT_WITHOUT_TAX (ventilation par taux de TVA) de la tâche de comptage. Issu de stg_oracle_lcdp__task_has_amount."
+        data_type: float64
+      - name: ca_cash_tva_eur
+        description: "Montant de TVA cash (€) = somme des TAX_AMOUNT de la tâche. Réconciliation : ca_cash_ht_eur + ca_cash_tva_eur ≈ ca_cash_eur (TTC)."
+        data_type: float64
       - name: updated_at
         description: "Timestamp de dernière modification (pour incrément)."
         data_type: timestamp

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__comptage_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__comptage_tasks.sql
@@ -60,12 +60,45 @@ with comptage_base as (
         d.code, c.code, c.name, l.access_info,
         t.real_start_date,
         t.updated_at, t.created_at, t.extracted_at
+),
+
+-- Ventilation HT / TVA par tâche (somme des taux) depuis TASK_HAS_AMOUNT
+amount_per_task as (
+    select
+        idtask,
+        sum(amount_without_tax) as ca_cash_ht_eur,
+        sum(tax_amount) as ca_cash_tva_eur
+    from {{ ref('stg_oracle_lcdp__task_has_amount') }}
+    group by idtask
+),
+
+comptage_enrichi as (
+    select
+        cb.task_id,
+        cb.device_id,
+        cb.company_id,
+        cb.location_id,
+        cb.device_code,
+        cb.company_code,
+        cb.company_name,
+        cb.task_location_info,
+        cb.task_start_date,
+        cb.ca_pieces_eur,
+        cb.ca_billets_eur,
+        cb.ca_cash_eur,
+        a.ca_cash_ht_eur,
+        a.ca_cash_tva_eur,
+        cb.updated_at,
+        cb.created_at,
+        cb.extracted_at
+    from comptage_base as cb
+    left join amount_per_task as a on cb.task_id = a.idtask
 )
 
-select * from comptage_base
+select * from comptage_enrichi
 
 {% if is_incremental() %}
-    where comptage_base.updated_at >= (
+    where comptage_enrichi.updated_at >= (
         select max(t.updated_at) - interval 1 day
         from {{ this }} as t
     )

--- a/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
@@ -604,6 +604,44 @@ models:
                 field: idresources
         description: "Identifiant de la resources"
 
+  - name: stg_oracle_lcdp__task_has_amount
+    description: "Ventilation HT/TVA par taux et par tâche (montants encaissés). Source du HT/TVA des comptages cash. Orphelins écartés par inner join sur task."
+    columns:
+      - name: idtask
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_oracle_lcdp__task')
+                field: idtask
+        description: "Identifiant de la tâche"
+      - name: idtax
+        tests:
+          - not_null
+        description: "Identifiant du taux de taxe"
+      - name: tax_rate
+        description: "Taux de TVA (%) : 0, 5.5, 10, 20"
+      - name: tax_amount
+        description: "Montant de TVA (€) pour ce taux"
+      - name: amount_without_tax
+        description: "Montant HT (€) pour ce taux"
+      - name: percentage
+        description: "Part de ce taux dans le total de la tâche (%)"
+      - name: idtax_region
+        description: "Identifiant région de taxe"
+      - name: extracted_at
+        description: "Timestamp dextraction depuis Oracle"
+        tests:
+          - not_null
+      - name: deleted_at
+        description: "Timestamp de suppression (NULL si actif)"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - idtask
+              - idtax
+
   - name: stg_oracle_lcdp__task_status
     description: "Statuts des tâches transformés et nettoyés depuis la base Oracle LCDP"
     columns:

--- a/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
@@ -91,6 +91,18 @@ sources:
               - not_null
             description: "Identifiant de la resources"
 
+      - name: lcdp_task_has_amount
+        description: "Ventilation HT/TVA par taux et par tâche (montants encaissés). Source du HT/TVA des comptages cash."
+        columns:
+          - name: idtask
+            tests:
+              - not_null
+            description: "Identifiant de la tâche"
+          - name: idtax
+            tests:
+              - not_null
+            description: "Identifiant du taux de taxe"
+
       - name: lcdp_label_has_task
         description: "Labels par tâche"
         columns:

--- a/models/staging/oracle_lcdp/stg_oracle_lcdp__task_has_amount.sql
+++ b/models/staging/oracle_lcdp/stg_oracle_lcdp__task_has_amount.sql
@@ -1,0 +1,41 @@
+{{
+    config(
+        materialized='table',
+        description='task_has_amount nettoyés depuis lcdp_task_has_amount - ventilation HT/TVA par taux et par tâche (montants encaissés). Source du HT/TVA des comptages cash. Inner join sur stg_oracle_lcdp__task pour écarter les orphelins.'
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('oracle_lcdp', 'lcdp_task_has_amount') }}
+),
+
+cleaned_data as (
+    select
+        -- IDs convertis en BIGINT
+        cast(idtask as int64) as idtask,
+        cast(idtax as int64) as idtax,
+        cast(idtax_region as int64) as idtax_region,
+
+        -- Montants / taux
+        cast(tax_rate as float64) as tax_rate,
+        cast(tax_amount as float64) as tax_amount,
+        cast(amount_without_tax as float64) as amount_without_tax,
+        cast(percentage as float64) as percentage,
+
+        -- Timestamps harmonisés
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+
+    from source_data
+),
+
+-- Synchro avec la table des tâches pour éviter les orphelins
+filtered_data as (
+    select cr.*
+    from cleaned_data as cr
+    inner join {{ ref('stg_oracle_lcdp__task') }} as t
+        on cr.idtask = t.idtask
+)
+
+select * from filtered_data


### PR DESCRIPTION
## Contexte & but final

Ce chantier prépare la **séparation du parc DA FROID Nayax en deux populations** côté mart `fct_lcdp__chargement_sortie`, via `dim_lcdp__device.currency_mode` :

| Population | n | Ventes captées | Analyse cible |
|---|---|---|---|
| **FULL NAYAX** (sans monnayeur) | ~105 | 100 % via Nayax | **complète** : volume + CA + marge (logique actuelle conservée) |
| **NAYAX + MONNAYEUR** | ~58 | Nayax **+ espèces** | **CA / marge uniquement** (pas de volume — ventes pièces non détaillées), à grain ≥ mensuel |

Sur les machines à monnayeur, une partie des ventes est encaissée en **espèces**, **invisible côté télémétrie Nayax** → le CA y était sous-estimé (~17 %). Le CA cash est capté via `int_oracle_lcdp__comptage_tasks` (tâches REGL COMPTAGE, pièces + billets, livré en PR #128).

**Cette PR ajoute le détail HT / TVA du cash** : le comptage ne portait que le TTC (montant encaissé brut), or le métier/DAF raisonne en HT. Le HT existe en source dans `TASK_HAS_AMOUNT` (ventilation par taux), désormais extraite.

## Changements

### Nouveau staging `stg_oracle_lcdp__task_has_amount`
- Ventilation HT/TVA par taux et par tâche (source `lcdp_task_has_amount`, déclarée dans `_sources.yml`).
- Casts STRING → int64 / float64.
- **Inner join sur `stg_oracle_lcdp__task`** pour écarter les orphelins (décalage de refresh → ~19k lignes droppées), même pattern que `task_has_resources`.
- PK `(idtask, idtax)` confirmée unique. Tests : `not_null`, `relationships(idtask → task)`, `unique_combination_of_columns`.

### Enrichissement `int_oracle_lcdp__comptage_tasks`
- `+ ca_cash_ht_eur` (Σ `AMOUNT_WITHOUT_TAX`) et `+ ca_cash_tva_eur` (Σ `TAX_AMOUNT`) par comptage.
- On conserve `ca_pieces_eur` / `ca_billets_eur` / `ca_cash_eur` (TTC).

## Validation (dev)

- **Réconciliation HT + TVA = TTC** à 0,01 % près (99 308 € vs 99 295 € sur 2 332 comptages 2026 ; 1 seul comptage non réconcilié > 0,5 €).
- **0** comptage sans ventilation HT.
- Builds : staging **6/6** ✅ · comptage **PASS=5, WARN=1** (warn attendu : `device_id` NULL sur de rares comptages orphelins).

## Test plan post-merge

- [ ] `dbt build -s stg_oracle_lcdp__task_has_amount -t prod`
- [ ] `dbt run -s int_oracle_lcdp__comptage_tasks --full-refresh -t prod` (colonnes ajoutées sur modèle incremental)
- [ ] Re-vérifier le taux d'orphelins (devrait baisser une fois `task` et `task_has_amount` rafraîchies en phase)

## Suite (hors PR)

Intégration du CA cash (TTC + HT) dans le mart `fct_lcdp__chargement_sortie` : flag `has_monnayeur`, brique `ca_cash_*`, et `taux_ecoulement_volume = NULL` pour les machines à monnayeur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)