### PR TITLE
refactor(yuman): unify intervention_state as single source of truth + orphan flag

### DIFF
--- a/models/intermediate/yuman/_yuman__intermediate_models.yml
+++ b/models/intermediate/yuman/_yuman__intermediate_models.yml
@@ -83,6 +83,41 @@ models:
           True si l'intervention n'a pas été réalisée (au moins un des champs
           workorder_motif_non_intervention / workorder_detail_non_intervention
           renseigné). Recoupe la logique de non-facturation du mart pricing.
+
+      # --- ETAT METIER CANONIQUE ---
+      - name: intervention_state
+        description: >
+          État métier canonique de l'intervention, source de vérité unique pour toute
+          la chaîne Yuman aval (int_yuman__interventions le reprend en passthrough,
+          fct_technique__suivi_partenaire en dérive ses flags d'alerte). Dérivé de
+          workorder_status, demand_status et des flags de non-intervention / pause.
+          Valeurs : REALISEE (workorder Closed sans motif/détail de non-intervention) ;
+          NON_REALISEE (workorder Closed MAIS motif/détail de non-intervention renseigné) ;
+          EN_PAUSE (In progress avec champ de pause renseigné) ;
+          EN_COURS (In progress sans pause) ; PLANIFIEE (Scheduled) ;
+          DEMANDE_OUVERTE (pas de workorder, demande Open) ;
+          DEMANDE_REJETEE (pas de workorder, demande Rejected) ;
+          AUTRE (filet de sécurité, capte tout statut Yuman futur non prévu).
+        tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - REALISEE
+                  - NON_REALISEE
+                  - EN_PAUSE
+                  - EN_COURS
+                  - PLANIFIEE
+                  - DEMANDE_OUVERTE
+                  - DEMANDE_REJETEE
+                  - AUTRE
+              config:
+                severity: warn
+      - name: is_realized
+        description: >
+          True si l'intervention a réellement été réalisée (intervention_state = 'REALISEE' :
+          workorder Closed sans motif de non-intervention). Flag de filtre principal des marts.
+      - name: has_workorder
+        description: True si un bon de travail existe (workorder_status non null), False pour une demande seule.
       - name: workorder_necessite_intervenir
         description: Indique si une intervention est nécessaire.
       - name: workorder_si_non_pourquoi
@@ -204,7 +239,9 @@ models:
       # --- ETAT METIER ---
       - name: intervention_state
         description: >
-          État métier canonique de l'intervention, dérivé de workorder_status, demand_status
+          État métier canonique de l'intervention, repris en passthrough depuis
+          int_yuman__demands_workorders_enriched (source de vérité unique ; plus aucune
+          dérivation d'état n'est faite ici). Dérivé de workorder_status, demand_status
           et des flags de non-intervention / pause. Valeurs :
           REALISEE (workorder Closed sans motif/détail de non-intervention → l'intervention a
           bien eu lieu) ;

--- a/models/intermediate/yuman/_yuman__intermediate_models.yml
+++ b/models/intermediate/yuman/_yuman__intermediate_models.yml
@@ -118,6 +118,12 @@ models:
           workorder Closed sans motif de non-intervention). Flag de filtre principal des marts.
       - name: has_workorder
         description: True si un bon de travail existe (workorder_status non null), False pour une demande seule.
+      - name: is_orphan_workorder
+        description: >
+          True pour un bon de travail "sec" (orphelin) : workorder présent mais sans demande
+          rattachée (demand_id NULL, issu du full join amont). Ces lignes n'ont aucun
+          référentiel partenaire/client/site (tous NULL). Définition unique : reprise par
+          int_yuman__interventions (qui les exclut) et fct_technique__suivi_partenaire (flag).
       - name: workorder_necessite_intervenir
         description: Indique si une intervention est nécessaire.
       - name: workorder_si_non_pourquoi

