### PR TITLE
feat(lcdp): snapshot SCD2 du parc machines (snap_lcdp__device)

### DIFF
--- a/snapshots/lcdp/_lcdp__snapshots.yml
+++ b/snapshots/lcdp/_lcdp__snapshots.yml
@@ -1,0 +1,42 @@
+version: 2
+
+snapshots:
+  - name: snap_lcdp__device
+    description: |
+      Historique SCD2 du parc machines LCDP (source : dim_lcdp__device).
+
+      Capture tout changement métier de la fiche machine : labels (catégorie,
+      marque, état, statut matériel, types, badge, mode devise...), rattachement
+      client/emplacement et statut actif.
+
+      Stratégie : check (check_cols='all') — une nouvelle version uniquement
+      quand une colonne sélectionnée change réellement, indépendamment de
+      updated_at (exclu du select pour éviter le bruit). dbt_valid_from =
+      heure d'exécution du snapshot.
+
+    columns:
+      - name: device_id
+        description: "Identifiant unique machine (clé naturelle du snapshot)"
+        tests:
+          - not_null
+
+      - name: dbt_valid_from
+        description: "Timestamp de prise d'effet de cette version"
+
+      - name: dbt_valid_to
+        description: "Timestamp de fin de validité (NULL = version courante)"
+
+      - name: dbt_scd_id
+        description: "Identifiant unique de l'enregistrement snapshot (SCD2)"
+        tests:
+          - unique
+          - not_null
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - device_id
+          config:
+            where: "dbt_valid_to is null"
+            severity: error

--- a/snapshots/lcdp/snap_lcdp__device.sql
+++ b/snapshots/lcdp/snap_lcdp__device.sql
@@ -1,0 +1,88 @@
+-- ==============================================================================
+-- SNAPSHOT: LCDP Device Dimension History
+-- ==============================================================================
+-- Source: dim_lcdp__device
+-- Purpose: Track historical changes du parc machines LCDP (labels, rattachement
+--          client/emplacement, statut, etc.).
+-- Strategy: Check (check_cols='all') - une nouvelle version uniquement quand une
+--           des colonnes métier sélectionnées change réellement (indépendant de
+--           updated_at). Pas de version "vide" sur simple bump de modification_date.
+--           updated_at est volontairement EXCLU du select (sinon il déclencherait
+--           une version à chaque modif ERP, ré-introduisant le bruit).
+--           dbt_valid_from = heure d'exécution du snapshot (pas la date métier).
+--
+-- Usage:
+--   Etat courant : SELECT * FROM snapshots.snap_lcdp__device WHERE dbt_valid_to IS NULL
+--   Historique   : SELECT * FROM snapshots.snap_lcdp__device WHERE device_id = XXX ORDER BY dbt_valid_from
+--   Changements d'un label (ex. device_category) :
+--     with history as (
+--         select device_id, device_category, dbt_valid_from,
+--             lag(device_category) over (partition by device_id order by dbt_valid_from) as prev
+--         from snapshots.snap_lcdp__device
+--     )
+--     select * from history
+--     where device_category is distinct from prev and prev is not null
+-- ==============================================================================
+
+{% snapshot snap_lcdp__device %}
+
+{{
+    config(
+      unique_key='device_id',
+      strategy='check',
+      check_cols='all',
+      invalidate_hard_deletes=True,
+      tags=['oracle_lcdp']
+    )
+}}
+
+    with source_table as (
+        select *
+        from {{ ref('dim_lcdp__device') }}
+    )
+
+    select
+        -- Identifiants
+        device_id,
+        device_iddevice,
+        device_type_id,
+        company_id,
+        location_id,
+
+        -- Codes et noms
+        device_code,
+        device_name,
+        company_code,
+        company_name,
+
+        -- Caractéristiques machine (labels)
+        device_category,
+        device_brand,
+        device_state,
+        device_material_status,
+        audit_type,
+        typology_da,
+        currency_mode,
+
+        -- Types machine (labels)
+        fountain_type,
+        grinder_type,
+        percolator_type,
+        type_sp,
+        type_dasa,
+        model_sp,
+        brand_sp,
+        badge,
+
+        -- Localisation
+        device_location,
+
+        -- Statut
+        is_active,
+
+        -- Date de création (immuable, ne déclenche pas de version)
+        last_installation_date,
+        created_at
+    from source_table
+
+{% endsnapshot %}


### PR DESCRIPTION
## Quoi

Nouveau snapshot SCD2 `snap_lcdp__device` qui historise `dim_lcdp__device` pour suivre dans le temps les changements de labels (catégorie, marque, état, statut matériel, types, badge, mode devise…), le rattachement client/emplacement et le statut actif du parc machines LCDP.

## Choix de stratégie

`strategy='check'` + `check_cols='all'` plutôt que `timestamp` sur `updated_at` :

- Les labels viennent de `lcdp_label_has_device` (table séparée, sans `modification_date`) → `timestamp` risquerait de rater un changement de label si `modification_date` ne bouge pas, et créerait des versions "vides" sur les bumps non-métier.
- `check` ne crée une version **que** quand une colonne métier change réellement → chaque ligne SCD2 = un vrai changement, CTE d'analyse triviale (`lag()` + `is distinct from`).
- `updated_at` est **exclu** du select (sinon il deviendrait un déclencheur et réintroduirait le bruit).
- Trade-off assumé : `dbt_valid_from` = heure du run snapshot, pas la date métier exacte.

## Convention

By-BU, alignée sur `models/marts/lcdp/` : dossier `snapshots/lcdp/`, `snap_lcdp__device`, `_lcdp__snapshots.yml`.

## Tests

- `not_null` sur `device_id`
- `unique` + `not_null` sur `dbt_scd_id`
- `unique_combination_of_columns(device_id)` where `dbt_valid_to is null` → une seule version courante par machine

## Orchestration

Couvert par le `dbt snapshot` global quotidien (9:00). Rien à ajouter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)