### PR TITLE
feat(lcdp): movement_type (signe quantité) + briques retraits dans chargement_sortie

### DIFF
--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -179,8 +179,25 @@ models:
         description: "Dernier Prix d'achat unitaire hors tax du produit"
         data_type: int64
 
+      - name: load_type_code
+        description: "Label source du mouvement (LOADING / REMOVING). Indicatif : peut être incohérent avec le signe de la quantité — utiliser movement_type pour le sens réel."
+        data_type: string
+
+      - name: movement_type
+        description: >
+          Sens réel du mouvement de stock, dérivé du SIGNE de load_quantity
+          (vérité terrain) et non du label load_type_code : load_quantity < 0
+          => 'REMOVING' (retrait), sinon 'LOADING' (chargement).
+          Corrige les cas LOADING à quantité négative et REMOVING à quantité positive.
+        data_type: string
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['LOADING', 'REMOVING']
+
       - name: load_quantity
-        description: "Quantité produit chargée ou retirée"
+        description: "Quantité produit chargée (positive) ou retirée (négative), conditionnement appliqué"
         data_type: int64
 
       - name: load_valuation

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__chargement_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__chargement_tasks.sql
@@ -139,6 +139,10 @@ select
     task_status_code,
     load_type_code,
 
+    -- Sens du mouvement de stock, piloté par le SIGNE de la quantité (vérité terrain),
+    -- pas par le label : un LOADING à quantité négative est un retrait, et inversement.
+    case when load_quantity < 0 then 'REMOVING' else 'LOADING' end as movement_type,
+
     -- Infos métier
     product_source_type,
     product_destination_type,

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -336,9 +336,9 @@ models:
   - name: fct_lcdp__chargement_sortie
     description: |
       [QUOI MÉTIER] Taux d'écoulement (VOLUME) hebdomadaire des machines LCDP télémétrées Nayax FULL NAYAX (sans monnayeur) — comparaison entrées (quantités vendables chargées) vs sorties (nombre de ventes Nayax). Modèle volume pur, sans mesure monétaire (le CA est porté par fct_lcdp__ca_mensuel).
-      [COMMENT CONSTRUITE] Périmètre filtré sur dim_lcdp__device.audit_type='1- AUDIT TELEMETRIE (NAYAX)' AND device_category='DA FROID' AND currency_mode='SANS MONNAIE' (full Nayax). Les machines à monnayeur (currency_mode='AVEC MONNAIE') sont EXCLUES : une partie de leurs ventes est encaissée en espèces (invisible côté Nayax) → le taux d'écoulement volume y serait faussé ; leur suivi CA passe par fct_lcdp__ca_mensuel. Entrées issues de int_oracle_lcdp__chargement_tasks filtrées sur load_type_code='LOADING' (les REMOVING = retraits de stock sont exclus pour ne pas fausser le flux d'entrée), jointes à dim_lcdp__product et au seed ref_oracle_lcdp__product_group_vendable (filtre is_vendable=true → 3 groupes SNACK / BOISSON FROIDE / PRODUIT FRAIS). Sorties issues de int_oracle_lcdp__telemetry_tasks (1 event = 1 vente). Agrégation par device × semaine ISO (lundi), FULL OUTER JOIN entre les deux flux. Rolling 4 semaines (W-3 à W incluse) calculé via window function bornée à 21 jours.
+      [COMMENT CONSTRUITE] Périmètre filtré sur dim_lcdp__device.audit_type='1- AUDIT TELEMETRIE (NAYAX)' AND device_category='DA FROID' AND currency_mode='SANS MONNAIE' (full Nayax). Les machines à monnayeur (currency_mode='AVEC MONNAIE') sont EXCLUES : une partie de leurs ventes est encaissée en espèces (invisible côté Nayax) → le taux d'écoulement volume y serait faussé ; leur suivi CA passe par fct_lcdp__ca_mensuel. Entrées issues de int_oracle_lcdp__chargement_tasks, classées par movement_type (sens dérivé du SIGNE de la quantité, pas du label) : les LOADING alimentent qty_vendable_chargee, les REMOVING (retraits de stock, ex. péremption) alimentent qty_vendable_retiree ; jointes à dim_lcdp__product et au seed ref_oracle_lcdp__product_group_vendable (filtre is_vendable=true → 3 groupes SNACK / BOISSON FROIDE / PRODUIT FRAIS). Sorties issues de int_oracle_lcdp__telemetry_tasks (1 event = 1 vente). Agrégation par device × semaine ISO (lundi), FULL OUTER JOIN entre les deux flux. Rolling 4 semaines (W-3 à W incluse) calculé via window function bornée à 21 jours.
       [GRAIN] 1 ligne par device_id × week_start_date.
