### PR TITLE
feat(lcdp): split marts — écoulement (full Nayax) vs CA mensuel (tout le parc)

### DIFF
--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -335,10 +335,10 @@ models:
   # CHARGEMENT vs SORTIE (taux d'écoulement Nayax)
   - name: fct_lcdp__chargement_sortie
     description: |
-      [QUOI MÉTIER] Taux d'écoulement hebdomadaire des machines LCDP télémétrées Nayax — comparaison entrées (chargements vendables) vs sorties (events Nayax PLANIFIED_SAILS) en volume et en €.
-      [COMMENT CONSTRUITE] Périmètre filtré sur dim_lcdp__device.audit_type='1- AUDIT TELEMETRIE (NAYAX)' AND device_category='DA FROID'. Entrées issues de int_oracle_lcdp__chargement_tasks filtrées sur load_type_code='LOADING' (les REMOVING = retraits de stock sont exclus pour ne pas fausser le flux d'entrée), jointes à dim_lcdp__product et au seed ref_oracle_lcdp__product_group_vendable (filtre is_vendable=true → 3 groupes SNACK / BOISSON FROIDE / PRODUIT FRAIS). Sorties issues de int_oracle_lcdp__telemetry_tasks (1 event = 1 vente, sale_amount_net remonté par Nayax). Agrégation par device × semaine ISO (lundi), FULL OUTER JOIN entre les deux flux. Rolling 4 semaines (W-3 à W incluse) calculé via window function bornée à 21 jours.
+      [QUOI MÉTIER] Taux d'écoulement hebdomadaire des machines LCDP télémétrées Nayax FULL NAYAX (sans monnayeur) — comparaison entrées (chargements vendables) vs sorties (events Nayax PLANIFIED_SAILS) en volume et en €.
+      [COMMENT CONSTRUITE] Périmètre filtré sur dim_lcdp__device.audit_type='1- AUDIT TELEMETRIE (NAYAX)' AND device_category='DA FROID' AND currency_mode='SANS MONNAIE' (full Nayax). Les machines à monnayeur (currency_mode='AVEC MONNAIE') sont EXCLUES : une partie de leurs ventes est encaissée en espèces (invisible côté Nayax) → le taux d'écoulement volume y serait faussé ; leur suivi CA passe par fct_lcdp__ca_mensuel. Entrées issues de int_oracle_lcdp__chargement_tasks filtrées sur load_type_code='LOADING' (les REMOVING = retraits de stock sont exclus pour ne pas fausser le flux d'entrée), jointes à dim_lcdp__product et au seed ref_oracle_lcdp__product_group_vendable (filtre is_vendable=true → 3 groupes SNACK / BOISSON FROIDE / PRODUIT FRAIS). Sorties issues de int_oracle_lcdp__telemetry_tasks (1 event = 1 vente, sale_amount_net remonté par Nayax). Agrégation par device × semaine ISO (lundi), FULL OUTER JOIN entre les deux flux. Rolling 4 semaines (W-3 à W incluse) calculé via window function bornée à 21 jours.
       [GRAIN] 1 ligne par device_id × week_start_date.