--- a/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
+++ b/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
@@ -124,132 +124,154 @@ contacts as (
         contact_mobile,
         contact_email
     from {{ ref('stg_yuman__contacts') }}
+),
+
+enriched as (
+    select
+    -- Demandes d'intervention
+        wd.demand_id,
+        wd.workorder_id,
+        wd.material_id,
+        wd.site_id,
+        wd.client_id,
+        wd.user_id,
+        wd.demand_description,
+        wd.demand_status,
+        wd.demand_reject_comment,
+        wd.demand_created_at,
+        wd.demand_updated_at,
+
+        -- Categorie demande
+        wdc.demand_category_name,
+
+        -- Interventions
+        wo.technician_id,
+        wo.workorder_number,
+        wo.workorder_category,
+        wo.workorder_type,
+        wo.workorder_status,
+        wo.workorder_title,
+        wo.workorder_description,
+        wo.workorder_report,
+        wo.workorder_technician_name,
+        wo.workorder_date_creation,
+        wo.workorder_motif_non_intervention,
+        wo.workorder_detail_non_intervention,
+        wo.workorder_raison_mise_en_pause,
+        wo.workorder_explication_mise_en_pause,
+
+        -- Intervention mise en pause : au moins un des deux champs de pause renseigne
+        coalesce(
+            trim(wo.workorder_raison_mise_en_pause) != ''
+            or trim(wo.workorder_explication_mise_en_pause) != '',
+            false
+        ) as is_workorder_paused,
+
+        -- Intervention actuellement en pause : en pause ET toujours en cours
+        -- (un Closed conserve ses champs de pause = pause historique, pas active)
+        coalesce(
+            (
+                trim(wo.workorder_raison_mise_en_pause) != ''
+                or trim(wo.workorder_explication_mise_en_pause) != ''
+            )
+            and wo.workorder_status = 'In progress',
+            false
+        ) as is_workorder_currently_paused,
+
+        -- Intervention non realisee : au moins un des deux champs de non-intervention renseigne
+        coalesce(
+            trim(wo.workorder_motif_non_intervention) != ''
+            or trim(wo.workorder_detail_non_intervention) != '',
+            false
+        ) as is_workorder_not_done,
+
+        wo.workorder_necessite_intervenir,
+        wo.workorder_si_non_pourquoi,
+        wo.date_planned,
+        wo.date_started,
+        wo.date_done,
+        wo.workorder_time_taken,
+
+        -- Clients
+        cl.partner_name,
+        cl.client_code,
+        cl.client_name,
+        cl.client_category,
+        cl.client_is_active,
+
+        -- Sites
+        s.site_code,
+        s.site_name,
+        s.site_address,
+        s.site_postal_code,
+
+        -- Contact du site
+        c.contact_id,
+        c.contact_name,
+        c.contact_title,
+        c.contact_phone,
+        c.contact_mobile,
+        c.contact_email,
+
+        -- Materiels
+        m.material_name,
+        m.material_serial_number,
+        m.material_brand,
+        m.material_description,
+        m.material_in_service_date,
+
+        -- Categories de materiels
+        mc.material_category,
+
+        -- Utilisateurs
+        u.manager_id,
+        u.user_name,
+        u.user_type,
+        u.is_manager_as_technician,
+
+        -- Agence du technicien (via mapping)
+        tam.agence as technician_agency_stock,
+        tam.equipe as technician_equipe
+
+    from workorder_demands as wd
+    left join workorder_demands_categories as wdc
+        on wd.demand_category_id = wdc.demand_category_id
+    full join workorders as wo
+        on wd.workorder_id = wo.workorder_id
+    left join clients as cl
+        on wd.client_id = cl.client_id
+    left join sites as s
+        on wd.site_id = s.site_id
+    left join contacts as c
+        on wd.contact_id = c.contact_id
+    left join materials as m
+        on wd.material_id = m.material_id
+    left join materials_categories as mc
+        on m.category_id = mc.category_id
+    left join users as u
+        on wd.user_id = u.user_id
+    left join tech_agence_mapping as tam
+        on
+            upper(trim(regexp_replace(wo.workorder_technician_name, r'\[INACTIF\]\s*', '')))
+            = upper(trim(tam.nom || ' ' || tam.prenom))
 )
 