-      [NOTES] Hors périmètre : DA CHAUD, DA SEMI-AUTO, BORNE/BROYEUR (chargement non commensurable aux events) et machines à monnayeur (volume faussé — voir fct_lcdp__ca_mensuel pour leur CA). Backfill depuis 2025-01-01. taux_ecoulement_volume = NULL si chargement = 0 (vidange de stock historique attendue). MODÈLE VOLUME PUR : aucune mesure monétaire (CA, coût, marge) n'est exposée ici (décision 2026-06-17) — le suivi repose uniquement sur le rapport quantités chargées / nombre de ventes. Le CA full-Nayax est disponible dans fct_lcdp__ca_mensuel (grain mensuel). Les chargements REMOVING (retraits de stock) sont exclus — traçabilité via int_oracle_lcdp__chargement_tasks.
+      [NOTES] Hors périmètre : DA CHAUD, DA SEMI-AUTO, BORNE/BROYEUR (chargement non commensurable aux events) et machines à monnayeur (volume faussé — voir fct_lcdp__ca_mensuel pour leur CA). Backfill depuis 2025-01-01. taux_ecoulement_volume = NULL si chargement = 0 (vidange de stock historique attendue). MODÈLE VOLUME PUR : aucune mesure monétaire (CA, coût, marge) n'est exposée ici (décision 2026-06-17) — le suivi repose uniquement sur le rapport quantités chargées / nombre de ventes. Le CA full-Nayax est disponible dans fct_lcdp__ca_mensuel (grain mensuel). RETRAITS : les REMOVING (produit sorti des machines, ex. péremption) sont exposés via qty_vendable_retiree (volume d'articles, pas de count d'opérations) ; le taux d'écoulement NET (taux_ecoulement_volume_net_4wk = ventes / (chargé − retiré)) corrige le dénominateur. Classement chargé/retiré piloté par movement_type (signe de la quantité, cf. int_oracle_lcdp__chargement_tasks).
     config:
       contract:
         enforced: false
@@ -358,12 +358,12 @@ models:
           - not_null
 
       - name: qty_vendable_chargee
-        description: "Quantité totale chargée sur la semaine, restreinte aux product_group vendables"
+        description: "Quantité vendable chargée sur la semaine (movement_type='LOADING'), restreinte aux product_group vendables"
         tests:
           - not_null
 
-      - name: nb_chargements
-        description: "Nombre de tâches distinctes de chargement sur la semaine"
+      - name: qty_vendable_retiree
+        description: "Quantité vendable retirée des machines sur la semaine (movement_type='REMOVING', ex. péremption), en valeur positive, restreinte aux product_group vendables"
         tests:
           - not_null
 
@@ -378,11 +378,17 @@ models:
       - name: qty_vendable_chargee_4wk
         description: "Quantité chargée vendable cumulée sur la fenêtre W-3 à W (4 semaines glissantes)"
 
+      - name: qty_vendable_retiree_4wk
+        description: "Quantité retirée vendable cumulée sur la fenêtre W-3 à W (4 semaines glissantes)"
+
       - name: nb_ventes_4wk
         description: "Nombre d'events télémétrie cumulé sur la fenêtre W-3 à W"
 
       - name: taux_ecoulement_volume_4wk
         description: "Ratio nb_ventes_4wk / qty_vendable_chargee_4wk. Lisse les décalages chargement → vente."
+
+      - name: taux_ecoulement_volume_net_4wk
+        description: "Taux d'écoulement NET 4 sem. : nb_ventes_4wk / (qty_vendable_chargee_4wk − qty_vendable_retiree_4wk). Déduit les retraits du dénominateur. NULL si retiré >= chargé (dénominateur <= 0, fenêtre de déstockage non interprétable)."
 
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -393,6 +399,9 @@ models:
       - dbt_utils.expression_is_true:
           arguments:
             expression: "qty_vendable_chargee >= 0"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "qty_vendable_retiree >= 0"
       - dbt_utils.expression_is_true:
           arguments:
             expression: "nb_ventes >= 0"

--- a/models/marts/lcdp/fct_lcdp__chargement_sortie.sql
+++ b/models/marts/lcdp/fct_lcdp__chargement_sortie.sql
@@ -7,10 +7,14 @@
 }}
 
 -- Taux d'écoulement (VOLUME) des DA FROID full Nayax, par device × semaine ISO.
--- Modèle VOLUME PUR : entrées (qty vendable chargée) vs sorties (nb ventes Nayax).
+-- Modèle VOLUME PUR : entrées (qty vendable chargée / retirée) vs sorties (nb ventes Nayax).
 -- Aucune mesure monétaire ici : le CA est porté par fct_lcdp__ca_mensuel (tout le
 -- parc + cash). Périmètre limité au full Nayax car sur les machines à monnayeur
 -- une partie des ventes part en espèces (invisible côté Nayax) → le volume serait faux.