-      [NOTES] Hors périmètre V1 : DA CHAUD, DA SEMI-AUTO et BORNE/BROYEUR (chargement non commensurable aux events). Backfill depuis 2025-01-01. taux_ecoulement_volume = NULL si chargement = 0 (vidange de stock historique attendue). MARGE : le mart ne fige PAS de taux de marge brute (un ratio par semaine n'est pas additif et le coût de référence dépend de la période analysée). La marge se calcule en BI, alignée sur la période filtrée : coût_unitaire = Σ cout_achat_chargement_eur / Σ qty_vendable_chargee sur la période → COGS = Σ nb_ventes × coût_unitaire → taux_marge_brute = (Σ CA HT - COGS) / Σ CA HT. Repli sur cout_unitaire_achat_repli_eur (moyenne historique par device) quand la période n'a aucun chargement. Le COGS est estimé car le produit vendu est INDÉFINI côté Nayax (on suppose mix vendu = mix chargé). Taux de marge brute typique ≈ 50-55%. Les chargements REMOVING (retraits de stock) sont exclus — traçabilité via int_oracle_lcdp__chargement_tasks.
+      [NOTES] Hors périmètre : DA CHAUD, DA SEMI-AUTO, BORNE/BROYEUR (chargement non commensurable aux events) et machines à monnayeur (volume faussé — voir fct_lcdp__ca_mensuel pour leur CA). Backfill depuis 2025-01-01. taux_ecoulement_volume = NULL si chargement = 0 (vidange de stock historique attendue). MARGE : le mart ne fige PAS de taux de marge brute (un ratio par semaine n'est pas additif et le coût de référence dépend de la période analysée). La marge se calcule en BI, alignée sur la période filtrée : coût_unitaire = Σ cout_achat_chargement_eur / Σ qty_vendable_chargee sur la période → COGS = Σ nb_ventes × coût_unitaire → taux_marge_brute = (Σ CA HT - COGS) / Σ CA HT. Repli sur cout_unitaire_achat_repli_eur (moyenne historique par device) quand la période n'a aucun chargement. Le COGS est estimé car le produit vendu est INDÉFINI côté Nayax (on suppose mix vendu = mix chargé). Taux de marge brute typique ≈ 50-55%. Les chargements REMOVING (retraits de stock) sont exclus — traçabilité via int_oracle_lcdp__chargement_tasks.
     config:
       contract:
         enforced: false
@@ -429,3 +429,56 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "ca_ht_sortie_eur >= 0"
+  - name: fct_lcdp__ca_mensuel
+    description: |
+      [QUOI MÉTIER] Chiffre d'affaires mensuel des machines LCDP télémétrées Nayax (DA FROID), consolidant le CA Nayax et le CA encaissé en espèces (machines à monnayeur). Vue revenue pure (sans marge).
+      [COMMENT CONSTRUITE] Périmètre dim_lcdp__device.audit_type='1- AUDIT TELEMETRIE (NAYAX)' AND device_category='DA FROID' (machines AVEC et SANS monnayeur). CA Nayax = Σ sale_amount_net_eur (HT) / sale_amount_net_tax_eur (TTC) de int_oracle_lcdp__telemetry_tasks, agrégé au mois. CA cash = Σ ca_cash_ht_eur / ca_cash_eur de int_oracle_lcdp__comptage_tasks (pièces + billets, machines à monnayeur), au mois du comptage. FULL OUTER JOIN device × mois entre les deux flux ; CA total = Nayax + cash. has_monnayeur depuis currency_mode. Backfill depuis 2025-01-01.
+      [GRAIN] 1 ligne par device_id × month_start_date (1er jour du mois).
+      [NOTES] Grain MENSUEL volontaire : le CA cash arrive par à-coups au comptage (cadence ~1-2 sem), le mois lisse ce décalage. Pour les machines full Nayax (has_monnayeur=false), ca_cash_* = 0. PAS de marge ici (revenue pur) : le COGS du cash est inconnu (produit vendu en espèces non détaillé) — le suivi marge/écoulement reste sur fct_lcdp__chargement_sortie (full Nayax uniquement). Pas de volume non plus (ventes pièces non comptées). Montants HT et TTC exposés.
+    config:
+      contract:
+        enforced: false
+    columns:
+      - name: month_start_date
+        description: "Premier jour du mois (date_trunc month) de la mesure"
+        tests:
+          - not_null
+      - name: device_id
+        description: "Identifiant de la machine (FK vers dim_lcdp__device)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__device')
+                field: device_id
+      - name: company_id
+        description: "Identifiant du client (FK vers dim_lcdp__company)"
+      - name: has_monnayeur
+        description: "TRUE si la machine a un monnayeur (currency_mode=AVEC MONNAIE) → CA cash présent ; FALSE = full Nayax"
+      - name: nb_ventes_nayax
+        description: "Nombre d'events de vente Nayax sur le mois (ventes carte/sans contact ; n'inclut pas les ventes espèces)"
+      - name: ca_nayax_ht_eur
+        description: "CA HT des ventes Nayax sur le mois (€)"
+      - name: ca_nayax_ttc_eur
+        description: "CA TTC des ventes Nayax sur le mois (€)"
+      - name: ca_cash_ht_eur
+        description: "CA HT encaissé en espèces (comptages du mois, €). 0 pour les machines sans monnayeur."
+      - name: ca_cash_ttc_eur
+        description: "CA TTC encaissé en espèces (pièces + billets des comptages du mois, €). 0 pour les machines sans monnayeur."
+      - name: ca_total_ht_eur
+        description: "CA HT total = ca_nayax_ht_eur + ca_cash_ht_eur (€)"
+      - name: ca_total_ttc_eur
+        description: "CA TTC total = ca_nayax_ttc_eur + ca_cash_ttc_eur (€)"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - device_id
+              - month_start_date
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "ca_total_ht_eur >= 0"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "ca_total_ttc_eur >= 0"
+

--- a/models/marts/lcdp/fct_lcdp__ca_mensuel.sql
+++ b/models/marts/lcdp/fct_lcdp__ca_mensuel.sql
@@ -1,0 +1,80 @@
+{{
+    config(
+        materialized='table',
+        partition_by={'field': 'month_start_date', 'data_type': 'date'},
+        cluster_by=['device_id']
+    )
+}}
+
+with devices_perimeter as (
+    select
+        device_id,
+        company_id,
+        coalesce(currency_mode = 'AVEC MONNAIE', false) as has_monnayeur
+    from {{ ref('dim_lcdp__device') }}
+    where
+        audit_type = '1- AUDIT TELEMETRIE (NAYAX)'
+        and device_category = 'DA FROID'
+),
+
+-- CA Nayax (ventes télémétrie) agrégé au mois
+nayax_monthly as (
+    select
+        t.device_id,
+        date_trunc(date(t.task_start_date), month) as month_start_date,
+        count(*) as nb_ventes_nayax,
+        sum(t.sale_amount_net_eur) as ca_nayax_ht_eur,
+        sum(t.sale_amount_net_tax_eur) as ca_nayax_ttc_eur
+    from {{ ref('int_oracle_lcdp__telemetry_tasks') }} as t
+    where
+        t.device_id in (select dp.device_id from devices_perimeter as dp)
+        and date(t.task_start_date) >= date('2025-01-01')
+    group by 1, 2
+),
+
+-- CA cash (comptages espèces, machines à monnayeur) agrégé au mois du comptage
+cash_monthly as (
+    select
+        c.device_id,
+        date_trunc(date(c.task_start_date), month) as month_start_date,
+        sum(c.ca_cash_ht_eur) as ca_cash_ht_eur,
+        sum(c.ca_cash_eur) as ca_cash_ttc_eur
+    from {{ ref('int_oracle_lcdp__comptage_tasks') }} as c
+    where
+        c.device_id in (select dp.device_id from devices_perimeter as dp)
+        and date(c.task_start_date) >= date('2025-01-01')
+    group by 1, 2
+),
+
+joined as (
+    select
+        coalesce(n.device_id, c.device_id) as device_id,
+        coalesce(n.month_start_date, c.month_start_date) as month_start_date,
+        coalesce(n.nb_ventes_nayax, 0) as nb_ventes_nayax,
+        coalesce(n.ca_nayax_ht_eur, 0) as ca_nayax_ht_eur,
+        coalesce(n.ca_nayax_ttc_eur, 0) as ca_nayax_ttc_eur,
+        coalesce(c.ca_cash_ht_eur, 0) as ca_cash_ht_eur,
+        coalesce(c.ca_cash_ttc_eur, 0) as ca_cash_ttc_eur
+    from nayax_monthly as n
+    full outer join cash_monthly as c
+        on
+            n.device_id = c.device_id
+            and n.month_start_date = c.month_start_date
+)
+
+select
+    j.month_start_date,
+    j.device_id,
+    d.company_id,
+    d.has_monnayeur,
+
+    j.nb_ventes_nayax,
+    j.ca_nayax_ht_eur,
+    j.ca_nayax_ttc_eur,
+    j.ca_cash_ht_eur,
+    j.ca_cash_ttc_eur,
+    j.ca_nayax_ht_eur + j.ca_cash_ht_eur as ca_total_ht_eur,
+    j.ca_nayax_ttc_eur + j.ca_cash_ttc_eur as ca_total_ttc_eur
+
+from joined as j
+left join devices_perimeter as d on j.device_id = d.device_id

--- a/models/marts/lcdp/fct_lcdp__chargement_sortie.sql
+++ b/models/marts/lcdp/fct_lcdp__chargement_sortie.sql
@@ -12,6 +12,11 @@ with devices_perimeter as (
     where
         audit_type = '1- AUDIT TELEMETRIE (NAYAX)'
         and device_category = 'DA FROID'
+        -- Full Nayax uniquement : sur les machines à monnayeur, une partie des
+        -- ventes est encaissée en espèces (invisible côté Nayax) → le taux
+        -- d'écoulement volume y serait faux. Leur suivi CA passe par
+        -- fct_lcdp__ca_mensuel.
+        and currency_mode = 'SANS MONNAIE'
 ),
 
 vendable_groups as (


### PR DESCRIPTION
## Contexte & but

Aboutissement du chantier suivi DA FROID Nayax : les machines se scindent en deux populations (`dim_lcdp__device.currency_mode`) avec des **analyses, grains et périmètres différents** → **2 marts distincts** plutôt qu'un compromis bancal.

| | Écoulement (volume + marge) | CA (revenue) |
|---|---|---|
| Mart | `fct_lcdp__chargement_sortie` (refocalisé) | `fct_lcdp__ca_mensuel` (nouveau) |
| Population | DA FROID **full Nayax** (105) | **toutes** DA FROID Nayax (163) |
| Grain | hebdo (+ rolling 4w) | **mensuel** |
| Mesures | chargement, ventes, taux écoulement, marge | CA Nayax + CA cash = CA total HT/TTC |

## 1. `fct_lcdp__chargement_sortie` — refocalisé full Nayax

- Filtre ajouté : `currency_mode = 'SANS MONNAIE'`. Les machines à monnayeur sont **exclues** car une partie de leurs ventes est encaissée en espèces (invisible côté Nayax) → le taux d'écoulement volume y serait faussé.
- Grain hebdo, mesures, marge : **inchangés**. Doc YAML mise à jour (périmètre + renvoi vers le CA mart).

## 2. `fct_lcdp__ca_mensuel` — nouveau, tout le parc

- **Grain device × mois** : le CA cash arrive par à-coups au comptage (~1-2 sem) → le mois lisse le décalage temporel.
- `ca_nayax_ht/ttc` (télémétrie) + `ca_cash_ht/ttc` (comptages pièces + billets via `int_oracle_lcdp__comptage_tasks`) → `ca_total_ht/ttc`.
- `has_monnayeur` distingue full Nayax (cash = 0) des machines à monnayeur.
- **Revenue pur** : pas de marge (le COGS du cash est inconnu — produit vendu en espèces non détaillé). La marge/écoulement reste sur `fct_lcdp__chargement_sortie`.
- **HT et TTC** exposés.

## Validation (dev, 2026)

- Machines à monnayeur : CA cash = **16,4 %** du CA total (133 798 € Nayax + 26 298 € cash).
- `fct_lcdp__chargement_sortie` : 105 devices, **0 ligne non-full-Nayax** après refocus.
- Builds : **22/22** (modèles + tests).

## Points d'attention

- 4 machines à `currency_mode` NULL (gap dim) → classées `has_monnayeur=false` dans le CA mart ; l'une porte un petit cash (~possible monnayeur mal typé). Immatériel (0,5 %), à signaler au master data.
- Le **CA Nayax apparaît dans les deux marts** (hebdo / mensuel) — normal (même mesure, deux grains, deux usages) ; pas de jointure fait-à-fait.

## Test plan post-merge

- [ ] `dbt build -s fct_lcdp__chargement_sortie fct_lcdp__ca_mensuel -t prod`
- [ ] Vérifier la volumétrie (CA mart ~163 devices, écoulement 105) et part cash ~16 %

## Suite

Mettre à jour les dashboards / exposer en Power BI : un rapport volume/écoulement (full Nayax) + un rapport CA mensuel (tout le parc, Nayax + cash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)