+-- Etat metier canonique de l'intervention : source de verite unique consommee
+-- par int_yuman__interventions (passthrough) ET fct_technique__suivi_partenaire
+-- (flags d'alerte derives). Derive de workorder_status, demand_status et des flags
+-- de non-intervention / pause deja calcules ci-dessus. Cf. _yuman__intermediate_models.yml.
 select
-    -- Demandes d'intervention
-    wd.demand_id,
-    wd.workorder_id,
-    wd.material_id,
-    wd.site_id,
-    wd.client_id,
-    wd.user_id,
-    wd.demand_description,
-    wd.demand_status,
-    wd.demand_reject_comment,
-    wd.demand_created_at,
-    wd.demand_updated_at,
-
-    -- Categorie demande
-    wdc.demand_category_name,
-
-    -- Interventions
-    wo.technician_id,
-    wo.workorder_number,
-    wo.workorder_category,
-    wo.workorder_type,
-    wo.workorder_status,
-    wo.workorder_title,
-    wo.workorder_description,
-    wo.workorder_report,
-    wo.workorder_technician_name,
-    wo.workorder_date_creation,
-    wo.workorder_motif_non_intervention,
-    wo.workorder_detail_non_intervention,
-    wo.workorder_raison_mise_en_pause,
-    wo.workorder_explication_mise_en_pause,
-
-    -- Intervention mise en pause : au moins un des deux champs de pause renseigne
-    coalesce(
-        trim(wo.workorder_raison_mise_en_pause) != ''
-        or trim(wo.workorder_explication_mise_en_pause) != '',
-        false
-    ) as is_workorder_paused,
-
-    -- Intervention actuellement en pause : en pause ET toujours en cours
-    -- (un Closed conserve ses champs de pause = pause historique, pas active)
-    coalesce(
-        (
-            trim(wo.workorder_raison_mise_en_pause) != ''
-            or trim(wo.workorder_explication_mise_en_pause) != ''
-        )
-        and wo.workorder_status = 'In progress',
-        false
-    ) as is_workorder_currently_paused,
-
-    -- Intervention non realisee : au moins un des deux champs de non-intervention renseigne
-    coalesce(
-        trim(wo.workorder_motif_non_intervention) != ''
-        or trim(wo.workorder_detail_non_intervention) != '',
-        false
-    ) as is_workorder_not_done,
-
-    wo.workorder_necessite_intervenir,
-    wo.workorder_si_non_pourquoi,
-    wo.date_planned,
-    wo.date_started,
-    wo.date_done,
-    wo.workorder_time_taken,
-
-    -- Clients
-    cl.partner_name,
-    cl.client_code,
-    cl.client_name,
-    cl.client_category,
-    cl.client_is_active,
-
-    -- Sites
-    s.site_code,
-    s.site_name,
-    s.site_address,
-    s.site_postal_code,
-
-    -- Contact du site
-    c.contact_id,
-    c.contact_name,
-    c.contact_title,
-    c.contact_phone,
-    c.contact_mobile,
-    c.contact_email,
-
-    -- Materiels
-    m.material_name,
-    m.material_serial_number,
-    m.material_brand,
-    m.material_description,
-    m.material_in_service_date,
-
-    -- Categories de materiels
-    mc.material_category,
-
-    -- Utilisateurs
-    u.manager_id,
-    u.user_name,
-    u.user_type,
-    u.is_manager_as_technician,
-
-    -- Agence du technicien (via mapping)
-    tam.agence as technician_agency_stock,
-    tam.equipe as technician_equipe
-
-from workorder_demands as wd
-left join workorder_demands_categories as wdc
-    on wd.demand_category_id = wdc.demand_category_id
-full join workorders as wo
-    on wd.workorder_id = wo.workorder_id
-left join clients as cl
-    on wd.client_id = cl.client_id
-left join sites as s
-    on wd.site_id = s.site_id
-left join contacts as c
-    on wd.contact_id = c.contact_id
-left join materials as m
-    on wd.material_id = m.material_id
-left join materials_categories as mc
-    on m.category_id = mc.category_id
-left join users as u
-    on wd.user_id = u.user_id
-left join tech_agence_mapping as tam
-    on
-        upper(trim(regexp_replace(wo.workorder_technician_name, r'\[INACTIF\]\s*', '')))
-        = upper(trim(tam.nom || ' ' || tam.prenom))
+    *,
+    case
+        when workorder_status = 'Closed' and not is_workorder_not_done then 'REALISEE'
+        when workorder_status = 'Closed' then 'NON_REALISEE'
+        when is_workorder_currently_paused then 'EN_PAUSE'
+        when workorder_status = 'In progress' then 'EN_COURS'
+        when workorder_status = 'Scheduled' then 'PLANIFIEE'
+        when workorder_status is null and demand_status = 'Open' then 'DEMANDE_OUVERTE'
+        when workorder_status is null and demand_status = 'Rejected' then 'DEMANDE_REJETEE'
+        else 'AUTRE'
+    end as intervention_state,
+    (workorder_status = 'Closed' and not is_workorder_not_done) as is_realized,
+    (workorder_status is not null) as has_workorder
+from enriched

--- a/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
+++ b/models/intermediate/yuman/int_yuman__demands_workorders_enriched.sql
@@ -273,5 +273,9 @@ select
         else 'AUTRE'
     end as intervention_state,
     (workorder_status = 'Closed' and not is_workorder_not_done) as is_realized,
-    (workorder_status is not null) as has_workorder
+    (workorder_status is not null) as has_workorder,
+    -- Workorder orphelin : bon de travail "sec" sans demande rattachee (full join amont).
+    -- Sans demande = sans referentiel partenaire/client/site. Definition unique reprise
+    -- par int_yuman__interventions (exclusion) et fct_technique__suivi_partenaire (flag).
+    (demand_id is null) as is_orphan_workorder
 from enriched

--- a/models/intermediate/yuman/int_yuman__interventions.sql
+++ b/models/intermediate/yuman/int_yuman__interventions.sql
@@ -109,10 +109,11 @@ with base_workorders as (
         ) as a_facturer
 
     from {{ ref('int_yuman__demands_workorders_enriched') }}
-    -- Exclusion des bons de travail "secs" (sans demande rattachée) : ils décrochent du
-    -- référentiel client/partenaire (partner_name, client_id… NULL) et fausseraient la clé
-    -- d'intervention aval (key_inter) + la tarification. ~44 lignes en prod (full join amont).
-    where demand_id is not null
+    -- Exclusion des bons de travail "secs" (orphelins, sans demande rattachée) : ils
+    -- décrochent du référentiel client/partenaire (partner_name, client_id… NULL) et
+    -- fausseraient la clé d'intervention aval (key_inter) + la tarification (~65 lignes).
+    -- Flag canonique défini une seule fois en amont (cf. is_orphan_workorder).
+    where not is_orphan_workorder
 ),
 
 -- CTE de référence : nettoyage type d'intervention, machine, métropole, tarification

