### PR TITLE
chore(deps): bump dbt-core 1.11.11 + dbt-adapters 1.24.2

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -12,10 +12,10 @@ colorama==0.4.6
 cryptography==46.0.5
 daff==1.4.2
 db-dtypes==1.5.0
-dbt-adapters==1.22.8
+dbt-adapters==1.24.2
 dbt-bigquery==1.11.1
 dbt-common==1.37.3
-dbt-core==1.11.7
+dbt-core==1.11.11
 dbt-extractor==0.6.0
 dbt-protos==1.0.431
 dbt-semantic-interfaces==0.9.0
@@ -97,7 +97,7 @@ sniffio==1.3.1
 snowplow-tracker==1.1.0
 sqlfluff==4.0.0
 sqlfluff-templater-dbt==4.0.0
-sqlparse==0.5.4
+sqlparse==0.5.5
 tblib==3.2.2
 tenacity==9.1.4
 text-unidecode==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Local dev and CI/CD only (dbt is managed via official Docker image)
-dbt-core==1.11.7
+dbt-core==1.11.11
 dbt-bigquery==1.11.1
 sqlfluff==4.0.0
 sqlfluff-templater-dbt==4.0.0


### PR DESCRIPTION
## Quoi

Bump des dépendances dbt :
- **dbt-core** `1.11.7` → `1.11.11` (patch, même minor)
- **dbt-adapters** `1.22.8` → `1.24.2` (minor, dernière release)
- **sqlparse** `0.5.4` → `0.5.5` (dé-pinné upstream en dbt-core 1.11.8)

`dbt-bigquery` reste `1.11.1` (déjà à jour). Tous les autres transitifs restent figés (bump contraint, pas de re-résolution complète → pas de saut pandas 3.0 etc.).

## Pourquoi

- 4 patchs de retard sur dbt-core (fixes internes : pin défensif dbt-adapters, mypy/click, `static_analysis`).
- dbt-adapters mis à jour vers la release courante ; `1.24.2` embarque le fix du `KeyError` JS-UDF introduit en `1.24.0` sur dbt-core < 1.12.

## Comment

Lock régénéré dans `python:3.11-slim` (base du Dockerfile) : install du lock existant puis upgrade ciblé `dbt-core` + `dbt-adapters` uniquement.

## Validation locale (target=dev)

- `dbt deps` ✅
- `dbt debug` ✅ connection ok
- `dbt parse` ✅ (seuls les 4 warnings `PropertyMovedToConfig` pré-existants)
- `dbt compile` ✅ 177 modèles, exit 0

Aucun changement de code requis.

## Post-merge ⚠️

Le job `cd` rebuild et push `dbt-runner:latest`, mais **ne fait pas** de `gcloud run jobs update` → le Cloud Run Job continuera de tourner sur l'ancien digest tant que le job n'est pas mis à jour. À traiter après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)