+-- Mouvements de stock classés par movement_type (signe de la quantité, cf.
+-- int_oracle_lcdp__chargement_tasks) : LOADING = chargé, REMOVING = retiré
+-- (produit sorti de la machine, ex. péremption). Le taux d'écoulement NET tient
+-- compte du retiré au dénominateur : ventes / (chargé − retiré).
 
 with devices_perimeter as (
     select device_id
@@ -35,8 +39,10 @@ chargement_weekly as (
     select
         c.device_id,
         date_trunc(date(c.task_start_date), week (monday)) as week_start_date,
-        sum(c.load_quantity) as qty_vendable_chargee,
-        count(distinct c.task_id) as nb_chargements
+        sum(case when c.movement_type = 'LOADING' then c.load_quantity else 0 end)
+            as qty_vendable_chargee,
+        sum(case when c.movement_type = 'REMOVING' then -c.load_quantity else 0 end)
+            as qty_vendable_retiree
     from {{ ref('int_oracle_lcdp__chargement_tasks') }} as c
     inner join {{ ref('dim_lcdp__product') }} as p
         on c.product_id = p.product_id
@@ -45,7 +51,6 @@ chargement_weekly as (
     where
         c.device_id in (select dp.device_id from devices_perimeter as dp)
         and date(c.task_start_date) >= date('2025-01-01')
-        and c.load_type_code = 'LOADING'
     group by 1, 2
 ),
 
@@ -66,7 +71,7 @@ joined as (
         coalesce(c.device_id, t.device_id) as device_id,
         coalesce(c.week_start_date, t.week_start_date) as week_start_date,
         coalesce(c.qty_vendable_chargee, 0) as qty_vendable_chargee,
-        coalesce(c.nb_chargements, 0) as nb_chargements,
+        coalesce(c.qty_vendable_retiree, 0) as qty_vendable_retiree,
         coalesce(t.nb_ventes, 0) as nb_ventes
     from chargement_weekly as c
     full outer join telemetry_weekly as t
@@ -80,10 +85,11 @@ with_rolling as (
         device_id,
         week_start_date,
         qty_vendable_chargee,
-        nb_chargements,
+        qty_vendable_retiree,
         nb_ventes,
 
         sum(qty_vendable_chargee) over wk4 as qty_vendable_chargee_4wk,
+        sum(qty_vendable_retiree) over wk4 as qty_vendable_retiree_4wk,
         sum(nb_ventes) over wk4 as nb_ventes_4wk
 
     from joined
@@ -100,7 +106,7 @@ select
 
     -- Briques additives (entrées)
     qty_vendable_chargee,
-    nb_chargements,
+    qty_vendable_retiree,
 
     -- Briques additives (sorties)
     nb_ventes,
@@ -110,7 +116,13 @@ select
 
     -- Briques additives rolling 4 semaines
     qty_vendable_chargee_4wk,
+    qty_vendable_retiree_4wk,
     nb_ventes_4wk,
-    safe_divide(nb_ventes_4wk, qty_vendable_chargee_4wk) as taux_ecoulement_volume_4wk
+    safe_divide(nb_ventes_4wk, qty_vendable_chargee_4wk) as taux_ecoulement_volume_4wk,
+
+    -- Taux d'écoulement NET 4 sem. : tient compte du retiré au dénominateur.
+    -- NULL si retiré >= chargé (dénominateur <= 0, fenêtre de déstockage non interprétable).
+    safe_divide(nb_ventes_4wk, nullif(greatest(qty_vendable_chargee_4wk - qty_vendable_retiree_4wk, 0), 0))
+        as taux_ecoulement_volume_net_4wk
 
 from with_rolling


### PR DESCRIPTION
## Contexte
Sur le mart volume `fct_lcdp__chargement_sortie`, on ne traçait que les chargements `LOADING`. Les retraits de stock (`REMOVING`, ex. péremption) étaient invisibles, et la classification reposait sur le label `load_type_code`, parfois incohérent avec le signe réel de la quantité.

## Changements
**Intermédiaire — `int_oracle_lcdp__chargement_tasks`**
- Nouvelle colonne `movement_type`, dérivée du **signe de `load_quantity`** (vérité terrain) et non du label : `load_quantity < 0` → `REMOVING`, sinon `LOADING`.
- Corrige 526 lignes incohérentes avec le label (5 LOADING négatifs, 521 REMOVING positifs).
- Documente `load_type_code` (absent du YAML) + tests `not_null` / `accepted_values`.

**Mart — `fct_lcdp__chargement_sortie`**
- Agrégation par `movement_type`.
- Nouvelles briques additives : `qty_vendable_retiree`, `qty_vendable_retiree_4wk`.
- Nouveau ratio confort : `taux_ecoulement_volume_net_4wk` = ventes / (chargé − retiré), **NULL** si retiré ≥ chargé (fenêtre de déstockage non interprétable — artefact de décalage chargement→retrait).
- Les counts d'opérations (`nb_chargements` / `nb_retraits`) ne sont **pas** exposés : le modèle reste strictement au grain unité (`qty_*`, `nb_ventes`), pas de mélange avec un grain tâche.
- Descriptions YAML (4 blocs) + tests mis à jour.

## Validation
- Lint sqlfluff OK sur les deux modèles.
- Build dev full-refresh OK (intermédiaire 308k lignes + mart), tous les tests PASS.
- Contrôles dev : 0 taux net négatif, classification `movement_type` cohérente avec le signe.

## Impact
Parc full Nayax depuis 2026 : chargé 290 530 · retiré 966 (~0,3 %) — marginal au global, significatif machine par machine (suivi péremption / sur-stockage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)