--- a/models/intermediate/yuman/int_yuman__interventions.sql
+++ b/models/intermediate/yuman/int_yuman__interventions.sql
@@ -60,6 +60,11 @@ with base_workorders as (
         material_serial_number,
         technician_equipe,
 
+        -- Etat metier canonique (defini une seule fois dans le modele enrichi amont)
+        intervention_state,
+        is_realized,
+        has_workorder,
+
         lower(coalesce(
             workorder_category,
             case
@@ -345,22 +350,9 @@ final_table as (
             when dc.delai_jours_ouvres > 2
                 then 'J++'
             else 'ERREUR'
-        end as type_delai,
-
-        -- Etat métier canonique de l'intervention (cf. _yuman__intermediate_models.yml)
-        case
-            when p.workorder_status = 'Closed' and not p.is_workorder_not_done then 'REALISEE'
-            when p.workorder_status = 'Closed' then 'NON_REALISEE'
-            when p.is_workorder_currently_paused then 'EN_PAUSE'
-            when p.workorder_status = 'In progress' then 'EN_COURS'
-            when p.workorder_status = 'Scheduled' then 'PLANIFIEE'
-            when p.workorder_status is null and p.demand_status = 'Open' then 'DEMANDE_OUVERTE'
-            when p.workorder_status is null and p.demand_status = 'Rejected' then 'DEMANDE_REJETEE'
-            else 'AUTRE'
-        end as intervention_state,
-
-        (p.workorder_status = 'Closed' and not p.is_workorder_not_done) as is_realized,
-        (p.workorder_status is not null) as has_workorder
+        end as type_delai
+    -- Etat metier canonique (intervention_state, is_realized, has_workorder) deja
+    -- present via p.* : source de verite unique dans le modele enrichi amont.
     from priced as p
     left join delai_calcul as dc
         on p.workorder_id = dc.wo_id

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -806,6 +806,12 @@ models:
                   - AUTRE
               config:
                 severity: warn
+      - name: is_orphan_workorder
+        description: >
+          True pour un bon de travail orphelin (sans demande rattachée) : aucun référentiel
+          partenaire/client/site. Flag canonique partagé avec int_yuman__demands_workorders_enriched
+          (qui le définit) et int_yuman__interventions (qui les exclut). Conservés ici mais
+          filtrables : à exclure des analyses par partenaire (partner_name NULL).
       - name: workorder_technician_name
         description: "Nom du technicien affecté"
       - name: technician_equipe

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -705,18 +705,25 @@ models:
 
       [COMMENT CONSTRUITE]
       Chaque ligne = 1 demande d'intervention enrichie avec son workorder
-      associé + client + site + matériel + technicien. 7 flags d'alerte
-      (`alerte_*`) sont calculés pour permettre au PBI de filtrer les
-      situations qui déclenchaient auparavant un email automatique.
+      associé + client + site + matériel + technicien. La colonne
+      `intervention_state` (état métier canonique) est reprise depuis
+      int_yuman__demands_workorders_enriched. 9 flags d'alerte (`alerte_*`)
+      permettent au PBI de filtrer les situations qui déclenchaient
+      auparavant un email automatique : 7 sont de simples projections
+      booléennes de `intervention_state` (aucune logique d'état recalculée
+      ici → iso avec int_yuman__interventions), 2 sont des alertes
+      opérationnelles spécifiques sans équivalent canonique
+      (`alerte_en_cours_non_cloture` = staleness, `alerte_hors_delais` = SLA
+      curative ouverte).
 
       [GRAIN]
       1 ligne par demande Yuman (`demand_id`).
 
       [NOTES]
-      Les flags `alerte_*` sont la valeur business clé — utilisés comme
-      slicers dans le rapport de monitoring partenaires. Mart conservé même
-      s'il n'est pas activement consommé aujourd'hui (anciennement utilisé
-      pour les emails, à reprendre dans une vue BI future).
+      `intervention_state` et les flags `alerte_*` sont la valeur business clé —
+      utilisés comme slicers dans le rapport de monitoring partenaires. Mart
+      conservé même s'il n'est pas activement consommé aujourd'hui (anciennement
+      utilisé pour les emails, à reprendre dans une vue BI future).
 
     columns:
       - name: demand_id
@@ -778,6 +785,27 @@ models:
         description: "Type d'intervention (Reactive = curative, Preventive…)"
       - name: workorder_status
         description: "Statut du bon de travail (Scheduled, InProgress, Closed…)"
+      - name: intervention_state
+        description: >
+          État métier canonique de l'intervention (REALISEE, NON_REALISEE, EN_PAUSE,
+          EN_COURS, PLANIFIEE, DEMANDE_OUVERTE, DEMANDE_REJETEE, AUTRE). Passthrough
+          depuis int_yuman__demands_workorders_enriched : source de vérité unique de
+          l'état, dont dérivent les 7 premiers flags alerte_*. Voir la doc complète sur
+          int_yuman__demands_workorders_enriched.
+        tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - REALISEE
+                  - NON_REALISEE
+                  - EN_PAUSE
+                  - EN_COURS
+                  - PLANIFIEE
+                  - DEMANDE_OUVERTE
+                  - DEMANDE_REJETEE
+                  - AUTRE
+              config:
+                severity: warn
       - name: workorder_technician_name
         description: "Nom du technicien affecté"
       - name: technician_equipe
@@ -795,23 +823,32 @@ models:
           Nombre de jours ouvrés écoulés depuis la création (hors week-ends et jours fériés).
           Calculé uniquement pour les curatives encore ouvertes (logique hors délais).
       - name: alerte_demand_open
-        description: "Demande créée par le client, pas encore traitée par le support (demand_status = Open)"
+        description: "intervention_state = DEMANDE_OUVERTE : demande sans workorder, pas encore traitée (Open)"
       - name: alerte_demand_accepted
-        description: "Demande acceptée par le support (demand_status = Accepted)"
+        description: "demand_status = Accepted : demande acceptée par le support (statut demande, orthogonal à l'état)"
       - name: alerte_demand_rejected
-        description: "Demande rejetée par le support (demand_status = Rejected)"
-      - name: alerte_workorder_canceled
-        description: "Demande acceptée mais workorder annulé (motif ou détail de non-intervention renseigné)"
+        description: "intervention_state = DEMANDE_REJETEE : demande sans workorder, rejetée (Rejected)"
+      - name: alerte_non_realisee
+        description: >
+          intervention_state = NON_REALISEE : workorder clôturé AVEC motif/détail de
+          non-intervention (intervention non effectuée). Remplace l'ancien
+          alerte_workorder_canceled, qui ne se déclenchait jamais en prod.
       - name: alerte_planifiee
-        description: "Intervention planifiée (statut Scheduled)"
+        description: "intervention_state = PLANIFIEE : intervention planifiée (Scheduled)"
       - name: alerte_cloturee
-        description: "Intervention clôturée (vraie clôture, sans motif de non-intervention)"
+        description: "intervention_state = REALISEE : intervention clôturée et réalisée (sans motif de non-intervention)"
       - name: alerte_pause
-        description: "Intervention mise en pause (raison ou explication renseignée)"
+        description: >
+          intervention_state = EN_PAUSE : pause active (workorder In progress avec champ
+          de pause renseigné). Exclut les pauses historiques portées par un workorder clôturé.
       - name: alerte_en_cours_non_cloture
-        description: "Intervention démarrée avant aujourd'hui et toujours ouverte"
+        description: >
+          Alerte opérationnelle (hors état canonique) : intervention démarrée avant
+          aujourd'hui et toujours ouverte (staleness).
       - name: alerte_hors_delais
-        description: "Curative ouverte dépassant 3 jours ouvrés depuis la création"
+        description: >
+          Alerte opérationnelle (hors état canonique) : curative ouverte dépassant
+          3 jours ouvrés depuis la création (SLA).
 
 
   - name: dim_technique__technician

--- a/models/marts/technique/fct_technique__suivi_partenaire.sql
+++ b/models/marts/technique/fct_technique__suivi_partenaire.sql
@@ -118,6 +118,7 @@ select
     base.workorder_type,
     base.workorder_status,
     base.intervention_state,
+    base.is_orphan_workorder,
     base.workorder_technician_name,
     base.technician_equipe,
     base.workorder_report,

--- a/models/marts/technique/fct_technique__suivi_partenaire.sql
+++ b/models/marts/technique/fct_technique__suivi_partenaire.sql
@@ -10,22 +10,25 @@
     Modèle de suivi opérationnel par partenaire — remplace le DAG MAIL_Yuman_Module_Notification.
 
     Chaque ligne = une demande d'intervention enrichie avec son workorder associé.
-    Les 9 flags d'alerte sont séparés entre statut de la demande et statut du workorder :
+    La colonne intervention_state (état métier canonique, défini une seule fois dans
+    int_yuman__demands_workorders_enriched) est la source de vérité de l'état. Les 7
+    premiers flags d'alerte en sont de simples projections booléennes — aucune logique
+    d'état n'est recalculée ici, ce qui garantit l'iso avec int_yuman__interventions.
 
-    Statut de la demande (demand_status) :
-      - alerte_demand_open           : demande créée par le client, pas encore traitée par le support
-      - alerte_demand_accepted       : demande acceptée par le support
-      - alerte_demand_rejected       : demande rejetée par le support
+    Flags dérivés de l'état canonique :
+      - alerte_demand_open           : intervention_state = DEMANDE_OUVERTE (demande sans workorder, Open)
+      - alerte_demand_accepted       : demand_status = Accepted (statut de la demande, orthogonal à l'état)
+      - alerte_demand_rejected       : intervention_state = DEMANDE_REJETEE (demande sans workorder, Rejected)
+      - alerte_non_realisee          : intervention_state = NON_REALISEE (workorder Closed AVEC motif)
+      - alerte_planifiee             : intervention_state = PLANIFIEE (Scheduled)
+      - alerte_cloturee              : intervention_state = REALISEE (vraie clôture, sans motif de non-intervention)
+      - alerte_pause                 : intervention_state = EN_PAUSE (pause active : In progress avec champ de pause)
 
-    Statut du workorder :
-      - alerte_workorder_canceled    : demande acceptée mais workorder annulé (motif/détail non-intervention renseigné)
-      - alerte_planifiee             : intervention planifiée (Scheduled)
-      - alerte_cloturee              : intervention clôturée (vraie clôture, sans motif de non-intervention)
-      - alerte_pause                 : intervention mise en pause
-      - alerte_en_cours_non_cloture  : démarrée avant aujourd'hui, toujours ouverte
+    Alertes opérationnelles spécifiques (hors état canonique, logique temporelle / SLA) :
+      - alerte_en_cours_non_cloture  : démarrée avant aujourd'hui, toujours ouverte (staleness)
       - alerte_hors_delais           : curative ouverte > 3 jours ouvrés (logique NESHU, extensible)
 
-    Usage Power BI : filtrer sur partner_name, technician_equipe, demand_created_at, flags d'alerte.
+    Usage Power BI : filtrer sur partner_name, technician_equipe, demand_created_at, intervention_state, flags d'alerte.
 */
 
 with base as (
@@ -114,6 +117,7 @@ select
     base.workorder_number,
     base.workorder_type,
     base.workorder_status,
+    base.intervention_state,
     base.workorder_technician_name,
     base.technician_equipe,
     base.workorder_report,
@@ -138,48 +142,37 @@ select
     coalesce(bde.nb_jours_ouvrables_ecoules, 0) as nb_jours_ouvrables_ecoules,
 
     -- -------------------------------------------------------------------------
-    -- FLAGS D'ALERTE — statut de la demande
+    -- FLAGS D'ALERTE — dérivés de l'état canonique intervention_state
+    -- (source de vérité unique : int_yuman__demands_workorders_enriched)
     -- -------------------------------------------------------------------------
 
-    -- 1. Demande créée par le client, pas encore traitée par le support
-    base.demand_status = 'Open' as alerte_demand_open,
+    -- 1. Demande créée par le client, pas encore traitée (aucun workorder rattaché)
+    base.intervention_state = 'DEMANDE_OUVERTE' as alerte_demand_open,
 
-    -- 2. Demande acceptée par le support
+    -- 2. Demande acceptée par le support (statut de la demande, orthogonal à l'état d'intervention)
     base.demand_status = 'Accepted' as alerte_demand_accepted,
 
-    -- 3. Demande rejetée par le support
-    base.demand_status = 'Rejected' as alerte_demand_rejected,
+    -- 3. Demande rejetée par le support (aucun workorder rattaché)
+    base.intervention_state = 'DEMANDE_REJETEE' as alerte_demand_rejected,
+
+    -- 4. Intervention non réalisée (workorder clôturé AVEC motif/détail de non-intervention)
+    base.intervention_state = 'NON_REALISEE' as alerte_non_realisee,
+
+    -- 5. Intervention planifiée (Scheduled)
+    base.intervention_state = 'PLANIFIEE' as alerte_planifiee,
+
+    -- 6. Intervention clôturée et réalisée (vraie clôture, sans motif de non-intervention)
+    base.intervention_state = 'REALISEE' as alerte_cloturee,
+
+    -- 7. Intervention actuellement en pause (In progress avec champ de pause renseigné)
+    base.intervention_state = 'EN_PAUSE' as alerte_pause,
 
     -- -------------------------------------------------------------------------
-    -- FLAGS D'ALERTE — statut du workorder
+    -- ALERTES OPÉRATIONNELLES SPÉCIFIQUES — hors état canonique
+    -- (logique temporelle / SLA, sans équivalent dans intervention_state)
     -- -------------------------------------------------------------------------
 
-    -- 4. Demande acceptée mais workorder annulé (motif ou détail de non-intervention renseigné)
-    (
-        base.demand_status = 'Accepted'
-        and (
-            base.workorder_motif_non_intervention is not null
-            or base.workorder_detail_non_intervention is not null
-        )
-    ) as alerte_workorder_canceled,
-
-    -- 5. Intervention planifiée (technicien et date assignés)
-    base.workorder_status = 'Scheduled' as alerte_planifiee,
-
-    -- 6. Intervention clôturée (vraie clôture, sans motif de non-intervention)
-    (
-        base.workorder_status = 'Closed'
-        and base.workorder_motif_non_intervention is null
-        and base.workorder_detail_non_intervention is null
-    ) as alerte_cloturee,
-
-    -- 7. Intervention mise en pause
-    (
-        base.workorder_raison_mise_en_pause is not null
-        or base.workorder_explication_mise_en_pause is not null
-    ) as alerte_pause,
-
-    -- 8. Intervention en cours non clôturée (démarrée avant aujourd'hui, toujours ouverte)
+    -- 8. Intervention démarrée avant aujourd'hui et toujours ouverte (staleness)
     (
         base.workorder_status != 'Closed'
         and base.date_started is not null


### PR DESCRIPTION
## Contexte

`fct_technique__suivi_partenaire` recalculait son propre état d'intervention (9 flags `alerte_*` ad-hoc) en parallèle de l'état métier canonique `intervention_state` défini dans `int_yuman__interventions` → **drift** entre deux vérités sur l'état d'une même intervention.

Objectif : **une seule définition de l'état**, consommée par tous, pour supprimer le drift.

## Approche — centralisation (Option C)

L'état canonique est désormais défini **une seule fois** dans `int_yuman__demands_workorders_enriched` (le modèle de base commun) et propagé :

```
int_yuman__demands_workorders_enriched   ← intervention_state défini ICI (1 seule fois)
   ├─> int_yuman__interventions           ← passthrough via p.* (CASE dupliqué supprimé)
   └─> fct_technique__suivi_partenaire    ← flags d'alerte = projections de l'état
```

## Changements

### 1. `int_yuman__demands_workorders_enriched` (source de vérité)
- Select final encapsulé en CTE `enriched`, puis ajout de l'état canonique : `intervention_state`, `is_realized`, `has_workorder`.
- Ajout du flag `is_orphan_workorder` (`demand_id is null`) : définition unique du concept "workorder sec / orphelin" (sans demande, donc sans référentiel partenaire/client/site).
- ⚠️ **Le gros diff de ce fichier est de la ré-indentation** liée au wrap en CTE (normalisée par sqlfluff). La logique métier inchangée se lit dans le `select` final.

### 2. `int_yuman__interventions` (devient passthrough)
- Suppression du `CASE intervention_state` dupliqué + des dérivations `is_realized` / `has_workorder` : repris via `p.*`. **Sortie strictement identique.**
- Exclusion des orphans exprimée via le flag canonique : `where not is_orphan_workorder` (remplace `where demand_id is not null`, même résultat).

### 3. `fct_technique__suivi_partenaire` (flags dérivés)
- Expose `intervention_state` + `is_orphan_workorder`.
- Les **7 flags d'état** deviennent de simples projections (`intervention_state = 'REALISEE'`, etc.) → **iso garanti**, aucune logique d'état recalculée.
- `alerte_en_cours_non_cloture` (staleness) et `alerte_hors_delais` (SLA curative ouverte) conservés et **documentés comme alertes hors-état canonique**.

## Corrections de fond (chiffrées sur prod, 18 937 lignes)

| Flag | Avant | Après |
|---|---|---|
| `alerte_workorder_canceled` | **toujours FALSE** — bug : `demand_status='Accepted'` + motif de non-intervention ne co-occurrent jamais | renommé **`alerte_non_realisee`** = `intervention_state='NON_REALISEE'` → **799** lignes correctement remontées |
| `alerte_pause` | 569 lignes, dont **555 pauses historiques** sur interventions déjà clôturées (fausses alertes) | aligné sur **EN_PAUSE** (pause active) → **14** lignes |

> Renommage volontaire `alerte_workorder_canceled` → `alerte_non_realisee` (le flag annulé ne se déclenchait jamais). **Breaking pour Power BI** s'il référence l'ancien nom — à vérifier côté rapport.

## Tests / qualité

- Test `accepted_values(intervention_state)` posé sur la **source** (modèle enrichi) **et** le mart.
- `unique(demand_id)` sur le mart : OK.
- **Cohérence flag ↔ état exacte** (prod) : DEMANDE_OUVERTE 192 / DEMANDE_REJETEE 317 / NON_REALISEE 799 / PLANIFIEE 226 / REALISEE 17 385 / EN_PAUSE 14.
- `intervention_state` couvre **100 %** des lignes (`AUTRE` = 0).

## Périmètre / orphans

- Les **65 workorders orphelins** (`demand_id` null, partner/client/site tous NULL) :
  - **gardés** dans le mart mais **flaggés** `is_orphan_workorder` → filtrables en PBI (à exclure des analyses par partenaire) ;
  - **exclus** de `int_yuman__interventions` (inchangé), désormais via le flag canonique.

## Validation

`dbt build -s int_yuman__demands_workorders_enriched+ --target dev` → **PASS=57, 0 erreur** (tous consommateurs : `fct_technique__intervention`, `fct_neshu__workorder_delai`, `fct_neshu__machine_appro_intervention`, `fct_technique__workorder_product` + tests). sqlfluff lint clean sur les 3 SQL.

## À noter pour le reviewer

- Renommage de flag potentiellement breaking côté Power BI (voir ci-dessus).
- Le diff volumineux de `int_yuman__demands_workorders_enriched` est ~exclusivement de l'indentation (wrap en CTE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
