### PR TITLE
Repo structure: versioned AI layer, pre-commit guardrails & per-layer convention docs

### DIFF
--- a/.claude/commands/build-source.md
+++ b/.claude/commands/build-source.md
@@ -1,0 +1,16 @@
+---
+description: Build (run + test, ordre DAG) tous les modeles d'une source via son tag
+argument-hint: <source> (ex. oracle_neshu, yuman, gac)
+allowed-tools: Bash(./dbt_venv/bin/dbt build:*), Bash(./dbt_venv/bin/dbt ls:*)
+---
+
+Build la source `$1` sur la cible **dev** (jamais `prod` sauf demande explicite).
+
+Lance :
+
+```bash
+./dbt_venv/bin/dbt build --select tag:$1
+```
+
+- Si le tag `$1` ne correspond a aucun modele, liste les tags disponibles plutot que d'echouer en silence.
+- Rapporte fidelement les echecs `run`/`test` avec leur output ; ne declare pas succes si un test est en erreur ou warning non attendu.

--- a/.claude/commands/freshness.md
+++ b/.claude/commands/freshness.md
@@ -1,0 +1,12 @@
+---
+description: Verifie la fraicheur des sources (dbt source freshness)
+allowed-tools: Bash(./dbt_venv/bin/dbt source freshness:*)
+---
+
+Lance le check de fraicheur des sources :
+
+```bash
+./dbt_venv/bin/dbt source freshness
+```
+
+Resume les sources en `warn`/`error` (avec leur age vs seuil), en t'appuyant sur les tiers de `docs/freshness.md` (Critique / Standard / Relaxe). Ne signale pas comme anormal ce qui rentre dans le tier attendu.

--- a/.claude/commands/lint-fix.md
+++ b/.claude/commands/lint-fix.md
@@ -1,0 +1,14 @@
+---
+description: Corrige automatiquement le SQL (sqlfluff fix) puis relint pour confirmer
+argument-hint: <path> (fichier .sql ou dossier sous models/)
+allowed-tools: Bash(./dbt_venv/bin/sqlfluff fix:*), Bash(./dbt_venv/bin/sqlfluff lint:*)
+---
+
+Corrige puis verifie le SQL de `$1` (regles SQLFluff v4 : lowercase, indent 4, max 120, pas de trailing comma).
+
+```bash
+./dbt_venv/bin/sqlfluff fix $1
+./dbt_venv/bin/sqlfluff lint $1
+```
+
+Liste les violations restantes que `fix` n'a pas pu corriger automatiquement (a regler a la main). Ne considere le fichier propre que si le relint final ne renvoie aucune erreur.

--- a/.claude/commands/new-mart.md
+++ b/.claude/commands/new-mart.md
@@ -3,7 +3,7 @@ description: Scaffold un nouveau mart (SQL + YAML) conforme a CONVENTIONS.md
 argument-hint: <bu> <entity> (ex. supply_chain couverture_stock)
 ---
 
-Cree un nouveau mart pour la BU `$1`, entite `$2`, en respectant **strictement** `CONVENTIONS.md` § Marts — pattern complet.
+Cree un nouveau mart pour la BU `$1`, entite `$2`, en respectant **strictement** `docs/conventions/marts.md` (§ Marts — pattern complet).
 
 Procedure :
 

--- a/.claude/commands/new-mart.md
+++ b/.claude/commands/new-mart.md
@@ -1,0 +1,17 @@
+---
+description: Scaffold un nouveau mart (SQL + YAML) conforme a CONVENTIONS.md
+argument-hint: <bu> <entity> (ex. supply_chain couverture_stock)
+---
+
+Cree un nouveau mart pour la BU `$1`, entite `$2`, en respectant **strictement** `CONVENTIONS.md` § Marts — pattern complet.
+
+Procedure :
+
+1. **Determiner le grain et le type** (dim vs fact) avec moi avant d'ecrire. Nom de fichier : `models/marts/$1/<dim|fct>_$1__$2.sql` (entite au singulier, snake_case, nom metier).
+2. **Explorer l'upstream via le MCP BigQuery** avant d'ecrire : `get_table_info` pour le schema, `SELECT DISTINCT` pour les `accepted_values`, `COUNT(*)` pour les bornes `row_count_between`, `MIN/MAX(date)` pour les plages. Utiliser les schemas `prod_*` (pas `dev_*`, souvent perimes).
+3. **Ecrire le SQL** : star schema strict (FK `<entity>_id` uniquement, pas de jointure fait-a-fait, pas de snowflake, pas d'OBT). Ordre des colonnes grain-first. `{{ config() }}` pour la materialisation uniquement (pas de description, pas de `tags`).
+4. **Ecrire l'entree YAML** dans `_$1__marts_models.yml` : description en 4 blocs `[QUOI METIER]` / `[COMMENT CONSTRUITE]` / `[GRAIN]` / `[NOTES]` (grain obligatoire), + tests minimum (Dim : `unique`+`not_null` PK error, `accepted_values`/row count warn ; Fact : `not_null`+`relationships` FK, `unique_combination_of_columns`, `expression_is_true` invariants). Tests generiques sous `arguments:`.
+5. **Mettre a jour l'exposure** `models/exposures/$1.yml` si un rapport Power BI consomme ce mart.
+6. **Linter** : `./dbt_venv/bin/sqlfluff lint` sur le fichier avant de considerer termine.
+
+Ne saute aucune couche : si un intermediate manque, le signaler plutot que de faire la logique metier dans le mart.

--- a/.claude/hooks/bq-auth-headers.sh
+++ b/.claude/hooks/bq-auth-headers.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Helper: outputs Authorization + project headers for BigQuery MCP
+# Uses the dbt service account keyfile — no interactive gcloud login needed
+KEYFILE="${DBT_BIGQUERY_KEYFILE:-/opt/credentials/gcp-meltano-key.json}"
+TOKEN=$(GOOGLE_APPLICATION_CREDENTIALS="$KEYFILE" gcloud auth application-default print-access-token 2>/dev/null)
+if [[ -z "$TOKEN" ]]; then
+    echo '{"error": "Failed to get token from service account keyfile — check KEYFILE path"}' >&2
+    exit 1
+fi
+printf '{"Authorization": "Bearer %s", "x-goog-user-project": "evs-datastack-prod"}\n' "$TOKEN"

--- a/.claude/hooks/dbt-mcp.sh
+++ b/.claude/hooks/dbt-mcp.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Launcher for the dbt MCP server (dbt Labs `dbt-mcp`), local dbt Core mode.
+# Sources .env so dbt can resolve profiles.yml — no secrets stored in .mcp.json.
+# Runs via `pipx run` on python3.12 (dbt-mcp requires >=3.12): isolated, ephemeral,
+# does NOT touch dbt_venv (python 3.11) — dbt itself is invoked via DBT_PATH.
+set -euo pipefail
+
+# Resolve project root from this launcher's location (.claude/hooks/ → two levels up).
+# Keeps the launcher portable across machines / checkout paths.
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Load dbt env vars (DBT_BIGQUERY_PROJECT, DBT_BIGQUERY_KEYFILE, etc.) for profile resolution.
+set -a
+# shellcheck disable=SC1091
+source "${PROJECT_DIR}/.env"
+set +a
+
+# MCP server config — local Core only; everything requiring dbt Cloud is disabled.
+export DBT_PROJECT_DIR="${PROJECT_DIR}"
+export DBT_PATH="${PROJECT_DIR}/dbt_venv/bin/dbt"
+export DBT_PROFILES_DIR="${PROJECT_DIR}"
+export DISABLE_SEMANTIC_LAYER="true"
+export DISABLE_DISCOVERY="true"
+export DISABLE_ADMIN_API="true"
+export DISABLE_SQL="true"
+export DISABLE_LSP="true"
+export DISABLE_DBT_CODEGEN="false"
+
+exec pipx run --python /usr/bin/python3.12 --spec dbt-mcp dbt-mcp

--- a/.claude/hooks/lint-sql.sh
+++ b/.claude/hooks/lint-sql.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Hook: PostToolUse → lint .sql files in models/ after every Edit or Write
+# Exit 0 = no issues; exit 2 = lint errors found (Claude sees output and fixes them)
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('tool_input', {}).get('file_path', ''))")
+
+# Only act on .sql files inside models/
+[[ "$FILE_PATH" == *.sql && "$FILE_PATH" == */models/* ]] || exit 0
+
+# Use dbt templater to correctly resolve ref(), source(), and custom macros.
+# Jinja templater was faster but broke on dbt-specific Jinja (ref, dbt_utils, project macros).
+REPO_ROOT="$(git -C "$(dirname "$FILE_PATH")" rev-parse --show-toplevel 2>/dev/null)"
+SQLFLUFF_BIN="sqlfluff"
+if [[ -n "$REPO_ROOT" && -x "$REPO_ROOT/dbt_venv/bin/sqlfluff" ]]; then
+    SQLFLUFF_BIN="$REPO_ROOT/dbt_venv/bin/sqlfluff"
+fi
+OUTPUT=$("$SQLFLUFF_BIN" lint "$FILE_PATH" 2>&1)
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+    echo "SQLFluff lint failed for $FILE_PATH:" >&2
+    echo "$OUTPUT" >&2
+    exit 2
+fi

--- a/.claude/hooks/parse-yaml.sh
+++ b/.claude/hooks/parse-yaml.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Hook: PostToolUse → run dbt parse after every .yml edit in models/
+# Catches broken ref(), missing columns, and YAML schema errors immediately.
+# Exit 0 = parse OK; exit 2 = parse error (Claude sees output and fixes it)
+
+INPUT=$(cat)
+FILE_PATH=$(echo "$INPUT" | python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('tool_input', {}).get('file_path', ''))")
+
+# Only act on .yml files inside models/
+[[ "$FILE_PATH" == *.yml && "$FILE_PATH" == */models/* ]] || exit 0
+
+# Resolve project root from this hook's location (.claude/hooks/ → two levels up).
+# Keeps the hook portable across machines / checkout paths.
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Load project env vars so dbt can connect
+ENV_FILE="${PROJECT_DIR}/.env"
+if [[ -f "$ENV_FILE" ]]; then
+    set -a
+    # shellcheck source=/dev/null
+    source "$ENV_FILE"
+    set +a
+fi
+
+OUTPUT=$(cd "$PROJECT_DIR" && ./dbt_venv/bin/dbt parse 2>&1)
+RC=$?
+
+if [[ $RC -ne 0 ]]; then
+    echo "dbt parse failed after editing $FILE_PATH:" >&2
+    echo "$OUTPUT" >&2
+    exit 2
+fi

--- a/.claude/hooks/pbi-auth-headers.sh
+++ b/.claude/hooks/pbi-auth-headers.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Helper: fetches Power BI Bearer token via client credentials (Azure AD service principal)
+# Credentials: tenant/client IDs hardcoded (non-sensitive); secret fetched from GCP Secret Manager
+
+TENANT_ID="89952e84-b730-40e0-b247-e35f466c6658"
+CLIENT_ID="f8b4a457-c63b-49d8-8c9a-0f0db384f2b8"
+PROJECT="evs-datastack-prod"
+SECRET_NAME="pbi-client-secret"
+
+CLIENT_SECRET=$(gcloud secrets versions access latest \
+    --secret="$SECRET_NAME" \
+    --project="$PROJECT" 2>/dev/null)
+
+if [[ -z "$CLIENT_SECRET" ]]; then
+    echo '{"error": "Failed to fetch pbi-client-secret from Secret Manager — check gcloud auth"}' >&2
+    exit 1
+fi
+
+RESPONSE=$(curl -s -X POST \
+    "https://login.microsoftonline.com/${TENANT_ID}/oauth2/v2.0/token" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -d "grant_type=client_credentials&client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&scope=https://analysis.windows.net/powerbi/api/.default")
+
+TOKEN=$(echo "$RESPONSE" | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+
+if [[ -z "$TOKEN" ]]; then
+    echo '{"error": "Failed to obtain Power BI token from Microsoft"}' >&2
+    exit 1
+fi
+
+printf '{"Authorization": "Bearer %s"}\n' "$TOKEN"

--- a/.claude/hooks/pbi-mcp-remote.sh
+++ b/.claude/hooks/pbi-mcp-remote.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Fetches a Power BI Bearer token, then launches mcp-remote with the token injected.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HEADERS=$("$SCRIPT_DIR/pbi-auth-headers.sh")
+TOKEN=$(echo "$HEADERS" | grep -o '"Authorization": *"Bearer [^"]*"' | grep -o 'Bearer [^"]*')
+if [[ -z "$TOKEN" ]]; then
+    echo "Failed to get Power BI token" >&2
+    exit 1
+fi
+exec npx mcp-remote "https://api.fabric.microsoft.com/v1/mcp/powerbi" \
+    --header "Authorization:$TOKEN"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/lint-sql.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/parse-yaml.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,11 +6,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/lint-sql.sh"
+            "command": "/mnt/data/transform/.claude/hooks/lint-sql.sh"
           },
           {
             "type": "command",
-            "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/parse-yaml.sh"
+            "command": "/mnt/data/transform/.claude/hooks/parse-yaml.sh"
           }
         ]
       }

--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -42,8 +42,8 @@ All optional, positional:
 
 ## What it checks
 
-Source of truth for every rule is `CONVENTIONS.md` (§ Nommage des marts,
-§ Marts — pattern complet) and `CLAUDE.md`. Each finding gets a priority.
+Source of truth for every rule is `CONVENTIONS.md` (§ Nommage des marts),
+`docs/conventions/marts.md` (§ Marts — pattern complet) and `CLAUDE.md`. Each finding gets a priority.
 
 ### P1 — Trust / correctness (mislead the SQL or the user)
 

--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: audit-docs
+description: Audit dbt documentation quality of marts against real BigQuery data. Detects undocumented columns, undocumented enums, naming-convention violations (is_*/has_* non-boolean, *_date/*_at type mismatches), weak model descriptions (4-block trame / missing grain), and missing PK/FK tests. Produces a prioritized report with ready-to-paste YAML for mechanical fixes and templates for business meaning. Read-only — proposes, never edits.
+argument-hint: "[bu] [layer] [model] (e.g. 'neshu marts consommation')"
+user-invocable: true
+---
+
+# Audit Docs — Documentation Quality of the Consumed Layer
+
+Close the virtuous loop: surface where the dbt documentation is incomplete or
+inconsistent **vs the real BigQuery data**, so the data engineer knows exactly
+what to document and where. This audits the *consumed* layer (marts first) —
+the surface the DATA pole and Power BI actually read.
+
+This skill **proposes**, it never edits models or YAML. For anything that needs
+business meaning (what an enum value means, the grain), it emits a *template*
+for the DE to fill — it must not invent semantics.
+
+## Arguments
+
+All optional, positional:
+
+- `$0` — BU (e.g. `neshu`, `finance`). If omitted, audit ALL marts BUs.
+- `$1` — layer: `marts` (default). `intermediate` / `staging` supported but
+  lower priority (the consumed layer is marts).
+- `$2` — specific model name (e.g. `consommation`, `company`). If omitted,
+  audit all models in scope.
+
+### Usage examples
+
+```
+/audit-docs                          → all marts, all BUs
+/audit-docs neshu                    → all marts of the neshu BU
+/audit-docs neshu marts consommation → just fct_neshu__consommation
+/audit-docs finance                  → all marts of the finance BU
+```
+
+**BUs:** `technique`, `commerce`, `finance`, `services_generaux`, `supply_chain`,
+`neshu`, `lcdp`.
+**dbt files:** `models/marts/<bu>/{dim,fct}_<bu>__<entity>.sql` + `.yml`.
+**BigQuery dataset:** `prod_marts` (project `evs-datastack-prod`).
+
+## What it checks
+
+Source of truth for every rule is `CONVENTIONS.md` (§ Nommage des marts,
+§ Marts — pattern complet) and `CLAUDE.md`. Each finding gets a priority.
+
+### P1 — Trust / correctness (mislead the SQL or the user)
+
+| Check | How |
+|---|---|
+| **Undocumented enum** | low-cardinality STRING column (≤ 25 distinct) whose YAML has **no `accepted_values` test** AND whose description doesn't list the values. Detect real values via `distinct_values`. These are filter columns — undocumented = invented WHERE values. |
+| **Boolean naming violation** | `is_*` / `has_*` column whose BQ type is **not BOOL** (e.g. `is_done` INT64). |
+| **Date/time suffix violation** | `*_date` not `DATE`; `*_at` not `TIMESTAMP`. |
+| **Missing grain** | model description has no `[GRAIN]` block / no "1 ligne par X" statement. |
+
+### P2 — Completeness
+
+| Check | How |
+|---|---|
+| **Undocumented column** | BQ column with no description in manifest/YAML (ignore system cols below). |
+| **Weak model description** | missing, or not following the 4-block trame `[QUOI MÉTIER]` / `[COMMENT CONSTRUITE]` / `[GRAIN]` / `[NOTES]`. |
+| **Missing PK tests (dim)** | `dim_` without `unique` + `not_null` on its PK (`<entity>_id`). |
+| **Missing FK tests (fct)** | `fct_` FK column (`*_id`) without a `relationships` test. |
+
+### P3 — Data smells (flag, don't block)
+
+| Check | How |
+|---|---|
+| **Inconsistent categoricals** | mixed casing / near-duplicate values in an enum (e.g. `categorie_machine`). |
+| **Suspicious values** | obvious typos in distinct values (e.g. `Tâche dactivité`). |
+
+## Steps
+
+### 1. Resolve scope
+Map BU(s) → marts models (read `models/marts/<bu>/` for SQL + YAML file names).
+
+### 2. Read current docs (the anti-drift step)
+Prefer `target/manifest.json` + `target/catalog.json` — descriptions live there
+via `persist_docs`, and catalog has every column + BQ type. Fall back to the
+`.yml` files. **Always read the current state** so you never propose a fix that
+already exists.
+
+### 3. Gather BQ reality
+- Columns + types: from `catalog.json`, or `mcp__bigquery__get_table_info`.
+- Enum values: `mcp__bigquery__execute_sql_readonly` with
+  `SELECT <col> AS value, count(*) n FROM prod_marts.<table> GROUP BY value ORDER BY n DESC LIMIT 30`.
+  Only probe STRING columns that look categorical (skip free-text, ids, names).
+
+### 4. Cross-reference, prioritize, and report
+Group by table, P1 → P3. For each finding: **what** / **why (which convention)**
+/ **suggested fix**. Split fixes into:
+- **Mécanique** — you write the ready-to-paste YAML (column description for an
+  obvious field, `accepted_values` with the real values you observed, a test block).
+- **Sens métier** — you emit a *template* with the observed facts (e.g. "enum
+  `resp` = {0, 50, 100} — signification ? remplir la description") for the DE.
+
+## Output format
+
+```
+# Audit docs — <scope>
+
+## fct_neshu__consommation (prod_marts)
+
+### P1
+- [enum non documenté] `data_source` = {TELEMETRIE, CHARGEMENT, LIVRAISON} — aucun accepted_values.
+  → Mécanique, à coller :
+      - name: data_source
+        description: "Source de la consommation : TELEMETRIE | CHARGEMENT | LIVRAISON."
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['TELEMETRIE', 'CHARGEMENT', 'LIVRAISON']
+- [grain manquant] la description n'a pas de bloc [GRAIN].
+  → Template : "[GRAIN] 1 ligne par ____ (à préciser)."
+
+### P2
+- [colonne sans description] `location` — non documentée.
+  → Template (sens métier) : décrire `location`.
+
+## Résumé
+- Modèles audités : N
+- Trous P1 : x · P2 : y · P3 : z
+- Top 3 à traiter en premier : ...
+```
+
+## Important notes
+
+- **Read-only.** Never edit a model, YAML, or run a write. Propose only.
+- **Never invent business meaning.** Enum semantics, grain, ambiguous columns →
+  template for the DE, not a guessed description.
+- **Ignore system columns**: `dbt_updated_at`, `dbt_invocation_id`, `_sdc_*`,
+  and the standard staging timestamps when auditing upstream.
+- Cap enum probes at cardinality ≤ 25 and skip obvious free-text / id / name /
+  code columns (high cardinality) — they aren't enums.
+- Generic test args nest under `arguments:` (dbt ≥ 1.11), per `CONVENTIONS.md`.
+- Marts descriptions live in **YAML only** (not the SQL config block) — propose
+  YAML edits, never `{{ config(description=...) }}` for marts.
+- Project is always `evs-datastack-prod`. Be thorough but concise — flag gaps,
+  don't list what's already fine.
+- This finds **where** to document; the DE provides **what**. That division is
+  the point of the loop.

--- a/.claude/skills/audit-docs/SKILL.md
+++ b/.claude/skills/audit-docs/SKILL.md
@@ -42,8 +42,8 @@ All optional, positional:
 
 ## What it checks
 
-Source of truth for every rule is `CONVENTIONS.md` (§ Nommage des marts),
-`docs/conventions/marts.md` (§ Marts — pattern complet) and `CLAUDE.md`. Each finding gets a priority.
+Source of truth for every rule is `docs/conventions/marts.md` (§ Nommage + § Marts — pattern complet),
+the transversal rules in `CONVENTIONS.md`, and `CLAUDE.md`. Each finding gets a priority.
 
 ### P1 — Trust / correctness (mislead the SQL or the user)
 

--- a/.claude/skills/audit-sources/SKILL.md
+++ b/.claude/skills/audit-sources/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: audit-sources
+description: Audit dbt models against real BigQuery schemas. Detects missing columns, stale references, and schema drift between dbt SQL/YAML and actual BigQuery tables. Works on any layer (raw, staging, intermediate, marts) and can target a specific model.
+argument-hint: "[source] [layer] [model] (e.g. 'oracle_neshu staging company')"
+user-invocable: true
+---
+
+# Audit Sources — Schema Drift Detection
+
+Compare dbt definitions against real BigQuery schemas to detect drift, missing columns, and stale references.
+
+## Arguments
+
+All arguments are optional and positional:
+
+- `$0` — source name (e.g. `oracle_neshu`). If omitted, audit ALL sources.
+- `$1` — layer to audit: `raw` (default), `staging`, `intermediate`, or `marts`
+- `$2` — specific entity/model name (e.g. `company`, `device`). If omitted, audit all models in the layer.
+
+### Usage examples
+
+```
+/audit-sources                                    → all sources, raw vs _sources.yml
+/audit-sources oracle_neshu                       → one source, raw vs _sources.yml
+/audit-sources oracle_neshu staging               → all staging models for oracle_neshu
+/audit-sources oracle_neshu staging company       → just stg_oracle_neshu__company
+/audit-sources oracle_neshu marts device          → just dim_oracle_neshu__device (or fct_)
+/audit-sources yuman intermediate                 → all intermediate models for yuman
+```
+
+## Audit logic per layer
+
+### Layer: `raw` (default)
+
+Compare `_sources.yml` declarations and staging SQL against actual `prod_raw` tables.
+
+| Check | Description |
+|-------|-------------|
+| **Missing in BQ** | Table declared in `_sources.yml` but not in `prod_raw` |
+| **Missing in dbt** | Table in `prod_raw` (matching source prefix) but not declared |
+| **No staging model** | Table declared in sources but no `stg_` SQL file exists |
+| **Missing columns** | Column in BQ but not selected in staging model |
+| **Extra columns** | Column referenced in staging but not in BQ (potential breakage) |
+| **Undeclared columns** | Column in BQ, selected in staging, but not in `_sources.yml` |
+
+**BigQuery dataset:** `prod_raw`
+**dbt files:** `models/staging/<source>/_<source>__sources.yml` + `stg_<source>__*.sql`
+
+### Layer: `staging`
+
+Compare actual `prod_staging` tables in BigQuery against staging SQL model definitions.
+
+| Check | Description |
+|-------|-------------|
+| **Column mismatch** | Column in BQ `prod_staging` table but not in the SQL select |
+| **Extra in SQL** | Column in SQL but not materialized in BQ (build may be stale) |
+| **Type mismatch** | Column type in BQ differs from what the SQL cast produces |
+
+**BigQuery dataset:** `prod_staging`
+**dbt files:** `models/staging/<source>/stg_<source>__<entity>.sql`
+**Model name pattern:** `stg_<source>__<entity>`
+
+### Layer: `intermediate`
+
+Same checks as staging, against `prod_intermediate`.
+
+**BigQuery dataset:** `prod_intermediate`
+**dbt files:** `models/intermediate/<source>/int_<source>__<entity>.sql`
+**Model name pattern:** `int_<source>__<entity>`
+
+### Layer: `marts`
+
+Same checks as staging, against `prod_marts`. Models can have `dim_` or `fct_` prefix.
+
+**BigQuery dataset:** `prod_marts`
+**dbt files:** `models/marts/<source>/dim_<source>__<entity>.sql` or `fct_<source>__<entity>.sql`
+**Model name pattern:** `dim_<source>__<entity>` or `fct_<source>__<entity>`
+
+## Steps
+
+### 1. Parse arguments and determine scope
+
+- Identify source(s), layer, and optional model filter
+- Map the layer to the correct BigQuery dataset and dbt file paths
+
+### 2. Gather BigQuery-side info
+
+- Use `mcp__bigquery__get_table_info` for targeted model audits (one table)
+- Use `mcp__bigquery__list_table_ids` + `get_table_info` for broader audits
+- Project is always `evs-datastack-prod`
+
+### 3. Gather dbt-side info
+
+- Read the relevant SQL file(s) to understand which columns are selected/cast
+- Read the relevant YAML file(s) for declared columns and tests
+
+### 4. Cross-reference and report
+
+Present results grouped by model:
+
+```
+## Audit: oracle_neshu / staging
+
+### stg_oracle_neshu__company (prod_staging)
+- OK: 10/10 columns match
+- No drift detected
+
+### stg_oracle_neshu__device (prod_staging)
+- DRIFT: column `firmware_version` exists in BQ but not in SQL
+- DRIFT: column `old_status` in SQL but not in BQ — potential breakage
+- TYPE: `iddevice` is STRING in BQ, cast to INT64 in SQL — verify intent
+
+### Summary
+- Models checked: 18
+- Clean: 15
+- With drift: 3 (5 issues total)
+```
+
+## Important notes
+
+- Use `mcp__bigquery__execute_sql_readonly` if `get_table_info` doesn't provide enough detail
+- Ignore `_sdc_*` columns — they are Meltano system metadata
+- The BigQuery project is always `evs-datastack-prod`
+- Dataset mapping: raw → `prod_raw`, staging → `prod_staging`, intermediate → `prod_intermediate`, marts → `prod_marts`
+- When auditing a specific model (`$2`), try both `dim_` and `fct_` prefixes for marts layer
+- Be thorough but concise — flag issues, don't repeat OK columns

--- a/.claude/skills/profile/SKILL.md
+++ b/.claude/skills/profile/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: profile
+description: Profile a BigQuery table from prod_raw before writing a dbt staging model. Shows column types, null rates, cardinality, sample values, and row count.
+argument-hint: "<table_name> (e.g. evs_company or oracle_neshu.evs_company)"
+user-invocable: true
+---
+
+# Profile a BigQuery Table
+
+Run a data profiling analysis on a `prod_raw` table to understand its shape before writing a dbt model.
+
+## Arguments
+
+`$ARGUMENTS` — the table to profile. Accepts:
+- Just the table name: `evs_company` (assumes `prod_raw` dataset)
+- Full path: `oracle_neshu.evs_company` (source.table — still uses `prod_raw` dataset)
+
+## Steps
+
+### 1. Get table metadata
+
+Use `mcp__bigquery__get_table_info` with:
+- projectId: `evs-datastack-prod`
+- datasetId: `prod_raw`
+- tableId: the table name from `$ARGUMENTS`
+
+Note the schema (column names and types), row count, and size.
+
+### 2. Run profiling query
+
+Use `mcp__bigquery__execute_sql_readonly` to run a single profiling query.
+
+Build a query that computes for each column:
+- **null_count** and **null_pct** — how many nulls
+- **distinct_count** — cardinality
+- **min / max** — for numeric and date/timestamp columns
+- **sample values** — a few example values for string columns
+
+Example pattern (adapt to actual columns):
+
+```sql
+select
+    count(*) as total_rows,
+
+    -- For each column:
+    countif(column_name is null) as column_name__nulls,
+    count(distinct column_name) as column_name__distinct,
+    min(column_name) as column_name__min,
+    max(column_name) as column_name__max
+from `evs-datastack-prod.prod_raw.TABLE_NAME`
+```
+
+For tables with many columns, split into multiple queries if needed (BigQuery has output limits).
+
+### 3. Get sample rows
+
+```sql
+select * from `evs-datastack-prod.prod_raw.TABLE_NAME` limit 5
+```
+
+### 4. Present the profile report
+
+```
+## Profile: prod_raw.evs_company
+Rows: 1,234 | Size: 2.3 MB | Last modified: 2026-04-07
+
+| Column | Type | Nulls | Null% | Distinct | Min | Max | Sample |
+|--------|------|-------|-------|----------|-----|-----|--------|
+| idcompany | INT64 | 0 | 0% | 1234 | 1 | 5678 | — |
+| name | STRING | 12 | 1% | 1100 | — | — | "Acme Corp" |
+| ...
+
+### Observations
+- column_x has 45% nulls — consider coalesce or filter
+- column_y has only 3 distinct values — candidate for enum/label
+- _sdc_extracted_at range: 2024-01-01 to 2026-04-07
+```
+
+### 5. Staging readiness recommendations
+
+Based on the profile, suggest:
+- Which columns to cast and to what type
+- Which columns need coalesce for nulls
+- Which columns look like foreign keys (naming pattern `id*`)
+- Which columns are candidates for `created_at`, `updated_at` mapping
+- Any data quality concerns (high null rates, low cardinality anomalies)
+
+## Important notes
+
+- Always use `mcp__bigquery__execute_sql_readonly` (never `execute_sql`)
+- Limit profiling queries to avoid scanning too much data on large tables — use `limit` or sampling if row count > 1M
+- Ignore `_sdc_*` columns in recommendations (they're system metadata) but do include them in the profile
+- The output should help the user write a correct staging model on the first try

--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,11 @@ __pycache__/
 .vscode/
 .DS_Store
 
-# Claude Code
-CLAUDE.md
-.mcp.json
-.claude/
+# Claude Code — la couche IA partagee est versionnee (CLAUDE.md, .mcp.json,
+# .claude/commands/, .claude/skills/, .claude/hooks/, .claude/settings.json).
+# On garde hors git uniquement les reglages perso et les notes de travail :
+.claude/settings.local.json
+.claude/notes/
 
 # Keyfile test
 keyfile.b64.txt

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,19 @@
+{
+  "mcpServers": {
+    "bigquery": {
+      "type": "http",
+      "url": "https://bigquery.googleapis.com/mcp",
+      "headersHelper": "${CLAUDE_PROJECT_DIR}/.claude/hooks/bq-auth-headers.sh"
+    },
+    "powerbi-remote": {
+      "type": "stdio",
+      "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pbi-mcp-remote.sh",
+      "args": []
+    },
+    "dbt-local": {
+      "type": "stdio",
+      "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/dbt-mcp.sh",
+      "args": []
+    }
+  }
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,16 +3,16 @@
     "bigquery": {
       "type": "http",
       "url": "https://bigquery.googleapis.com/mcp",
-      "headersHelper": "${CLAUDE_PROJECT_DIR}/.claude/hooks/bq-auth-headers.sh"
+      "headersHelper": "/mnt/data/transform/.claude/hooks/bq-auth-headers.sh"
     },
     "powerbi-remote": {
       "type": "stdio",
-      "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/pbi-mcp-remote.sh",
+      "command": "/mnt/data/transform/.claude/hooks/pbi-mcp-remote.sh",
       "args": []
     },
     "dbt-local": {
       "type": "stdio",
-      "command": "${CLAUDE_PROJECT_DIR}/.claude/hooks/dbt-mcp.sh",
+      "command": "/mnt/data/transform/.claude/hooks/dbt-mcp.sh",
       "args": []
     }
   }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Pre-commit guardrails — run regardless of who (or what) wrote the code.
+# Mirrors the Claude Code PostToolUse hooks (.claude/hooks/) so a human editing
+# without the AI cannot bypass linting.
+#
+# Install once per clone (isolated, ne pollue pas dbt_venv) :
+#   pipx install pre-commit
+#   pre-commit install              # commit-stage hooks (sqlfluff)
+#   pre-commit install --hook-type pre-push   # pre-push hooks (dbt parse)
+#
+# Hooks call ./dbt_venv/bin/* directly — single source of truth for tool versions
+# (sqlfluff/dbt pinned in requirements.txt). No duplicated tool install here.
+
+repos:
+  - repo: local
+    hooks:
+      # --- commit stage : lint SQL models with the dbt templater ---
+      - id: sqlfluff-lint
+        name: sqlfluff lint (models)
+        language: system
+        entry: bash -c 'set -a; [ -f .env ] && . ./.env; set +a; exec ./dbt_venv/bin/sqlfluff lint "$@"' --
+        files: ^models/.*\.sql$
+        pass_filenames: true
+
+      # --- pre-push stage : full dbt parse (slow + needs .env, shows dbt warnings) ---
+      - id: dbt-parse
+        name: dbt parse (whole project)
+        language: system
+        entry: bash -c 'set -a; [ -f .env ] && . ./.env; set +a; exec ./dbt_venv/bin/dbt parse'
+        pass_filenames: false
+        always_run: true
+        stages: [pre-push]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Seeds are in `data/reference_data/<source>/` and land in `prod_reference` / `dev
 - Booleans: `is_` / `has_` prefix · timestamps: `_at` suffix · dates: `_date` suffix
 - Every staging model exposes: `created_at`, `updated_at`, `extracted_at`, `deleted_at`
 
-Voir `CONVENTIONS.md` § Nommage des marts pour les règles complètes (suffixe de grain, suffixe de source si collision, etc.).
+Voir [`docs/conventions/marts.md`](docs/conventions/marts.md) § Nommage pour les règles complètes (suffixe de grain, suffixe de source si collision, etc.).
 
 ---
 
@@ -91,11 +91,11 @@ dbt build -s +exposure:business_review
 
 ## Workflow for new models
 
-Always follow this order — never skip layers:
+Always follow this order — never skip layers. Each layer has a dedicated convention doc — read it before writing:
 
-1. **Staging** — rename/cast columns, harmonise timestamps, expose all source fields
-2. **Intermediate** — business logic, task-type splits, cross-source joins
-3. **Marts** — final dims and facts for BI consumption
+1. **Staging** ([`docs/conventions/staging.md`](docs/conventions/staging.md)) — clean/cast columns (passthrough naming), harmonise timestamps, expose all source fields. One staging model = one source table.
+2. **Intermediate** ([`docs/conventions/intermediate.md`](docs/conventions/intermediate.md)) — business logic, task-type splits, enrichment. **Source-aligned, NOT cross-source** — multi-source unification happens in marts.
+3. **Marts** ([`docs/conventions/marts.md`](docs/conventions/marts.md)) — final dims and facts for BI consumption.
 
 For each new model, create the SQL and its YAML entry in the same PR:
 - Staging YAML: `_<source>__models.yml` in the same folder
@@ -229,16 +229,15 @@ After any model creation, deletion, or convention change, update the relevant do
 - Step-by-step model creation process if the workflow changes
 - Checklist before merge if new quality gates are added
 
-**`CONVENTIONS.md`** — the single source of truth for rules (with a `## Sommaire` TOC at the top):
-- Naming conventions (models, columns, files)
-- SQL patterns (staging boilerplate, label pivot pattern, etc.)
-- Materialisation defaults
-- Test strategy and severity rules
-- SQLFluff rules
+**`CONVENTIONS.md`** — now a **minimal global index**. Holds only transversal rules (naming format, columns, materialisation summary, test/severity strategy, SQLFluff, tags) + a router table to the per-layer docs. Layer-specific rules live in `docs/conventions/`, NOT here.
 
-**`docs/conventions/marts.md`** — extracted marts pattern (loaded on demand): star schema rules, 4-block YAML description trame, config hygiene, minimum tests per layer, anti-patterns, SQL skeleton, grain-first column order. Update here (not in `CONVENTIONS.md`) when a marts rule changes.
+**`docs/conventions/{staging,intermediate,marts,seeds-snapshots}.md`** — the per-layer/-resource convention docs, loaded on demand. Each follows the same skeleton (rôle · nommage · colonnes · pattern SQL · matérialisation · description · tests minimum · freshness · anti-patterns · checklist PR). **Update the relevant layer doc** when a rule for that layer changes — that's the source of truth now:
+- `staging.md` — passthrough naming rule, system columns, CTE pattern, incremental, tests, freshness method A/B
+- `intermediate.md` — source-aligned (not cross-source), ref-only, incremental, tests
+- `marts.md` — naming by BU, star schema, 4-block description trame, config hygiene, tests, anti-patterns, grain-first order
+- `seeds-snapshots.md` — CSV seeds (column_types, BigQuery types, BOM), SCD2 snapshots
 
-**`docs/freshness.md`** — source freshness authority: tiers, monitoring mechanisms (A/B), per-source target state. `CONVENTIONS.md § Source freshness` only points here.
+**`docs/freshness.md`** — source freshness authority: tiers, monitoring mechanisms (A/B), per-source target state. `CONVENTIONS.md § Source freshness` and `staging.md § 8` only point here.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,264 @@
+# CLAUDE.md — dbt_warehouse (EVS Professionnelle France)
+
+## Project overview
+ELT data warehouse for EVS Professionnelle France.
+**Stack:** Meltano + Cloud Run jobs (extract) → BigQuery `prod_raw` (lake) → dbt (transform) → GCP Cloud Workflows (orchestrate) → Power BI (viz)
+**dbt version:** 1.11.7 / dbt-bigquery 1.11.1
+**Team:** 1 Data Engineer (owner), 1 Data Analyst (contributes to marts)
+
+---
+
+## Local dev setup
+
+Required env vars (set in `.env`):
+```
+DBT_BIGQUERY_PROJECT=evs-datastack-prod
+DBT_BIGQUERY_KEYFILE=/path/to/keyfile.json
+DBT_BIGQUERY_DATASET_DEV=dev_      # prefix — actual datasets are dev_staging, dev_intermediate, dev_marts
+DBT_TARGET=dev                     # defaults to dev if not set
+```
+
+Default target is `dev`. Dev uses the same GCP project as prod but writes to `dev_*` datasets.
+Never run against `prod` target unless explicitly asked.
+
+---
+
+## Architecture — 3 layers
+
+| Layer | Schema | Materialization |
+|---|---|---|
+| `models/staging/` | `prod_staging` / `dev_staging` | table (one model = `incremental`) |
+| `models/intermediate/` | `prod_intermediate` / `dev_intermediate` | table |
+| `models/marts/` | `prod_marts` / `dev_marts` | table |
+
+**10 sources** in `prod_raw`: `oracle_neshu`, `oracle_lcdp`, `yuman`, `nesp_tech`, `nesp_co`, `mssql_sage`, `gac`, `yuman_gcs`, `oracle_neshu_gcs`, `oracle_lcdp_gcs`
+
+Seeds are in `data/reference_data/<source>/` and land in `prod_reference` / `dev_reference`.
+
+---
+
+## Naming conventions
+
+- **Staging / intermediate** : `<prefix>_<source>__<entity>.sql` (par source)
+- **Marts** : `<prefix>_<bu>__<entity>.sql` (par BU/domaine, **post-refacto by BU**)
+  - BUs : `neshu`, `lcdp`, `technique`, `commerce`, `finance`, `services_generaux`, `supply_chain`
+  - Entité **singulier**, snake_case, nom métier (pas le nom source, pas le nom du rapport BI)
+- Prefixes: `stg_` staging · `int_` intermediate · `dim_` dimension · `fct_` fact · `snap_` snapshot
+- YAML files: `_<source>__models.yml` (staging/intermediate) · `_<bu>__marts_models.yml` (marts) · `_<bu>__marts_sources.yml` (external Cloud Run tables)
+- Seeds: `ref_<source>__<entity>.csv`
+- Columns: snake_case · IDs as `id<entity>` in staging, `<entity>_id` in marts
+- Booleans: `is_` / `has_` prefix · timestamps: `_at` suffix · dates: `_date` suffix
+- Every staging model exposes: `created_at`, `updated_at`, `extracted_at`, `deleted_at`
+
+Voir `CONVENTIONS.md` § Nommage des marts pour les règles complètes (suffixe de grain, suffixe de source si collision, etc.).
+
+---
+
+## Common commands
+
+```bash
+# Build a specific model and its dependencies
+dbt build -s +dim_oracle_neshu__resources
+
+# Build all models for a source (by tag)
+dbt build --select tag:oracle_neshu
+
+# Build a full layer
+dbt build --select tag:staging
+dbt build --select tag:intermediate
+dbt build --select tag:marts
+
+# Lint before committing
+sqlfluff lint models/path/to/model.sql --templater jinja
+
+# Fix lint issues automatically
+sqlfluff fix models/path/to/model.sql --templater jinja
+
+# Run source freshness
+dbt source freshness
+
+# List all exposures
+dbt ls --select exposure:*
+
+# Build all models feeding a specific BI report
+dbt build -s +exposure:business_review
+```
+
+> Note: `sqlfluff` requires `--templater jinja` when `DBT_BIGQUERY_PROJECT` is not set,
+> otherwise use the default dbt templater with env vars loaded.
+
+---
+
+## Workflow for new models
+
+Always follow this order — never skip layers:
+
+1. **Staging** — rename/cast columns, harmonise timestamps, expose all source fields
+2. **Intermediate** — business logic, task-type splits, cross-source joins
+3. **Marts** — final dims and facts for BI consumption
+
+For each new model, create the SQL and its YAML entry in the same PR:
+- Staging YAML: `_<source>__models.yml` in the same folder
+- Marts YAML: `_<bu>__marts_models.yml` in the BU folder
+
+### Staging pattern
+```sql
+{{ config(materialized='table') }}
+with source_data as (select * from {{ source('...', '...') }}),
+cleaned_data as (
+    select
+        cast(id as int64) as id,
+        ...
+        timestamp(creation_date) as created_at,
+        timestamp(coalesce(modification_date, creation_date)) as updated_at,
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+    from source_data
+)
+select * from cleaned_data
+```
+
+### Marts dim pattern (label pivot)
+Oracle Neshu dims use an EAV label system. Standard pattern (staging refs stay per-source, output dim is per-BU):
+```sql
+with entity_labels as (
+    select e.*, l.code as label_code, lf.code as label_family_code
+    from {{ ref('stg_oracle_neshu__entity') }} as e
+    left join {{ ref('stg_oracle_neshu__label_has_entity') }} as lhe
+        on e.identity = lhe.identity and lhe.idlabel is not null
+    left join {{ ref('stg_oracle_neshu__label') }} as l on lhe.idlabel = l.idlabel
+    left join {{ ref('stg_oracle_neshu__label_family') }} as lf on l.idlabel_family = lf.idlabel_family
+),
+aggregated_labels as (
+    select
+        ...,
+        max(case when label_family_code = 'ISACTIVE' then label_code end) as is_active
+    from entity_labels
+    group by ...
+)
+select
+    ...,
+    coalesce(lower(is_active) = 'yes', false) as is_active
+from aggregated_labels
+```
+> File path: `models/marts/neshu/dim_neshu__<entity>.sql`.
+
+### When creating or modifying a mart
+
+Always follow `CONVENTIONS.md` § Marts — pattern complet. 4 piliers :
+
+1. **Description YAML en 4 blocs** : `[QUOI MÉTIER]` / `[COMMENT CONSTRUITE]` / `[GRAIN]` / `[NOTES]`. Grain obligatoire (1 ligne par X).
+2. **Tests minimum** : Dim → `unique` + `not_null` sur PK (error) + `accepted_values` / row count range (warn). Fact → `not_null` + `relationships` sur chaque FK (warn) + `unique_combination_of_columns` sur clé composite + `expression_is_true` sur invariants.
+3. **Config block hygiène** : `{{ config() }}` pour matérialisation uniquement. Description en YAML, pas en config (persist_docs déjà actif). Pas de `tags=[...]` model-level.
+4. **Star schema strict** : pas de jointure fait-à-fait, pas de snowflake, pas d'OBT (cf. `docs/migration-marts/inventory.md` §5 pour le pattern hybride flatten/relations PBI).
+5. **Ordre des colonnes (`select` final)** : règle **grain-first** — colonnes du grain en tête (`dimension temporelle → PK → FK`), puis FK restantes → attributs texte → dates secondaires → booléens → mesures → métadonnées (`*_at`) en dernier. Convention indicative, non lintée. Détail + exemple : `CONVENTIONS.md` § Marts §7.
+
+**Avec le MCP BigQuery** : explorer la source upstream avant d'écrire le mart (`get_table_info` pour schéma, `SELECT DISTINCT` pour `accepted_values`, `COUNT(*)` pour les bornes `row_count_between`, `MIN/MAX(date)` pour les plages).
+
+### Exposures (Power BI reports)
+
+Exposures declare which Power BI reports consume which dbt models. One file per BU dans `models/exposures/` :
+- `neshu.yml` · `lcdp.yml` · `finance.yml` · `services_generaux.yml` · `supply_chain.yml`
+- `technique.yml`, `commerce.yml` à créer quand des rapports y seront affectés
+
+Update l'exposure correspondante dès qu'un mart est créé/modifié et consommé par un rapport BI. `ref()` pour dbt models, `source()` pour tables externes Cloud Run.
+
+### External marts sources
+
+Tables dans `prod_marts` écrites directement par des Cloud Run jobs (hors dbt). Déclarées comme sources dans `_<bu>__marts_sources.yml` au sein du folder BU :
+- `models/marts/neshu/_neshu__marts_sources.yml` — `fct_neshu__monitoring_passage_appro`
+- `models/marts/lcdp/_lcdp__marts_sources.yml` — `fct_lcdp__monitoring_passage_appro`
+
+Référencer via `source('marts_<bu>_external', '<table>')`. Ne jamais créer de modèle dbt wrappant ces tables.
+
+---
+
+## BigQuery configuration
+
+### Partitioning
+Partition on the **date/timestamp column used as the main filter in Power BI reports**.
+- Fact tables → partition on the primary date dimension (e.g. `consumption_date`, `task_start_date`)
+- Staging incremental models → partition on the timestamp used for the incremental filter
+- Use `data_type: 'date'` for date columns, `data_type: 'timestamp'` for timestamps
+- No partition needed on small dimension tables (company, product, etc.)
+
+### Clustering
+Cluster on **foreign key columns** used in JOINs or BI filters, up to 4 columns.
+- Typical: `cluster_by: ['company_id', 'product_id', 'device_id']`
+- For staging incremental: cluster on the FK columns most used in downstream joins
+
+### Incremental strategy
+Only `stg_oracle_neshu__task` is incremental today. Standard pattern:
+```sql
+{{ config(materialized='incremental', unique_key='id', incremental_strategy='merge') }}
+...
+{% if is_incremental() %}
+    where updated_at > (select max(updated_at) from {{ this }})
+       or updated_at >= timestamp_sub(current_timestamp(), interval 7 day)
+{% endif %}
+```
+
+---
+
+## Documentation maintenance
+
+After any model creation, deletion, or convention change, update the relevant docs **in the same work session**.
+
+### What triggers an update
+
+| Change | README.md | CONTRIBUTING.md | CONVENTIONS.md | Autre |
+|---|---|---|---|---|
+| New model added | — | — | — | — |
+| New source added | Add row in Sources table | Add source to "Ajouter une nouvelle source" steps | — | — |
+| New BI report / exposure added | — | — | — | Update `models/exposures/<bu>.yml` |
+| New naming/column convention | — | — | Update relevant section | — |
+| New SQLFluff rule | — | — | Update SQLFluff table | — |
+| New materialization pattern | — | Update "Ajouter un nouveau modele" steps | Update Materialisation table | — |
+| New mandatory test pattern | — | Update checklist | Update Tests / Marts section | — |
+| Workflow or PR process change | — | Update relevant section | — | — |
+| BigQuery config change (partition/cluster) | — | — | Add/update BigQuery section | — |
+| New BU / marts folder | — | — | — | Update `docs/migration-marts/` (Phase 0/1) si refacto en cours |
+
+### What to update in each doc
+
+**`README.md`** — high-level overview for anyone discovering the project:
+- Sources table: when a new source is added or an existing one changes
+
+**`CONTRIBUTING.md`** — practical workflow guide for the Data Analyst:
+- Step-by-step model creation process if the workflow changes
+- Checklist before merge if new quality gates are added
+
+**`CONVENTIONS.md`** — the single source of truth for rules:
+- Naming conventions (models, columns, files)
+- SQL patterns (staging boilerplate, label pivot pattern, etc.)
+- Materialisation defaults
+- Test strategy and severity rules
+- SQLFluff rules
+
+---
+
+## Hard rules
+
+- **Snapshots strategy/columns inchangés** — gérés par GCP Cloud Workflows. **Exception** : mettre à jour les `ref()` à l'intérieur d'un snapshot est OK quand une dim référencée est renommée (cf. PR neshu : `snap_oracle_neshu__company` ref → `dim_neshu__company`). Ne jamais renommer le fichier snapshot ni sa table BQ (historique SCD2 perdu).
+- **Never delete or drop tables** unless explicitly asked
+- **Never run against prod target** unless explicitly asked
+- **Never skip SQLFluff lint** before considering a model done
+- **Marts must follow a star schema** — facts (`fct_`) reference dimensions (`dim_`) via `<entity>_id` foreign keys only. No fact-to-fact joins (un fait peut toutefois en **agréger** un autre à un grain plus grossier via `GROUP BY`, ou l'**étendre** à grain strictement identique 1:1 — cf. `CONVENTIONS.md` § Marts), no snowflaked dimensions, no wide one-big-table marts. **Aplatir uniquement les attributs d'affichage du parent direct (1-3 colonnes max)**, jamais une dim parente entière. Voir `CONVENTIONS.md` § Marts — pattern complet.
+- **Description placement** : staging **doit** avoir `description='...'` dans `{{ config() }}` (cf. feedback memory, convention historique). Intermediate et **marts** : description en YAML uniquement, pas dans le config block (persist_docs gère BQ).
+- All contributions go through PRs — DE owns staging/intermediate/snapshots, DA contributes/reviews marts.
+  **Exception** : les changements docs-only (README, docs/, CONTRIBUTING) partent en push direct sur master, pas de PR. Master est protégée : le push direct passe avec les droits owner (sinon fallback PR + merge --admin).
+
+---
+
+## Key packages
+
+- `dbt_utils` 1.3.3 — `unique_combination_of_columns`, `expression_is_true`, `generate_surrogate_key`
+- `dbt_expectations` 0.10.10 — row count ranges, date ranges, regex, null rate checks
+
+## SQLFluff rules (v4)
+
+- Keywords, functions, types: **lowercase**
+- Indent: **4 spaces**
+- Max line length: **120 characters**
+- **No trailing commas**
+- Templater: `dbt` (requires env vars) or `jinja` as fallback

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,13 +145,13 @@ from aggregated_labels
 
 ### When creating or modifying a mart
 
-Always follow `CONVENTIONS.md` § Marts — pattern complet. 4 piliers :
+Always follow [`docs/conventions/marts.md`](docs/conventions/marts.md) (§ Marts — pattern complet). 4 piliers :
 
 1. **Description YAML en 4 blocs** : `[QUOI MÉTIER]` / `[COMMENT CONSTRUITE]` / `[GRAIN]` / `[NOTES]`. Grain obligatoire (1 ligne par X).
 2. **Tests minimum** : Dim → `unique` + `not_null` sur PK (error) + `accepted_values` / row count range (warn). Fact → `not_null` + `relationships` sur chaque FK (warn) + `unique_combination_of_columns` sur clé composite + `expression_is_true` sur invariants.
 3. **Config block hygiène** : `{{ config() }}` pour matérialisation uniquement. Description en YAML, pas en config (persist_docs déjà actif). Pas de `tags=[...]` model-level.
-4. **Star schema strict** : pas de jointure fait-à-fait, pas de snowflake, pas d'OBT (cf. `docs/migration-marts/inventory.md` §5 pour le pattern hybride flatten/relations PBI).
-5. **Ordre des colonnes (`select` final)** : règle **grain-first** — colonnes du grain en tête (`dimension temporelle → PK → FK`), puis FK restantes → attributs texte → dates secondaires → booléens → mesures → métadonnées (`*_at`) en dernier. Convention indicative, non lintée. Détail + exemple : `CONVENTIONS.md` § Marts §7.
+4. **Star schema strict** : pas de jointure fait-à-fait, pas de snowflake, pas d'OBT (cf. [`docs/conventions/marts.md`](docs/conventions/marts.md) § 1 pour le pattern hybride flatten/relations PBI).
+5. **Ordre des colonnes (`select` final)** : règle **grain-first** — colonnes du grain en tête (`dimension temporelle → PK → FK`), puis FK restantes → attributs texte → dates secondaires → booléens → mesures → métadonnées (`*_at`) en dernier. Convention indicative, non lintée. Détail + exemple : [`docs/conventions/marts.md`](docs/conventions/marts.md) § 7.
 
 **Avec le MCP BigQuery** : explorer la source upstream avant d'écrire le mart (`get_table_info` pour schéma, `SELECT DISTINCT` pour `accepted_values`, `COUNT(*)` pour les bornes `row_count_between`, `MIN/MAX(date)` pour les plages).
 
@@ -214,10 +214,11 @@ After any model creation, deletion, or convention change, update the relevant do
 | New naming/column convention | — | — | Update relevant section | — |
 | New SQLFluff rule | — | — | Update SQLFluff table | — |
 | New materialization pattern | — | Update "Ajouter un nouveau modele" steps | Update Materialisation table | — |
-| New mandatory test pattern | — | Update checklist | Update Tests / Marts section | — |
+| New mandatory test pattern | — | Update checklist | Update Tests section | Update `docs/conventions/marts.md` § 4 if marts test rule |
+| New marts modeling rule | — | — | — | Update `docs/conventions/marts.md` |
 | Workflow or PR process change | — | Update relevant section | — | — |
 | BigQuery config change (partition/cluster) | — | — | Add/update BigQuery section | — |
-| New BU / marts folder | — | — | — | Update `docs/migration-marts/` (Phase 0/1) si refacto en cours |
+| New BU / marts folder | — | — | — | Create `_<bu>__marts_models.yml` + exposure file; marts refacto by BU is DONE (no `docs/migration-marts/`) |
 
 ### What to update in each doc
 
@@ -228,12 +229,16 @@ After any model creation, deletion, or convention change, update the relevant do
 - Step-by-step model creation process if the workflow changes
 - Checklist before merge if new quality gates are added
 
-**`CONVENTIONS.md`** — the single source of truth for rules:
+**`CONVENTIONS.md`** — the single source of truth for rules (with a `## Sommaire` TOC at the top):
 - Naming conventions (models, columns, files)
 - SQL patterns (staging boilerplate, label pivot pattern, etc.)
 - Materialisation defaults
 - Test strategy and severity rules
 - SQLFluff rules
+
+**`docs/conventions/marts.md`** — extracted marts pattern (loaded on demand): star schema rules, 4-block YAML description trame, config hygiene, minimum tests per layer, anti-patterns, SQL skeleton, grain-first column order. Update here (not in `CONVENTIONS.md`) when a marts rule changes.
+
+**`docs/freshness.md`** — source freshness authority: tiers, monitoring mechanisms (A/B), per-source target state. `CONVENTIONS.md § Source freshness` only points here.
 
 ---
 
@@ -243,7 +248,7 @@ After any model creation, deletion, or convention change, update the relevant do
 - **Never delete or drop tables** unless explicitly asked
 - **Never run against prod target** unless explicitly asked
 - **Never skip SQLFluff lint** before considering a model done
-- **Marts must follow a star schema** — facts (`fct_`) reference dimensions (`dim_`) via `<entity>_id` foreign keys only. No fact-to-fact joins (un fait peut toutefois en **agréger** un autre à un grain plus grossier via `GROUP BY`, ou l'**étendre** à grain strictement identique 1:1 — cf. `CONVENTIONS.md` § Marts), no snowflaked dimensions, no wide one-big-table marts. **Aplatir uniquement les attributs d'affichage du parent direct (1-3 colonnes max)**, jamais une dim parente entière. Voir `CONVENTIONS.md` § Marts — pattern complet.
+- **Marts must follow a star schema** — facts (`fct_`) reference dimensions (`dim_`) via `<entity>_id` foreign keys only. No fact-to-fact joins (un fait peut toutefois en **agréger** un autre à un grain plus grossier via `GROUP BY`, ou l'**étendre** à grain strictement identique 1:1 — cf. [`docs/conventions/marts.md`](docs/conventions/marts.md)), no snowflaked dimensions, no wide one-big-table marts. **Aplatir uniquement les attributs d'affichage du parent direct (1-3 colonnes max)**, jamais une dim parente entière. Voir [`docs/conventions/marts.md`](docs/conventions/marts.md) § Marts — pattern complet.
 - **Description placement** : staging **doit** avoir `description='...'` dans `{{ config() }}` (cf. feedback memory, convention historique). Intermediate et **marts** : description en YAML uniquement, pas dans le config block (persist_docs gère BQ).
 - All contributions go through PRs — DE owns staging/intermediate/snapshots, DA contributes/reviews marts.
   **Exception** : les changements docs-only (README, docs/, CONTRIBUTING) partent en push direct sur master, pas de PR. Master est protégée : le push direct passe avec les droits owner (sinon fallback PR + merge --admin).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -292,7 +292,7 @@ Quand un rapport Power BI est cree ou modifie, mettre a jour le fichier exposure
 2. Sauvegarder en **UTF-8 sans BOM** (pas depuis Excel directement — utiliser LibreOffice ou un editeur de texte)
 3. Ajouter une entree dans `data/schema.yml` avec :
    - `description` du seed
-   - `config: column_types:` pour **toutes les colonnes** (voir types autorises dans CONVENTIONS.md)
+   - `config: column_types:` pour **toutes les colonnes** (voir types autorises dans docs/conventions/seeds-snapshots.md)
    - `columns:` avec description et tests pour chaque colonne
 4. **Verifier les types en regardant les donnees reelles**, pas seulement le nom de colonne :
    ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,17 @@ direnv allow                             # a faire une seule fois dans le repo
 
 # 6. Vérifier que tout fonctionne
 dbt debug --target dev
+
+# 7. Installer les guardrails pre-commit (lint SQL au commit, dbt parse au push)
+pipx install pre-commit                      # isole, ne pollue pas dbt_venv
+pre-commit install                           # hooks de commit (sqlfluff)
+pre-commit install --hook-type pre-push      # hooks de push (dbt parse)
 ```
 
 > `direnv allow` est a executer une seule fois par machine/repo. Apres ca, les variables `.env` sont chargees automatiquement des que tu entres dans le dossier.
 > **Sans direnv**, charge les variables manuellement avant chaque session : `set -a && source .env && set +a`
+
+> **Guardrails pre-commit** : `.pre-commit-config.yaml` rejoue le lint SQLFluff (au commit) et `dbt parse` (au push) — les memes verifications que les hooks Claude Code. Elles tournent quel que soit l'auteur du code (humain ou IA), donc un commit non lint est bloque localement avant meme la CI.
 
 ### Comprendre les fichiers de dépendances
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -4,6 +4,24 @@ Regles de nommage, qualite et style appliquees dans le projet.
 
 ---
 
+## Sommaire
+
+| Section | Contenu |
+|---------|---------|
+| [Nommage des modeles](#nommage-des-modeles) | Format, prefixes par couche, convention marts by BU, fichiers YAML |
+| [Nommage des colonnes](#nommage-des-colonnes) | Conventions generales, colonnes systeme staging |
+| [Structure SQL](#structure-sql) | Pattern CTE staging, intermediate / marts |
+| [Materialisation](#materialisation) | Table / incremental / snapshot par couche |
+| [Marts — pattern complet](#marts--pattern-complet) | **Externalise → [`docs/conventions/marts.md`](docs/conventions/marts.md)** (modelisation, description, config, tests) |
+| [Tests de qualite](#tests-de-qualite) | Tests natifs, dbt_utils, dbt_expectations, severite |
+| [Source freshness](#source-freshness) | **Detail → [`docs/freshness.md`](docs/freshness.md)** (tiers, mecanismes, etat par source) |
+| [SQLFluff](#sqlfluff) | Regles, commandes, exclusions, `-- noqa` |
+| [Seeds et Snapshots](#seeds-et-snapshots) | CSV de reference, types BigQuery, SCD2 |
+| [Tags](#tags) | Selection par source / couche |
+| [Exposition Power BI](#exposition-power-bi) | Couche marts exposee, conventions de jointure |
+
+---
+
 ## Nommage des modeles
 
 ### Format general
@@ -147,287 +165,13 @@ Certains modeles intermediate utilisent `incremental` pour les gros volumes (ex:
 
 ## Marts — pattern complet
 
-Section unifiee : modelisation, description, config, tests. Tout ce qui concerne
-les marts est centralise ici. Pour le naming, voir §Nommage des marts.
-
-### 1. Principes de modelisation
-
-Les marts suivent **strictement un modele en etoile** : un fait au centre,
-des dimensions autour, jointures via `<entite>_id`. Pas de snowflake.
-Pas de One Big Table.
-
-- **Faits** (`fct_*`) : evenements ou mesures, pointent vers les dims via FK.
-  Un fait **peut** en referencer un autre dans deux cas seulement :
-  - (a) **fait agrege / rollup** a un grain plus grossier via `GROUP BY`
-    (ex. `fct_supply_chain__disponibilite_article_neshu_depot_mensuel`, rollup
-    mensuel de `fct_supply_chain__stock_neshu`) ;
-  - (b) **fait derive / extension** a grain strictement identique 1:1 (ajout
-    de colonnes calculees, grain inchange).
-
-  **Interdit** : joindre deux faits sur leurs cles de dimension pour combiner
-  leurs mesures — la dimension partagee cree un fan-out many-to-many qui
-  double compte les mesures additives. Pour combiner deux faits, faire un
-  drill-across (pre-agreger chacun au grain commun, *puis* joindre), dans
-  l'intermediate ou dans la couche Power BI. Le critere de decision est
-  **grain + cardinalite de jointure**, jamais l'appartenance BU : un
-  fait-a-fait meme BU peut double compter, un agregat cross-BU peut etre sain.
-- **Dimensions** (`dim_*`) : 1 ligne par entite metier (ticket, compte,
-  agent, machine, contrat...).
-  - **Aplatir uniquement les attributs d'affichage du parent direct** (1-3
-    colonnes max) pour eviter une jointure cote consommateur. Ex :
-    `dim_neshu__device` contient `company_name` pour les tooltips
-    et libelles, mais reste rattache a `dim_neshu__company` via `company_id`.
-  - **Ne JAMAIS aplatir une dim parente entiere** (toutes ses colonnes :
-    adresse, code postal, telephone, etc.) dans la dim enfant : c'est de
-    l'OBT (One Big Table) deguise. Garder les dims separees et conformes,
-    croiser via FK + relationships PBI ou SQL custom dans Power Query.
-    Pattern hybride accepte : "star schema dbt + flatten en PBI quand besoin,
-    promotion en mart si duplique 3+ fois".
-- **Cles** : FKs en `<entite>_id` dans les faits. Cles surrogates via
-  `dbt_utils.generate_surrogate_key` quand l'entite n'a pas de PK naturelle.
-- **Conformed dimensions** : une meme dim sert plusieurs faits, voire
-  plusieurs BU. Un fact `fct_neshu__workorder_delai` peut referencer
-  `dim_technique__client` sans probleme — c'est exactement le pattern
-  Kimball.
-- **Grain explicite** : chaque fait declare son grain dans la description
-  YAML. Pilier Kimball : "si tu ne sais pas le grain, tu ne sais pas le mart".
-
-### 2. Trame de description (YAML)
-
-Toute description de mart (dim ou fact) suit une trame en 4 blocs.
-Separes par une ligne vide pour la lisibilite dans dbt docs.
-
-```yaml
-- name: fct_neshu__chargement_consommation
-  description: >
-    [QUOI METIER]
-    Table de faits des chargements et consommations telemetrie par passage APPRO.
-
-    [COMMENT CONSTRUITE]
-    Croise les passages appro avec les telemetries via reconstruction
-    d'intervalles entre 2 passages successifs (LAG sur task_start_date).
-    Filtre sur taches statut FAIT depuis 2024.
-
-    [GRAIN]
-    1 ligne par (device, passage_appro, product). ~1.4M lignes.
-
-    [NOTES]
-    Ne contient pas les livraisons (voir fct_neshu__consommation pour la
-    vue consolidee multi-sources).
-```
-
-Pour une dim, meme structure mais souvent plus courte :
-
-```yaml
-- name: dim_neshu__company
-  description: >
-    [QUOI METIER]
-    Dimension client Neshu — societes enrichies des labels EAV
-    (region, secteur, statut, KA, teletravail, etc.).
-
-    [COMMENT CONSTRUITE]
-    Pivot des labels via int_oracle_neshu__company_labels.
-    Une ligne par societe active (label ISACTIVE='yes').
-
-    [GRAIN]
-    1 ligne par company_id (PK).
-```
-
-**Regles** :
-- **Grain obligatoire** sur faits ET dims (1 ligne par X).
-- **Pas de nom de rapport BI** dans la description — ca vit dans l'`exposure`.
-- **[NOTES] facultatif** mais utile pour exclusions / pieges courants /
-  references croisees vers d'autres marts.
-
-### 3. Config block hygiene
-
-Le `{{ config() }}` SQL gere uniquement la **materialisation**. La
-**description** vit dans le YAML uniquement (single source of truth).
-`persist_docs` est active dans `dbt_project.yml` — la description YAML
-est automatiquement poussee vers BigQuery.
-
-**Bon** :
-```sql
-{{ config(
-    materialized='table',
-    partition_by={'field': 'consumption_date', 'data_type': 'date'},
-    cluster_by=['company_id', 'device_id']
-) }}
-```
-
-**Anti-pattern (eviter)** :
-```sql
-{{ config(
-    materialized='table',
-    description='...'   -- doublon avec le YAML, source de drift
-) }}
-```
-
-Pas non plus de `tags=[...]` dans le `{{ config() }}` — les tags sont
-geres au niveau folder via `dbt_project.yml`. Exception : `cross_post_*`
-si pertinent (cf. `docs/pipeline-schedule.md`).
-
-### 4. Tests minimum par layer
-
-Deux niveaux d'exigence : **obligatoire** (severity `error` par defaut)
-et **recommande fort** (severity `warn` pour catcher les drifts silencieux).
-
-#### Dim — obligatoire
-
-```yaml
-columns:
-  - name: <pk>                    # company_id, device_id, etc.
-    tests:
-      - unique
-      - not_null
-```
-
-#### Dim — recommande fort
-
-```yaml
-columns:
-  - name: <date_col>              # created_at, updated_at, etc.
-    tests:
-      - dbt_expectations.expect_column_values_to_be_between:
-          arguments:
-            min_value: "timestamp('2010-01-01')"
-            max_value: "current_timestamp()"
-          config:
-            severity: warn
-
-  - name: <statut_col>            # is_active, status_code, etc.
-    tests:
-      - accepted_values:
-          arguments:
-            values: ['ACTIF', 'INACTIF']
-
-tests:
-  - dbt_expectations.expect_table_row_count_to_be_between:
-      arguments:
-        min_value: 100
-        max_value: 50000
-      config:
-        severity: warn
-```
-
-#### Fact — obligatoire
-
-```yaml
-columns:
-  - name: <fk>                    # company_id, device_id
-    tests:
-      - not_null
-      - relationships:
-          arguments:
-            to: ref('dim_neshu__company')
-            field: company_id
-          config:
-            severity: warn
-
-  - name: <partition_date>        # consumption_date, task_start_date
-    tests:
-      - not_null
-```
-
-#### Fact — recommande fort
-
-```yaml
-columns:
-  - name: <numeric_invariant>     # quantity, montant, etc.
-    tests:
-      - dbt_expectations.expect_column_values_to_be_between:
-          arguments:
-            min_value: 0
-          config:
-            severity: warn
-
-tests:
-  - dbt_utils.unique_combination_of_columns:    # cle composite
-      arguments:
-        combination_of_columns: [device_id, date, product_id]
-
-  - dbt_expectations.expect_table_row_count_to_be_between:
-      arguments:
-        min_value: 1000
-        max_value: 10000000
-      config:
-        severity: warn
-```
-
-#### Severity strategy
-
-| Test | Severity | Raison |
-|------|----------|--------|
-| PK `unique` + `not_null` sur dim | `error` | Casse les jointures sinon |
-| `not_null` sur FK obligatoire | `error` | Orphelin = bug data |
-| `relationships` sur FK | `warn` | Detecte les drifts sans bloquer le build |
-| `accepted_values` | `error` | Liste fermee — drift = nouveau code a connaitre |
-| Plages dates / numeriques | `warn` | Informatif, ne pas bloquer la prod |
-| `expect_table_row_count_to_be_between` | `warn` | Alerte de volume anormal |
-
-### 5. Anti-patterns a refuser
-
-| Anti-pattern | Pourquoi c'est interdit | A faire a la place |
-|--------------|------------------------|-------------------|
-| Jointure fait-a-fait dans Power BI | Explosion cartesienne, mesures fausses | Croiser au niveau intermediate ou via dim partagee |
-| Dim qui pointe vers une autre dim (`device → company`) | Snowflake, requetes plus lentes, complexite Power BI | Aplatir les attributs d'affichage parents dans la dim enfant (1-3 colonnes max) |
-| Mart "OBT" 1 modele = 1 rapport, tout deja joint | Duplication, perte de reutilisabilite, refresh long | Star schema + mesures Power BI |
-| FK manquante dans un fait | Ligne orpheline silencieuse | Test `relationships` sur la FK (severity warn ou error) |
-| Nom de rapport BI dans la description du mart | La doc rote quand le rapport est renomme / supprime | Referencer le mart dans l'`exposure` du rapport |
-| `description='...'` dans `{{ config() }}` ET dans YAML | Drift garanti | Description en YAML uniquement |
-| `tags=[...]` au niveau model | Casse l'organisation par folder | Tags via `dbt_project.yml` (sauf exceptions `cross_post_*`) |
-| Pas de grain dans la description | "Mart en aveugle", impossible a auditer | Ligne `[GRAIN]` explicite |
-
-### 6. Pattern type SQL (squelette)
-
-```sql
--- fct_<bu>__<event>.sql
-{{ config(
-    materialized='table',
-    partition_by={'field': 'event_date', 'data_type': 'date'},
-    cluster_by=['ticket_id']
-) }}
-
-with events as (
-    select * from {{ ref('int_<source>__<event>') }}
-)
-
-select
-    ticket_id,         -- FK vers dim_<bu>__ticket
-    account_id,        -- FK vers dim_<bu>__account
-    agent_id,          -- FK vers dim_<bu>__agent
-    event_date,
-    event_type,
-    duration_minutes   -- mesures additives uniquement
-from events
-```
-
-Description et tests vivent dans `_<bu>__marts_models.yml` (voir §2 et §4).
-
-### 7. Ordre des colonnes du `select` final
-
-Convention **indicative** (non verifiee par SQLFluff, mais attendue en review).
-Regle dite **grain-first** : les colonnes du grain ouvrent le `select`, puis on
-reprend un tri par role. Objectif : lire « de quoi parle la ligne » (cles →
-contexte → quand) avant « combien » (mesures).
-
-1. **Grain** — la/les colonne(s) qui definissent le grain, dans l'ordre
-   `dimension temporelle → cle primaire → cles etrangeres`. Sur un fait agrege
-   a grain temporel, la date de grain (`mois`, `event_date`) vient donc **en
-   premier** (ex. `fct_supply_chain__disponibilite_article_neshu_depot_mensuel`
-   ouvre sur `mois`, puis `company_id`, puis `product_code`).
-2. **Cles etrangeres** restantes (`<entity>_id`) non incluses dans le grain.
-3. **Attributs / dimensions** texte ou categoriels (`*_name`, `*_code`,
-   `*_type`, `*_status`).
-4. **Dates / timestamps metier** secondaires (hors date de grain).
-5. **Booleens / flags** (`is_*`, `has_*`) — ils qualifient la ligne.
-6. **Mesures** numeriques additives — toujours regroupees en fin de fait.
-7. **Metadonnees / audit** (`created_at`, `updated_at`, `extracted_at`,
-   `deleted_at`) — toujours en dernier.
-
-> Regle, pas dogme : si un regroupement metier est plus lisible (ex. coller
-> `entity_code`/`entity_name` juste apres leur FK), c'est tolere. Le grain en
-> tete et les metadonnees en queue, en revanche, sont systematiques.
+> **Cette section est externalisee** dans [`docs/conventions/marts.md`](docs/conventions/marts.md).
+> Elle y est maintenue comme **source unique de verite** pour tout ce qui concerne les
+> marts : principes de modelisation (star schema strict), trame de description YAML en
+> 4 blocs, hygiene du config block, tests minimum par layer, anti-patterns, squelette SQL
+> type et ordre des colonnes grain-first.
+>
+> Le **nommage** des marts reste ici, voir [§ Nommage des marts](#nommage-des-marts--convention-by-bu).
 
 ---
 
@@ -439,7 +183,7 @@ contexte → quand) avant « combien » (mesures).
 > sous `config:`. La forme à plat (`combination_of_columns:` directement sous le test) est
 > **dépréciée** et lève `MissingArgumentsPropertyInGenericTestDeprecation` — c'est un warning
 > aujourd'hui, une erreur en 1.12. Le `dbt build` du CI ne bloque PAS sur ce warning, donc
-> à vérifier manuellement en relecture de PR. Voir les exemples de la section Marts ci-dessus.
+> à vérifier manuellement en relecture de PR. Voir les exemples de [`docs/conventions/marts.md`](docs/conventions/marts.md) § 4.
 
 ### Tests dbt natifs
 
@@ -502,63 +246,19 @@ models:
 
 ## Source freshness
 
-> Voir `docs/freshness.md` pour l'audit complet et la justification par source.
+> **Detail complet dans [`docs/freshness.md`](docs/freshness.md)** : tiers definis,
+> mecanismes de monitoring (methode A `dbt source freshness` natif / methode B test
+> `dbt_expectations` sur staging pour les sources a timestamp STRING), et etat cible
+> par source. Ce document fait autorite — ne pas redupliquer la table des tiers ici.
 
-### Tiers
+Resume operationnel :
 
-| Tier | warn_after | error_after | Sources |
-|------|-----------|-------------|---------|
-| Critique | 26h | 36h | oracle_neshu, oracle_lcdp |
-| Standard | 26h | 48h | yuman, mssql_sage, nesp_co (activite/opportunite), oracle_neshu_gcs |
-| Quotidien Mon-Sat | 36h | 80h | yuman_gcs |
-| Hebdomadaire | 8j | 14j | nesp_tech |
-| Relaxe | 7j | 14j | gac, zoho_desk |
-| Manuel | 60j | 90j | nesp_co (nespresso_base_client) |
-
-### Deux mecanismes selon le type de timestamp source
-
-**Methode A — `dbt source freshness` natif** quand la source brute a un champ TIMESTAMP ou DATE :
-
-```yaml
-# _<source>__sources.yml
-sources:
-  - name: <source>
-    config:
-      loaded_at_field: _sdc_extracted_at
-      freshness:
-        warn_after: {count: 26, period: hour}
-        error_after: {count: 48, period: hour}
-    tables:
-      - name: <referentiel_stable>
-        config:
-          freshness: null   # desactive — table immuable
-```
-
-Commande : `dbt source freshness`
-
-**Methode B — test `dbt_expectations` sur staging** quand la source brute n'a qu'un champ STRING (external tables GCS, taps custom dlt). Le staging fait le cast en TIMESTAMP, on monitore a ce niveau :
-
-```yaml
-# _<source>__models.yml
-models:
-  - name: stg_<source>__<table>
-    tests:
-      - dbt_expectations.expect_row_values_to_have_recent_data:
-          arguments:
-            column_name: extracted_at
-            datepart: day
-            interval: 8
-          config:
-            severity: warn
-```
-
-Commande : couvert par `dbt test` standard.
-
-### Regles
-
-- **`freshness: null` uniquement sur les referentiels vraiment immuables** (codes, libellés, types). Toute source qui porte des evenements doit avoir un seuil, quitte a le mettre tres large.
-- **Ne jamais repeter** le freshness par table quand il est identique au defaut source — c'est du bruit YAML.
+- **6 tiers** de Critique (26h/36h) a Manuel (60j/90j) — voir le tableau complet dans `docs/freshness.md`.
+- **`freshness: null`** uniquement sur les referentiels vraiment immuables (codes, libelles, types). Toute source porteuse d'evenements doit avoir un seuil, quitte a le mettre tres large.
+- **Ne jamais repeter** le freshness par table quand il est identique au defaut source — bruit YAML.
 - **Toujours commenter le tier** en regard du bloc freshness (`# Freshness: tier Standard — 26h warn / 48h error`).
+
+Commandes : `dbt source freshness` (methode A) · couvert par `dbt test` (methode B).
 
 ---
 

--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,413 +1,148 @@
 # Conventions - EVS dbt Project
 
-Regles de nommage, qualite et style appliquees dans le projet.
+Index des conventions du projet. **Les règles détaillées vivent dans les docs par
+couche** ci-dessous — c'est le premier endroit où regarder pour écrire un modèle.
+Ce fichier ne garde que le **transversal** (commun à toutes les couches).
+
+## Où trouver quoi
+
+| Tu écris / modifies… | Doc de référence |
+|---|---|
+| un modèle staging (`stg_*`) | [`docs/conventions/staging.md`](docs/conventions/staging.md) |
+| un modèle intermediate (`int_*`) | [`docs/conventions/intermediate.md`](docs/conventions/intermediate.md) |
+| un mart (`dim_*` / `fct_*`) | [`docs/conventions/marts.md`](docs/conventions/marts.md) |
+| un seed ou un snapshot | [`docs/conventions/seeds-snapshots.md`](docs/conventions/seeds-snapshots.md) |
+| la fraîcheur d'une source | [`docs/freshness.md`](docs/freshness.md) |
 
 ---
 
-## Sommaire
+## Nommage (transversal)
 
-| Section | Contenu |
-|---------|---------|
-| [Nommage des modeles](#nommage-des-modeles) | Format, prefixes par couche, convention marts by BU, fichiers YAML |
-| [Nommage des colonnes](#nommage-des-colonnes) | Conventions generales, colonnes systeme staging |
-| [Structure SQL](#structure-sql) | Pattern CTE staging, intermediate / marts |
-| [Materialisation](#materialisation) | Table / incremental / snapshot par couche |
-| [Marts — pattern complet](#marts--pattern-complet) | **Externalise → [`docs/conventions/marts.md`](docs/conventions/marts.md)** (modelisation, description, config, tests) |
-| [Tests de qualite](#tests-de-qualite) | Tests natifs, dbt_utils, dbt_expectations, severite |
-| [Source freshness](#source-freshness) | **Detail → [`docs/freshness.md`](docs/freshness.md)** (tiers, mecanismes, etat par source) |
-| [SQLFluff](#sqlfluff) | Regles, commandes, exclusions, `-- noqa` |
-| [Seeds et Snapshots](#seeds-et-snapshots) | CSV de reference, types BigQuery, SCD2 |
-| [Tags](#tags) | Selection par source / couche |
-| [Exposition Power BI](#exposition-power-bi) | Couche marts exposee, conventions de jointure |
-
----
-
-## Nommage des modeles
-
-### Format general
+### Format des modèles
 
 ```
 <couche>_<source>__<entite>.sql
 ```
 
-Le double underscore `__` separe la source de l'entite.
+Le double underscore `__` sépare la source (ou la BU pour les marts) de l'entité.
 
-### Par couche
-
-| Couche | Prefixe | Exemple |
+| Couche | Préfixe | Exemple |
 |--------|---------|---------|
-| Staging | `stg_` | `stg_oracle_neshu__company.sql` |
-| Intermediate | `int_` | `int_oracle_neshu__appro_tasks.sql` |
-| Marts - Dimension | `dim_` | `dim_oracle_neshu__company.sql` |
-| Marts - Fact (mono-source) | `fct_` | `fct_oracle_neshu__conso_business_review.sql` |
-| Marts - Fact (cross-source) | `fct_<bu>__` | `fct_technique__neshu_maintenance_preventives.sql` |
-| Snapshot | `snap_` | `snap_oracle_neshu__device.sql` |
+| Staging | `stg_` | `stg_oracle_neshu__company` |
+| Intermediate | `int_` | `int_oracle_neshu__appro_tasks` |
+| Marts - Dimension | `dim_` | `dim_neshu__company` |
+| Marts - Fact | `fct_` | `fct_neshu__consommation` |
+| Snapshot | `snap_` | `snap_oracle_neshu__device` |
 
-> **Modeles cross-source :** un modele qui consomme des donnees de plusieurs sources differentes
-> va dans un dossier BU (`marts/technique/`) et non dans un dossier source (`marts/oracle_neshu/`).
-> Le prefixe du nom reflete la BU, pas la source.
-
-### Nommage des marts — convention by BU
-
-Les marts sont organises par **BU/domaine** (folder = BU), pas par source.
-Le nom du modele reflete la BU et l'entite metier, pas l'implementation source.
-
-| Element | Regle |
-|---------|-------|
-| Prefixe | `dim_` (dimension) ou `fct_` (fait) |
-| Cle BU/domaine | nom exact du folder : `neshu`, `lcdp`, `technique`, `commerce`, `finance`, `services_generaux`, `supply_chain` |
-| Separateur | `__` entre BU et entite |
-| Entite | singulier, snake_case, nom metier (pas le nom source, pas le nom du rapport BI) |
-| Suffixe de grain | uniquement si agrege au-dessus du grain naturel (`_quinzaine`, `_mensuel`) |
-| Suffixe de source | uniquement en cas de collision dans le meme folder (ex. `fct_supply_chain__stock_neshu` vs `fct_supply_chain__stock_yuman`) |
-| Nom du rapport BI | jamais dans le nom du mart — va dans l'`exposure` |
-
-Exemples (avant → apres) :
-
-| Avant | Apres | Pourquoi |
-|-------|-------|----------|
-| `fct_oracle_neshu__conso_business_review` | `fct_neshu__consommation` | source droppee, nom de rapport BI deplace vers exposure |
-| `fct_mssql_sage__pnl_bu_kpis` | `fct_finance__pnl_bu` | `_kpis` implicite dans un fait |
-| `dim_yuman__materials` | `dim_technique__material` | singulier, pas de source |
-| `fct_oracle_neshu__chargement_par_quinzaine` | `fct_neshu__chargement_quinzaine` | suffixe de grain conserve |
+> Staging/intermediate sont nommés **par source** ; les marts **par BU/domaine**
+> (détail : [`docs/conventions/marts.md`](docs/conventions/marts.md) § Nommage).
 
 ### Fichiers YAML
 
-Chaque source a deux fichiers YAML dans son dossier staging :
-
 | Fichier | Contenu |
 |---------|---------|
-| `_<source>__sources.yml` | Declaration des sources, freshness, colonnes brutes |
-| `_<source>__models.yml` | Documentation des modeles staging, tests |
+| `_<source>__sources.yml` | Déclaration sources, freshness, colonnes brutes |
+| `_<source>__models.yml` | Doc + tests des staging |
+| `_<source>__intermediate_models.yml` | Doc + tests des intermediate |
+| `_<bu>__marts_models.yml` / `_<bu>__marts_sources.yml` | Doc/tests des marts / tables externes Cloud Run |
 
----
+### Colonnes
 
-## Nommage des colonnes
-
-### Conventions generales
-
-| Regle | Exemple |
+| Règle | Exemple |
 |-------|---------|
 | snake_case | `company_name`, `postal_code` |
-| IDs : `id<entite>` (staging) | `idcompany`, `idtask` |
-| IDs : `<entite>_id` (marts) | `company_id`, `task_id` |
+| IDs : conserver le nom source en staging | `idcompany` (Oracle), `ticket_id` (Zoho) |
+| IDs : `<entite>_id` en marts | `company_id`, `task_id` |
+| Booléens : `is_` / `has_` | `is_active`, `has_contract` |
+| Timestamps : suffixe `_at` | `created_at`, `updated_at` |
+| Dates : suffixe `_date` | `start_date`, `end_date` |
 
-> Staging conserve le nommage du systeme source (`idcompany`) pour faciliter le debug et le mapping. Les marts normalisent en `<entite>_id` pour la clarte cote Power BI et consommateurs finaux.
-| Booleens : `is_` ou `has_` | `is_active`, `has_contract` |
-| Dates : `_at` pour timestamps | `created_at`, `updated_at` |
-| Dates : `_date` pour dates | `start_date`, `end_date` |
-
-### Colonnes systeme (staging)
-
-Chaque modele staging expose ces colonnes harmonisees :
-
-| Colonne | Type | Description |
-|---------|------|-------------|
-| `created_at` | TIMESTAMP | Date de creation dans la source |
-| `updated_at` | TIMESTAMP | Derniere modification (coalesce avec created_at) |
-| `extracted_at` | TIMESTAMP | Date d'extraction Meltano (`_sdc_extracted_at`) |
-| `deleted_at` | TIMESTAMP | Soft delete (`_sdc_deleted_at`) |
+> Détail du nommage des IDs par couche : staging (passthrough) →
+> [`staging.md`](docs/conventions/staging.md) § 3 ; marts (`<entite>_id`) →
+> [`marts.md`](docs/conventions/marts.md).
 
 ---
 
-## Structure SQL
+## Matérialisation (résumé)
 
-### Staging : pattern CTE standard
+| Couche | Défaut | Exception |
+|--------|--------|-----------|
+| Staging | `table` | `incremental` (merge) pour les grosses tables événementielles (tâches Oracle) |
+| Intermediate | `table` | `incremental` (merge) pour les gros volumes (tâches, P&L) |
+| Marts | `table` | — |
+| Snapshots | `timestamp` (SCD2) | — |
 
-```sql
-{{ config(materialized='table') }}
-
-with source_data as (
-    select * from {{ source('oracle_neshu', 'evs_company') }}
-),
-
-cleaned_data as (
-    select
-        -- IDs convertis en BIGINT
-        cast(idcompany as int64) as idcompany,
-
-        -- Colonnes texte
-        code,
-        name,
-
-        -- Timestamps harmonises
-        timestamp(creation_date) as created_at,
-        timestamp(coalesce(modification_date, creation_date)) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
-
-    from source_data
-)
-
-select * from cleaned_data
-```
-
-### Intermediate / Marts : pattern CTE
-
-- Utiliser des CTEs nommees pour chaque etape logique
-- Preferer `ref()` vers staging (jamais `source()` en intermediate/marts)
-- Commenter les sections avec `-- Identifiants`, `-- Metriques`, etc.
+Règles partition/cluster : partition sur la date filtre principale (Power BI /
+incrémental), cluster sur les FK les plus jointes (≤ 4 colonnes). Détail dans
+chaque doc de couche.
 
 ---
 
-## Materialisation
+## Tests & sévérité (transversal)
 
-| Couche | Materialisation | Raison |
-|--------|----------------|--------|
-| Staging | `table` | Exploration ad-hoc par les analystes |
-| Intermediate | `table` | Idem, tables reutilisees par plusieurs marts |
-| Marts | `table` | Exposition Power BI, performance requise |
-| Snapshots | `timestamp` | SCD Type 2, suivi historique |
+> **Syntaxe obligatoire (dbt ≥ 1.11)** : tout test générique paramétré
+> (`accepted_values`, `relationships`, `unique_combination_of_columns`,
+> `expression_is_true`, tous les `dbt_expectations.*`) imbrique ses arguments sous
+> `arguments:` et la severity sous `config:`. La forme à plat est **dépréciée**
+> (warning aujourd'hui, erreur en 1.12). Le CI ne bloque pas dessus → vérifier en
+> relecture de PR.
 
-Certains modeles intermediate utilisent `incremental` pour les gros volumes (ex: `int_oracle_neshu__appro_tasks`).
-
----
-
-## Marts — pattern complet
-
-> **Cette section est externalisee** dans [`docs/conventions/marts.md`](docs/conventions/marts.md).
-> Elle y est maintenue comme **source unique de verite** pour tout ce qui concerne les
-> marts : principes de modelisation (star schema strict), trame de description YAML en
-> 4 blocs, hygiene du config block, tests minimum par layer, anti-patterns, squelette SQL
-> type et ordre des colonnes grain-first.
->
-> Le **nommage** des marts reste ici, voir [§ Nommage des marts](#nommage-des-marts--convention-by-bu).
-
----
-
-## Tests de qualite
-
-> **Syntaxe obligatoire (dbt ≥ 1.11)** : tout test générique prenant des paramètres
-> (`accepted_values`, `relationships`, `unique_combination_of_columns`, `expression_is_true`,
-> tous les `dbt_expectations.*`) doit imbriquer ses arguments sous `arguments:`, et la severity
-> sous `config:`. La forme à plat (`combination_of_columns:` directement sous le test) est
-> **dépréciée** et lève `MissingArgumentsPropertyInGenericTestDeprecation` — c'est un warning
-> aujourd'hui, une erreur en 1.12. Le `dbt build` du CI ne bloque PAS sur ce warning, donc
-> à vérifier manuellement en relecture de PR. Voir les exemples de [`docs/conventions/marts.md`](docs/conventions/marts.md) § 4.
-
-### Tests dbt natifs
-
-| Test | Usage |
-|------|-------|
-| `unique` | Cle primaire unique |
-| `not_null` | Colonne obligatoire |
-| `relationships` | Integrite referentielle entre modeles |
-| `accepted_values` | Valeurs autorisees (a ajouter progressivement) |
-
-### dbt_utils
-
-| Test | Usage |
-|------|-------|
-| `unique_combination_of_columns` | Cle composite unique |
-| `expression_is_true` | Assertions metier personnalisees |
-
-### dbt_expectations
-
-Package pour des tests de qualite avances. Configuration dans les fichiers `_<source>__models.yml`.
-
-| Test | Usage | Exemple |
-|------|-------|---------|
-| `expect_table_row_count_to_be_between` | Volume attendu | min: 100, max: 100000 |
-| `expect_column_values_to_be_between` | Plage de valeurs | Dates entre 2015 et maintenant |
-| `expect_column_values_to_not_be_null` | Taux de null acceptable | `mostly: 0.95` |
-| `expect_column_values_to_match_regex` | Format de donnees | Codes, emails, SIRET |
-
-Exemple YAML :
-
-```yaml
-models:
-  - name: stg_oracle_neshu__company
-    tests:
-      - dbt_expectations.expect_table_row_count_to_be_between:
-          arguments:
-            min_value: 100
-            max_value: 100000
-    columns:
-      - name: real_start_date
-        tests:
-          - dbt_expectations.expect_column_values_to_be_between:
-              arguments:
-                min_value: "timestamp('2015-01-01')"
-                row_condition: "real_start_date is not null"
-              config:
-                severity: warn
-```
-
-> **Note dbt 1.11** : les parametres des tests generiques doivent etre enveloppes dans `arguments:`.
-
-### Strategie de severite
-
-| Severite | Usage |
+| Sévérité | Usage |
 |----------|-------|
-| `error` (defaut) | Tests critiques : unicite, not_null sur cles primaires |
-| `warn` | Tests informatifs : plages de dates, volumes, formats |
+| `error` (défaut) | Unicité + not_null sur clés primaires, `accepted_values` |
+| `warn` | Plages dates/numériques, volumes, `relationships`, fraîcheur |
 
----
-
-## Source freshness
-
-> **Detail complet dans [`docs/freshness.md`](docs/freshness.md)** : tiers definis,
-> mecanismes de monitoring (methode A `dbt source freshness` natif / methode B test
-> `dbt_expectations` sur staging pour les sources a timestamp STRING), et etat cible
-> par source. Ce document fait autorite — ne pas redupliquer la table des tiers ici.
-
-Resume operationnel :
-
-- **6 tiers** de Critique (26h/36h) a Manuel (60j/90j) — voir le tableau complet dans `docs/freshness.md`.
-- **`freshness: null`** uniquement sur les referentiels vraiment immuables (codes, libelles, types). Toute source porteuse d'evenements doit avoir un seuil, quitte a le mettre tres large.
-- **Ne jamais repeter** le freshness par table quand il est identique au defaut source — bruit YAML.
-- **Toujours commenter le tier** en regard du bloc freshness (`# Freshness: tier Standard — 26h warn / 48h error`).
-
-Commandes : `dbt source freshness` (methode A) · couvert par `dbt test` (methode B).
+Tests minimum **par couche** : voir le § Tests de chaque doc de couche.
+Packages : `dbt_utils` (`unique_combination_of_columns`, `expression_is_true`,
+`generate_surrogate_key`), `dbt_expectations` (row counts, plages, regex, recence).
 
 ---
 
 ## SQLFluff
 
-Le projet utilise [SQLFluff v4](https://sqlfluff.com/) avec le templater dbt. Configuration dans `.sqlfluff`.
+SQLFluff v4, templater dbt. Configuration dans `.sqlfluff`, exclusions dans `.sqlfluffignore`.
 
-### Regles principales
-
-| Regle | Parametre |
+| Règle | Paramètre |
 |-------|-----------|
-| Mots-cles | `lowercase` (select, from, where, join...) |
-| Fonctions | `lowercase` (cast, coalesce, timestamp...) |
-| Types | `lowercase` (int64, string, float64...) |
-| Alias tables | Explicite (`AS t`, pas juste `t`) |
-| Alias colonnes | Explicite (`AS nom`, pas juste `nom`) |
-| Virgule trailing | Interdit dans SELECT |
+| Mots-clés / fonctions / types | `lowercase` |
+| Alias tables & colonnes | explicites (`as`) |
+| Virgule trailing | interdite |
 | Indentation | 4 espaces |
-| Longueur de ligne | 120 caracteres max |
-
-### Commandes
+| Longueur de ligne | 120 max |
 
 ```bash
-# Analyser
-sqlfluff lint models/staging/oracle_neshu/
-sqlfluff lint models/
-
-# Corriger automatiquement
-sqlfluff fix models/staging/oracle_neshu/
-
-# Toujours verifier apres un fix
-git diff
+sqlfluff lint models/path/        # analyser
+sqlfluff fix models/path/         # corriger, puis vérifier avec git diff
 ```
 
-### Fichiers exclus
-
-Configure dans `.sqlfluffignore` : `target/`, `dbt_packages/`, `logs/`, `.venv/`, `venv_dbt/`.
-
-### `-- noqa`
-
-Pour desactiver une regle sur une ligne specifique (faux positifs) :
-
-```sql
-select max(updated_at) from {{ ref('stg_oracle_neshu__task') }}  -- noqa: RF02
-```
-
----
-
-## Seeds et Snapshots
-
-### Seeds (`data/reference_data/`)
-
-Fichiers CSV charges via `dbt seed`. Utilises pour les donnees de reference statiques (mappings, parametres). Organises par domaine :
-
-```
-data/reference_data/
-├── yuman/              # ref_yuman__cp_metropole.csv, ref_yuman__machine_clean.csv, ...
-├── oracle_neshu/       # ref_oracle_neshu__valo_parc_machine.csv, ...
-├── mssql_sage/         # ref_mssql_sage__code_analytique_bu.csv, ...
-├── nesp_tech/          # ref_nesp_tech__articles_prix.csv, ...
-├── nesp_co/            # ref_nesp_co__commerciaux.csv, ...
-└── general/            # ref_general__feries_metropole.csv, ...
-```
-
-#### Declaration des types de colonnes
-
-Les types sont declares **dans `data/schema.yml`** sous chaque seed, via le bloc `config: column_types:`. Ne pas utiliser `dbt_project.yml` pour les types par colonne.
-
-```yaml
-- name: ref_nesp_tech__key_facturation
-  description: "Cle de facturation des interventions techniques"
-  config:
-    column_types:
-      type_code: STRING
-      prod_factu: INT64
-      tarif_factu: FLOAT64
-      valid_from: DATE
-  columns:
-    - name: type_code
-      ...
-```
-
-#### Types BigQuery a utiliser
-
-| Type | Utiliser | Ne pas utiliser |
-|------|----------|-----------------|
-| Texte | `STRING` | `string`, `str`, `VARCHAR` |
-| Entier | `INT64` | `int`, `integer`, `INTEGER` |
-| Decimal | `FLOAT64` | `float`, `FLOAT`, `NUMERIC` |
-| Date | `DATE` | `date` |
-| Timestamp | `TIMESTAMP` | `timestamp`, `DATETIME` |
-| Booleen | `BOOLEAN` | `bool`, `BOOL` |
-
-> **Regle critique** : toujours verifier les valeurs reelles du CSV avant d'assigner un type.
-> Un code postal sans zero initial (`38000`) sera infere `INT64` par BigQuery — le typer
-> `STRING` casserait les joins existants. Ne pas se fier au nom de la colonne seul.
-
-#### Colonnes dans `data/schema.yml`
-
-Chaque colonne du CSV doit avoir une entree dans `columns:` avec une description.
-Les colonnes importantes doivent avoir des tests (`not_null`, `unique`, `relationships`).
-
-#### BOM dans les fichiers CSV
-
-Ne pas sauvegarder les CSV depuis Excel en UTF-8 avec BOM. Si un fichier contient un BOM
-(visible via `head -c 3 fichier.csv | xxd`), le supprimer avec :
-
-```bash
-sed -i '1s/^\xef\xbb\xbf//' data/reference_data/<source>/<fichier>.csv
-```
-
-### Snapshots (`snapshots/`)
-
-Suivi historique SCD Type 2 sur les entites qui evoluent :
-
-| Snapshot | Entite | Strategie |
-|----------|--------|-----------|
-| `snap_oracle_neshu__company` | Clients | timestamp |
-| `snap_oracle_neshu__device` | Machines | timestamp |
-| `snap_oracle_neshu__valo_parc_machines` | Parc machines | timestamp |
-
-Commande : `dbt snapshot`
+Désactiver une règle ponctuellement : `-- noqa: RF02` en fin de ligne.
 
 ---
 
 ## Tags
 
-Chaque modele est tag par source pour permettre une execution selective :
+Chaque modèle est taggé par source (et par couche) pour l'exécution sélective,
+via `dbt_project.yml` (hérité par dossier — pas de `tags=[...]` au niveau modèle) :
 
 ```bash
-dbt build --select tag:oracle_neshu    # Toute la chaine oracle_neshu
-dbt build --select tag:yuman           # Toute la chaine yuman
-dbt build --select tag:staging         # Tous les staging
-dbt build --select tag:marts           # Tous les marts
+dbt build --select tag:oracle_neshu   # toute la chaîne d'une source
+dbt build --select tag:staging        # toute une couche
 ```
 
-Les tags sont definis dans `dbt_project.yml` et herites automatiquement par les modeles enfants.
+---
+
+## Source freshness
+
+Tiers, mécanismes de monitoring (méthode A native / méthode B `dbt_expectations`)
+et état cible par source : **[`docs/freshness.md`](docs/freshness.md)** (autorité
+unique). Le placement du test côté staging est décrit dans
+[`docs/conventions/staging.md`](docs/conventions/staging.md) § 8.
 
 ---
 
 ## Exposition Power BI
 
-Les modeles marts (`dim_*` et `fct_*`) sont la couche exposee a Power BI.
-
-| Element | Convention |
-|---------|-----------|
-| Dataset BigQuery | `prod_marts` (production), `dev_marts` (developpement) |
-| Dimensions | `dim_<source>__<entite>` - tables de reference (clients, produits, machines) |
-| Facts | `fct_<source>__<metrique>` - tables de mesures (consommation, pricing, KPIs) |
-| Jointures | Via les colonnes `<entite>_id` presentes dans les dims et facts |
-
-Lors de la creation d'un nouveau mart, verifier que les noms de colonnes sont clairs pour un utilisateur Power BI (pas d'abreviations internes, pas d'IDs techniques exposes sans libelle).
+Les marts (`dim_*` / `fct_*`) sont la couche exposée à Power BI (`prod_marts`),
+jointes via les colonnes `<entite>_id`. Déclarer chaque rapport consommateur dans
+l'`exposure` de la BU (`models/exposures/<bu>.yml`). Détail :
+[`docs/conventions/marts.md`](docs/conventions/marts.md).

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ La couche assistant est **versionnee et partagee** par l'equipe (seuls `.claude/
 
 ```
 CLAUDE.md              Contexte projet (architecture, conventions, hard rules)
-.mcp.json              Serveurs MCP : BigQuery, Power BI, dbt (chemins via ${CLAUDE_PROJECT_DIR})
+.mcp.json              Serveurs MCP : BigQuery, Power BI, dbt (chemins absolus = repo en /mnt/data/transform ; adapter si checkout ailleurs)
 .claude/
 ├── commands/          Slash commands : /build-source, /new-mart, /lint-fix, /freshness
 ├── skills/            Skills : audit-sources, audit-docs, profile

--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ Voir la [documentation dbt generee](https://cebrailevs.github.io/dbt_transform/)
 - **Data Engineer** : `staging/`, `intermediate/` — qualite des sources et logique metier
 - **Data Analyst** : `intermediate/`, `marts/` — analytics et reporting
 
+### Couche IA (Claude Code)
+
+La couche assistant est **versionnee et partagee** par l'equipe (seuls `.claude/settings.local.json` et `.claude/notes/` restent locaux) :
+
+```
+CLAUDE.md              Contexte projet (architecture, conventions, hard rules)
+.mcp.json              Serveurs MCP : BigQuery, Power BI, dbt (chemins via ${CLAUDE_PROJECT_DIR})
+.claude/
+├── commands/          Slash commands : /build-source, /new-mart, /lint-fix, /freshness
+├── skills/            Skills : audit-sources, audit-docs, profile
+├── hooks/             Hooks PostToolUse (lint SQL + dbt parse) et helpers d'auth MCP
+└── settings.json      Config des hooks (versionnee)
+```
+
+Les memes garde-fous tournent aussi hors IA via `.pre-commit-config.yaml` (cf. [CONTRIBUTING.md](CONTRIBUTING.md)).
+
 ---
 
 ## Installation

--- a/docs/conventions/intermediate.md
+++ b/docs/conventions/intermediate.md
@@ -1,0 +1,126 @@
+# Conventions — couche Intermediate
+
+> Doc de référence pour écrire un modèle `int_*`. Règles transversales : voir
+> [`../../CONVENTIONS.md`](../../CONVENTIONS.md). Staging : [`staging.md`](staging.md) ·
+> Marts : [`marts.md`](marts.md).
+
+## 1. Rôle de la couche
+
+Consolider et enrichir **à l'intérieur d'une source** : déduplication, jointures
+staging ↔ référentiels, champs calculés/dérivés, réconciliation de grain. C'est la
+couche de logique métier au niveau entité/grain.
+
+- **Aligné par source**, pas cross-source : aujourd'hui 0 modèle intermediate ne
+  croise plusieurs sources. **L'unification multi-sources se fait en marts**, pas ici.
+- Lit **uniquement `ref('stg_*')`** (et `ref('ref_*')` pour les seeds). Jamais
+  `source()` (réservé au staging).
+
+## 2. Nommage
+
+- Fichier : `int_<source>__<entity>.sql`, dans le dossier de la source
+  (`models/intermediate/<source>/`).
+- YAML : `_<source>__intermediate_models.yml`.
+
+## 3. Colonnes
+
+- Passthrough des colonnes staging utiles + colonnes **dérivées/calculées**
+  (délais, flags, statuts canoniques, comptages).
+- snake_case ; booléens `is_`/`has_` ; dates `_at`/`_date`.
+- Les colonnes système staging (`created_at`…) sont relayées telles quelles si
+  pertinentes en aval.
+
+## 4. Pattern SQL
+
+CTEs nommées : base(s) `ref('stg_*')` → référentiels `ref('ref_*')` →
+transformations → assemblage final.
+
+```sql
+{{ config(materialized='table') }}
+
+with base as (
+    select * from {{ ref('stg_oracle_lcdp__task') }}
+),
+
+company as (
+    select * from {{ ref('stg_oracle_lcdp__company') }}
+),
+
+enriched as (
+    select
+        b.task_id,
+        b.company_id,
+        c.company_name,                 -- enrichissement via lookup
+        date_diff(b.real_end_date, b.real_start_date, day) as duration_days  -- champ calculé
+    from base as b
+    left join company as c on b.company_id = c.idcompany
+)
+
+select * from enriched
+```
+
+- **Déduplication** : `row_number() over (...)` + `qualify` (cf. patterns staging).
+- **Champs calculés** : délais, jours ouvrés, flags de validation, etc.
+
+## 5. Matérialisation
+
+- **`table`** par défaut (~82 %).
+- **`incremental`** (stratégie `merge`) pour les gros volumes événementiels :
+  tâches Oracle (`int_oracle_lcdp__*_tasks` sur `task_id`, partition
+  `task_start_date`), `int_mssql_sage__pnl_bu` (clé composite). `partition_by` sur
+  la date de filtre, `cluster_by` sur les FK les plus jointes en aval
+  (ex. `int_yuman__interventions` : partition `date_done`, cluster `client_id,
+  site_id, material_id`).
+- Clause `is_incremental()` : même pattern que le staging (`updated_at >` max +
+  fenêtre glissante de sécurité).
+
+## 6. Description
+
+- **En YAML uniquement**, pas dans le `{{ config() }}` (`persist_docs` pousse la
+  description YAML vers BigQuery). Tout modèle a une entrée YAML.
+- **Dette connue** : une partie des `int_*` existants portent encore une
+  `description=` dans le config — à retirer au fil des modifications, ne pas en
+  ajouter de nouvelle.
+
+## 7. Tests minimum
+
+Syntaxe dbt ≥ 1.11 (`arguments:` + `config:`).
+
+### Obligatoire
+
+```yaml
+columns:
+  - name: <pk_ou_grain>
+    tests: [unique, not_null]
+```
+
+- Grain composite → `dbt_utils.unique_combination_of_columns` (model-level).
+
+### Recommandé
+
+- `relationships` sur les FK structurantes (souvent déjà validé en staging — ne
+  pas redoubler partout, cibler les FK nouvelles introduites par l'intermediate).
+- `expression_is_true` (`dbt_utils`) sur les invariants métier des champs calculés.
+
+## 8. Freshness
+
+Non applicable à l'intermediate : la fraîcheur se monitore en amont (sources /
+staging). Voir [`../freshness.md`](../freshness.md).
+
+## 9. Anti-patterns
+
+| Anti-pattern | À faire à la place |
+|---|---|
+| Jointure cross-source en intermediate | Rester source-aligné ; unifier en marts |
+| `source()` au lieu de `ref()` | `ref('stg_*')` uniquement |
+| Agrégation au grain d'un rapport / pivot BI | Pousser en marts |
+| `description=` dans le `config()` | Description en YAML uniquement |
+| Logique de star schema (FK dimensionnelles, mesures finales) | C'est le rôle des marts |
+
+## 10. Checklist avant PR
+
+- [ ] Fichier `int_<source>__<entity>.sql` + entrée dans `_<source>__intermediate_models.yml`
+- [ ] `ref()` uniquement (aucun `source()`)
+- [ ] Pas de jointure cross-source
+- [ ] PK/grain testé `unique` + `not_null` (composite → `unique_combination_of_columns`)
+- [ ] Description en YAML (pas dans le config)
+- [ ] `sqlfluff lint` OK

--- a/docs/conventions/marts.md
+++ b/docs/conventions/marts.md
@@ -1,11 +1,34 @@
 # Marts — pattern complet
 
-> Extrait de `CONVENTIONS.md` (chargé à la demande). Référence unique pour tout
-> ce qui concerne les marts : modélisation, description, config, tests.
-> Pour le **nommage** des marts, voir `CONVENTIONS.md` § Nommage des marts.
+> Doc de référence pour écrire un mart (`dim_*` / `fct_*`) : nommage, modélisation,
+> description, config, tests. Règles transversales : [`../../CONVENTIONS.md`](../../CONVENTIONS.md).
+> Staging : [`staging.md`](staging.md) · Intermediate : [`intermediate.md`](intermediate.md).
 
-Section unifiee : modelisation, description, config, tests. Tout ce qui concerne
-les marts est centralise ici. Pour le naming, voir `CONVENTIONS.md` § Nommage des marts.
+## Nommage des marts — convention by BU
+
+Les marts sont organisés par **BU/domaine** (folder = BU), pas par source. Le nom
+reflète la BU et l'entité métier, pas l'implémentation source.
+
+| Élément | Règle |
+|---------|-------|
+| Préfixe | `dim_` (dimension) ou `fct_` (fait) |
+| Clé BU/domaine | nom exact du folder : `neshu`, `lcdp`, `technique`, `commerce`, `finance`, `services_generaux`, `supply_chain` |
+| Séparateur | `__` entre BU et entité |
+| Entité | singulier, snake_case, nom métier (pas le nom source, pas le nom du rapport BI) |
+| Suffixe de grain | uniquement si agrégé au-dessus du grain naturel (`_quinzaine`, `_mensuel`) |
+| Suffixe de source | uniquement en cas de collision dans le même folder (ex. `fct_supply_chain__stock_neshu` vs `fct_supply_chain__stock_yuman`) |
+| Nom du rapport BI | jamais dans le nom du mart — va dans l'`exposure` |
+
+Exemples (avant → après) :
+
+| Avant | Après | Pourquoi |
+|-------|-------|----------|
+| `fct_oracle_neshu__conso_business_review` | `fct_neshu__consommation` | source droppée, nom de rapport BI déplacé vers exposure |
+| `fct_mssql_sage__pnl_bu_kpis` | `fct_finance__pnl_bu` | `_kpis` implicite dans un fait |
+| `dim_yuman__materials` | `dim_technique__material` | singulier, pas de source |
+| `fct_oracle_neshu__chargement_par_quinzaine` | `fct_neshu__chargement_quinzaine` | suffixe de grain conservé |
+
+YAML : `_<bu>__marts_models.yml` (modèles) · `_<bu>__marts_sources.yml` (tables externes Cloud Run).
 
 ## 1. Principes de modelisation
 
@@ -285,3 +308,14 @@ contexte → quand) avant « combien » (mesures).
 > Regle, pas dogme : si un regroupement metier est plus lisible (ex. coller
 > `entity_code`/`entity_name` juste apres leur FK), c'est tolere. Le grain en
 > tete et les metadonnees en queue, en revanche, sont systematiques.
+
+## 8. Checklist avant PR
+
+- [ ] Fichier `<dim|fct>_<bu>__<entity>.sql` dans `models/marts/<bu>/` + entrée dans `_<bu>__marts_models.yml`
+- [ ] Description YAML en 4 blocs (`[QUOI MÉTIER]`/`[COMMENT CONSTRUITE]`/`[GRAIN]`/`[NOTES]`), **grain obligatoire**
+- [ ] Star schema : FK `<entity>_id` only, pas de jointure fait-à-fait, pas de snowflake, pas d'OBT
+- [ ] Tests minimum (Dim : PK `unique`+`not_null` ; Fact : FK `relationships` + clé composite + invariants)
+- [ ] `{{ config() }}` = matérialisation only (pas de `description`, pas de `tags`)
+- [ ] Ordre des colonnes grain-first
+- [ ] `exposure` mise à jour si un rapport Power BI consomme le mart
+- [ ] `sqlfluff lint` OK

--- a/docs/conventions/marts.md
+++ b/docs/conventions/marts.md
@@ -1,0 +1,287 @@
+# Marts — pattern complet
+
+> Extrait de `CONVENTIONS.md` (chargé à la demande). Référence unique pour tout
+> ce qui concerne les marts : modélisation, description, config, tests.
+> Pour le **nommage** des marts, voir `CONVENTIONS.md` § Nommage des marts.
+
+Section unifiee : modelisation, description, config, tests. Tout ce qui concerne
+les marts est centralise ici. Pour le naming, voir `CONVENTIONS.md` § Nommage des marts.
+
+## 1. Principes de modelisation
+
+Les marts suivent **strictement un modele en etoile** : un fait au centre,
+des dimensions autour, jointures via `<entite>_id`. Pas de snowflake.
+Pas de One Big Table.
+
+- **Faits** (`fct_*`) : evenements ou mesures, pointent vers les dims via FK.
+  Un fait **peut** en referencer un autre dans deux cas seulement :
+  - (a) **fait agrege / rollup** a un grain plus grossier via `GROUP BY`
+    (ex. `fct_supply_chain__disponibilite_article_neshu_depot_mensuel`, rollup
+    mensuel de `fct_supply_chain__stock_neshu`) ;
+  - (b) **fait derive / extension** a grain strictement identique 1:1 (ajout
+    de colonnes calculees, grain inchange).
+
+  **Interdit** : joindre deux faits sur leurs cles de dimension pour combiner
+  leurs mesures — la dimension partagee cree un fan-out many-to-many qui
+  double compte les mesures additives. Pour combiner deux faits, faire un
+  drill-across (pre-agreger chacun au grain commun, *puis* joindre), dans
+  l'intermediate ou dans la couche Power BI. Le critere de decision est
+  **grain + cardinalite de jointure**, jamais l'appartenance BU : un
+  fait-a-fait meme BU peut double compter, un agregat cross-BU peut etre sain.
+- **Dimensions** (`dim_*`) : 1 ligne par entite metier (ticket, compte,
+  agent, machine, contrat...).
+  - **Aplatir uniquement les attributs d'affichage du parent direct** (1-3
+    colonnes max) pour eviter une jointure cote consommateur. Ex :
+    `dim_neshu__device` contient `company_name` pour les tooltips
+    et libelles, mais reste rattache a `dim_neshu__company` via `company_id`.
+  - **Ne JAMAIS aplatir une dim parente entiere** (toutes ses colonnes :
+    adresse, code postal, telephone, etc.) dans la dim enfant : c'est de
+    l'OBT (One Big Table) deguise. Garder les dims separees et conformes,
+    croiser via FK + relationships PBI ou SQL custom dans Power Query.
+    Pattern hybride accepte : "star schema dbt + flatten en PBI quand besoin,
+    promotion en mart si duplique 3+ fois".
+- **Cles** : FKs en `<entite>_id` dans les faits. Cles surrogates via
+  `dbt_utils.generate_surrogate_key` quand l'entite n'a pas de PK naturelle.
+- **Conformed dimensions** : une meme dim sert plusieurs faits, voire
+  plusieurs BU. Un fact `fct_neshu__workorder_delai` peut referencer
+  `dim_technique__client` sans probleme — c'est exactement le pattern
+  Kimball.
+- **Grain explicite** : chaque fait declare son grain dans la description
+  YAML. Pilier Kimball : "si tu ne sais pas le grain, tu ne sais pas le mart".
+
+## 2. Trame de description (YAML)
+
+Toute description de mart (dim ou fact) suit une trame en 4 blocs.
+Separes par une ligne vide pour la lisibilite dans dbt docs.
+
+```yaml
+- name: fct_neshu__chargement_consommation
+  description: >
+    [QUOI METIER]
+    Table de faits des chargements et consommations telemetrie par passage APPRO.
+
+    [COMMENT CONSTRUITE]
+    Croise les passages appro avec les telemetries via reconstruction
+    d'intervalles entre 2 passages successifs (LAG sur task_start_date).
+    Filtre sur taches statut FAIT depuis 2024.
+
+    [GRAIN]
+    1 ligne par (device, passage_appro, product). ~1.4M lignes.
+
+    [NOTES]
+    Ne contient pas les livraisons (voir fct_neshu__consommation pour la
+    vue consolidee multi-sources).
+```
+
+Pour une dim, meme structure mais souvent plus courte :
+
+```yaml
+- name: dim_neshu__company
+  description: >
+    [QUOI METIER]
+    Dimension client Neshu — societes enrichies des labels EAV
+    (region, secteur, statut, KA, teletravail, etc.).
+
+    [COMMENT CONSTRUITE]
+    Pivot des labels via int_oracle_neshu__company_labels.
+    Une ligne par societe active (label ISACTIVE='yes').
+
+    [GRAIN]
+    1 ligne par company_id (PK).
+```
+
+**Regles** :
+- **Grain obligatoire** sur faits ET dims (1 ligne par X).
+- **Pas de nom de rapport BI** dans la description — ca vit dans l'`exposure`.
+- **[NOTES] facultatif** mais utile pour exclusions / pieges courants /
+  references croisees vers d'autres marts.
+
+## 3. Config block hygiene
+
+Le `{{ config() }}` SQL gere uniquement la **materialisation**. La
+**description** vit dans le YAML uniquement (single source of truth).
+`persist_docs` est active dans `dbt_project.yml` — la description YAML
+est automatiquement poussee vers BigQuery.
+
+**Bon** :
+```sql
+{{ config(
+    materialized='table',
+    partition_by={'field': 'consumption_date', 'data_type': 'date'},
+    cluster_by=['company_id', 'device_id']
+) }}
+```
+
+**Anti-pattern (eviter)** :
+```sql
+{{ config(
+    materialized='table',
+    description='...'   -- doublon avec le YAML, source de drift
+) }}
+```
+
+Pas non plus de `tags=[...]` dans le `{{ config() }}` — les tags sont
+geres au niveau folder via `dbt_project.yml`. Exception : `cross_post_*`
+si pertinent (cf. `docs/pipeline-schedule.md`).
+
+## 4. Tests minimum par layer
+
+Deux niveaux d'exigence : **obligatoire** (severity `error` par defaut)
+et **recommande fort** (severity `warn` pour catcher les drifts silencieux).
+
+### Dim — obligatoire
+
+```yaml
+columns:
+  - name: <pk>                    # company_id, device_id, etc.
+    tests:
+      - unique
+      - not_null
+```
+
+### Dim — recommande fort
+
+```yaml
+columns:
+  - name: <date_col>              # created_at, updated_at, etc.
+    tests:
+      - dbt_expectations.expect_column_values_to_be_between:
+          arguments:
+            min_value: "timestamp('2010-01-01')"
+            max_value: "current_timestamp()"
+          config:
+            severity: warn
+
+  - name: <statut_col>            # is_active, status_code, etc.
+    tests:
+      - accepted_values:
+          arguments:
+            values: ['ACTIF', 'INACTIF']
+
+tests:
+  - dbt_expectations.expect_table_row_count_to_be_between:
+      arguments:
+        min_value: 100
+        max_value: 50000
+      config:
+        severity: warn
+```
+
+### Fact — obligatoire
+
+```yaml
+columns:
+  - name: <fk>                    # company_id, device_id
+    tests:
+      - not_null
+      - relationships:
+          arguments:
+            to: ref('dim_neshu__company')
+            field: company_id
+          config:
+            severity: warn
+
+  - name: <partition_date>        # consumption_date, task_start_date
+    tests:
+      - not_null
+```
+
+### Fact — recommande fort
+
+```yaml
+columns:
+  - name: <numeric_invariant>     # quantity, montant, etc.
+    tests:
+      - dbt_expectations.expect_column_values_to_be_between:
+          arguments:
+            min_value: 0
+          config:
+            severity: warn
+
+tests:
+  - dbt_utils.unique_combination_of_columns:    # cle composite
+      arguments:
+        combination_of_columns: [device_id, date, product_id]
+
+  - dbt_expectations.expect_table_row_count_to_be_between:
+      arguments:
+        min_value: 1000
+        max_value: 10000000
+      config:
+        severity: warn
+```
+
+### Severity strategy
+
+| Test | Severity | Raison |
+|------|----------|--------|
+| PK `unique` + `not_null` sur dim | `error` | Casse les jointures sinon |
+| `not_null` sur FK obligatoire | `error` | Orphelin = bug data |
+| `relationships` sur FK | `warn` | Detecte les drifts sans bloquer le build |
+| `accepted_values` | `error` | Liste fermee — drift = nouveau code a connaitre |
+| Plages dates / numeriques | `warn` | Informatif, ne pas bloquer la prod |
+| `expect_table_row_count_to_be_between` | `warn` | Alerte de volume anormal |
+
+## 5. Anti-patterns a refuser
+
+| Anti-pattern | Pourquoi c'est interdit | A faire a la place |
+|--------------|------------------------|-------------------|
+| Jointure fait-a-fait dans Power BI | Explosion cartesienne, mesures fausses | Croiser au niveau intermediate ou via dim partagee |
+| Dim qui pointe vers une autre dim (`device → company`) | Snowflake, requetes plus lentes, complexite Power BI | Aplatir les attributs d'affichage parents dans la dim enfant (1-3 colonnes max) |
+| Mart "OBT" 1 modele = 1 rapport, tout deja joint | Duplication, perte de reutilisabilite, refresh long | Star schema + mesures Power BI |
+| FK manquante dans un fait | Ligne orpheline silencieuse | Test `relationships` sur la FK (severity warn ou error) |
+| Nom de rapport BI dans la description du mart | La doc rote quand le rapport est renomme / supprime | Referencer le mart dans l'`exposure` du rapport |
+| `description='...'` dans `{{ config() }}` ET dans YAML | Drift garanti | Description en YAML uniquement |
+| `tags=[...]` au niveau model | Casse l'organisation par folder | Tags via `dbt_project.yml` (sauf exceptions `cross_post_*`) |
+| Pas de grain dans la description | "Mart en aveugle", impossible a auditer | Ligne `[GRAIN]` explicite |
+
+## 6. Pattern type SQL (squelette)
+
+```sql
+-- fct_<bu>__<event>.sql
+{{ config(
+    materialized='table',
+    partition_by={'field': 'event_date', 'data_type': 'date'},
+    cluster_by=['ticket_id']
+) }}
+
+with events as (
+    select * from {{ ref('int_<source>__<event>') }}
+)
+
+select
+    ticket_id,         -- FK vers dim_<bu>__ticket
+    account_id,        -- FK vers dim_<bu>__account
+    agent_id,          -- FK vers dim_<bu>__agent
+    event_date,
+    event_type,
+    duration_minutes   -- mesures additives uniquement
+from events
+```
+
+Description et tests vivent dans `_<bu>__marts_models.yml` (voir §2 et §4).
+
+## 7. Ordre des colonnes du `select` final
+
+Convention **indicative** (non verifiee par SQLFluff, mais attendue en review).
+Regle dite **grain-first** : les colonnes du grain ouvrent le `select`, puis on
+reprend un tri par role. Objectif : lire « de quoi parle la ligne » (cles →
+contexte → quand) avant « combien » (mesures).
+
+1. **Grain** — la/les colonne(s) qui definissent le grain, dans l'ordre
+   `dimension temporelle → cle primaire → cles etrangeres`. Sur un fait agrege
+   a grain temporel, la date de grain (`mois`, `event_date`) vient donc **en
+   premier** (ex. `fct_supply_chain__disponibilite_article_neshu_depot_mensuel`
+   ouvre sur `mois`, puis `company_id`, puis `product_code`).
+2. **Cles etrangeres** restantes (`<entity>_id`) non incluses dans le grain.
+3. **Attributs / dimensions** texte ou categoriels (`*_name`, `*_code`,
+   `*_type`, `*_status`).
+4. **Dates / timestamps metier** secondaires (hors date de grain).
+5. **Booleens / flags** (`is_*`, `has_*`) — ils qualifient la ligne.
+6. **Mesures** numeriques additives — toujours regroupees en fin de fait.
+7. **Metadonnees / audit** (`created_at`, `updated_at`, `extracted_at`,
+   `deleted_at`) — toujours en dernier.
+
+> Regle, pas dogme : si un regroupement metier est plus lisible (ex. coller
+> `entity_code`/`entity_name` juste apres leur FK), c'est tolere. Le grain en
+> tete et les metadonnees en queue, en revanche, sont systematiques.

--- a/docs/conventions/seeds-snapshots.md
+++ b/docs/conventions/seeds-snapshots.md
@@ -1,0 +1,87 @@
+# Conventions — Seeds & Snapshots
+
+> Ces deux types de ressources ne sont pas des couches du DAG mais ont leurs
+> propres règles. Transversal : [`../../CONVENTIONS.md`](../../CONVENTIONS.md).
+
+## Seeds (`data/reference_data/`)
+
+Fichiers CSV chargés via `dbt seed`. Données de référence statiques (mappings,
+paramètres). Organisés par domaine source :
+
+```
+data/reference_data/
+├── yuman/              # ref_yuman__cp_metropole.csv, ref_yuman__machine_clean.csv, ...
+├── oracle_neshu/       # ref_oracle_neshu__valo_parc_machine.csv, ...
+├── mssql_sage/         # ref_mssql_sage__code_analytique_bu.csv, ...
+├── nesp_tech/          # ref_nesp_tech__articles_prix.csv, ...
+├── nesp_co/            # ref_nesp_co__commerciaux.csv, ...
+└── general/            # ref_general__feries_metropole.csv, ...
+```
+
+- Nommage : `ref_<source>__<entity>.csv`. Schéma de destination : `prod_reference` / `dev_reference`.
+
+### Déclaration des types de colonnes
+
+Types déclarés **dans `data/schema.yml`** sous chaque seed, via `config: column_types:`.
+Ne pas utiliser `dbt_project.yml` pour les types par colonne.
+
+```yaml
+- name: ref_nesp_tech__key_facturation
+  description: "Cle de facturation des interventions techniques"
+  config:
+    column_types:
+      type_code: STRING
+      prod_factu: INT64
+      tarif_factu: FLOAT64
+      valid_from: DATE
+  columns:
+    - name: type_code
+      ...
+```
+
+### Types BigQuery à utiliser
+
+| Type | Utiliser | Ne pas utiliser |
+|------|----------|-----------------|
+| Texte | `STRING` | `string`, `str`, `VARCHAR` |
+| Entier | `INT64` | `int`, `integer`, `INTEGER` |
+| Décimal | `FLOAT64` | `float`, `FLOAT`, `NUMERIC` |
+| Date | `DATE` | `date` |
+| Timestamp | `TIMESTAMP` | `timestamp`, `DATETIME` |
+| Booléen | `BOOLEAN` | `bool`, `BOOL` |
+
+> **Règle critique** : toujours vérifier les valeurs réelles du CSV avant
+> d'assigner un type. Un code postal sans zéro initial (`38000`) sera inféré
+> `INT64` par BigQuery — le typer `STRING` casserait les joins existants. Ne pas
+> se fier au nom de la colonne seul.
+
+### Colonnes dans `data/schema.yml`
+
+Chaque colonne du CSV doit avoir une entrée dans `columns:` avec une description.
+Les colonnes importantes doivent avoir des tests (`not_null`, `unique`, `relationships`).
+
+### BOM dans les fichiers CSV
+
+Ne pas sauvegarder les CSV depuis Excel en UTF-8 avec BOM. Si un fichier contient
+un BOM (visible via `head -c 3 fichier.csv | xxd`), le supprimer avec :
+
+```bash
+sed -i '1s/^\xef\xbb\xbf//' data/reference_data/<source>/<fichier>.csv
+```
+
+## Snapshots (`snapshots/`)
+
+Suivi historique SCD Type 2 sur les entités qui évoluent :
+
+| Snapshot | Entité | Stratégie |
+|----------|--------|-----------|
+| `snap_oracle_neshu__company` | Clients | timestamp |
+| `snap_oracle_neshu__device` | Machines | timestamp |
+| `snap_oracle_neshu__valo_parc_machines` | Parc machines | timestamp |
+
+Commande : `dbt snapshot`.
+
+> **Hard rule** : stratégie/colonnes des snapshots inchangées (gérés par GCP Cloud
+> Workflows). Ne jamais renommer le fichier snapshot ni sa table BQ (historique
+> SCD2 perdu). **Exception** : mettre à jour les `ref()` internes quand une dim
+> référencée est renommée est OK.

--- a/docs/conventions/staging.md
+++ b/docs/conventions/staging.md
@@ -34,12 +34,16 @@ Chaque `stg_*` expose ces 4 colonnes harmonisées :
 ### Nommage des colonnes — passthrough par défaut
 
 **Règle : raw → staging ne renomme pas les colonnes.** On conserve les noms de la
-source. Seules **deux** transformations de nom sont autorisées :
+source. Seules **trois** transformations de nom sont autorisées :
 
 1. **Harmonisation des 4 colonnes système** (`creation_date`→`created_at`,
-   `_sdc_extracted_at`→`extracted_at`, etc. — cf. § 3 colonnes système).
+   `_sdc_extracted_at`→`extracted_at`, etc. — cf. colonnes système ci-dessus).
 2. **Nettoyage d'un nom ambigu / non parlant**, typiquement un `id` nu →
    `<entity>_id`.
+3. **Préfixage par l'entité** des colonnes **génériques** (`name`, `address`,
+   `code`, `category`) → `client_name`, `site_address`… — **uniquement** quand la
+   source expose ces noms passe-partout sur des entités qui sont **co-jointes en
+   aval** (sinon, passthrough simple).
 
 Vérifié sur les données (diff colonnes raw vs staging) :
 
@@ -51,11 +55,14 @@ Vérifié sur les données (diff colonnes raw vs staging) :
 > La normalisation complète en `<entity>_id` pour **toutes** les sources se fait
 > au plus tard en marts. En staging, on reste fidèle à la source.
 
-> **Déviation connue — Yuman.** `stg_yuman__*` préfixe les colonnes métier par
-> l'entité (`name`→`client_name`, `address`→`client_address`, `code`→`client_code`).
-> Ça va au-delà du nettoyage et **n'est pas la convention cible** : ne pas
-> reproduire ce préfixage sur de nouveaux staging. Dette historique, à laisser en
-> l'état tant qu'aucun refactor Yuman n'est planifié.
+> **Cas du préfixage par entité — Yuman (pattern justifié).** Les `stg_yuman__*`
+> préfixent les colonnes métier (`name`→`client_name`, `address`→`site_address`,
+> `code`→`material_code`). Ce n'est **pas** une déviation : `int_yuman__demands_workorders_enriched`
+> joint **9 entités Yuman** qui partagent toutes des noms génériques — sans préfixe,
+> chaque jointure aval devrait désambiguïser à la main (≈190 références). Le préfixe
+> est donc **load-bearing**. Règle : préfixer en staging **si et seulement si** la
+> source a des noms génériques co-joints (cas Yuman) ; sinon, passthrough strict
+> (cas Oracle, Zoho).
 
 ### Autres colonnes
 

--- a/docs/conventions/staging.md
+++ b/docs/conventions/staging.md
@@ -1,0 +1,181 @@
+# Conventions — couche Staging
+
+> Doc de référence pour écrire un modèle `stg_*`. Règles transversales (format de
+> nommage, SQLFluff, tags) : voir [`../../CONVENTIONS.md`](../../CONVENTIONS.md).
+> Pattern marts : [`marts.md`](marts.md) · Intermediate : [`intermediate.md`](intermediate.md).
+
+## 1. Rôle de la couche
+
+Nettoyer et normaliser **une table source** : renommer, caster, harmoniser les
+timestamps, exposer tous les champs utiles. **Une source de staging = une table
+source.** Pas de logique métier, pas de jointure cross-source (ça vit en
+intermediate/marts). Le staging est la seule couche qui lit `source()`.
+
+## 2. Nommage
+
+- Fichier : `stg_<source>__<entity>.sql` (`__` sépare source et entité).
+- YAML : `_<source>__models.yml` (doc + tests) et `_<source>__sources.yml`
+  (déclaration source + freshness), dans le dossier de la source.
+- Entité en snake_case, au plus proche de la table source.
+
+## 3. Colonnes
+
+### Colonnes système — obligatoires sur tout staging
+
+Chaque `stg_*` expose ces 4 colonnes harmonisées :
+
+| Colonne | Type | Construction |
+|---|---|---|
+| `created_at` | TIMESTAMP | `timestamp(<date_creation_source>)` |
+| `updated_at` | TIMESTAMP | `timestamp(coalesce(<date_modif>, <date_creation>))` |
+| `extracted_at` | TIMESTAMP | `timestamp(_sdc_extracted_at)` (ou cast `safe.parse_timestamp` si STRING) |
+| `deleted_at` | TIMESTAMP | `timestamp(_sdc_deleted_at)` |
+
+### Nommage des colonnes — passthrough par défaut
+
+**Règle : raw → staging ne renomme pas les colonnes.** On conserve les noms de la
+source. Seules **deux** transformations de nom sont autorisées :
+
+1. **Harmonisation des 4 colonnes système** (`creation_date`→`created_at`,
+   `_sdc_extracted_at`→`extracted_at`, etc. — cf. § 3 colonnes système).
+2. **Nettoyage d'un nom ambigu / non parlant**, typiquement un `id` nu →
+   `<entity>_id`.
+
+Vérifié sur les données (diff colonnes raw vs staging) :
+
+| Source | Passthrough | Renommages |
+|---|---|---|
+| Oracle / company | 9/13 | uniquement les 4 colonnes système |
+| Zoho / tickets | 42/43 | uniquement `id` → `ticket_id` |
+
+> La normalisation complète en `<entity>_id` pour **toutes** les sources se fait
+> au plus tard en marts. En staging, on reste fidèle à la source.
+
+> **Déviation connue — Yuman.** `stg_yuman__*` préfixe les colonnes métier par
+> l'entité (`name`→`client_name`, `address`→`client_address`, `code`→`client_code`).
+> Ça va au-delà du nettoyage et **n'est pas la convention cible** : ne pas
+> reproduire ce préfixage sur de nouveaux staging. Dette historique, à laisser en
+> l'état tant qu'aucun refactor Yuman n'est planifié.
+
+### Autres colonnes
+
+- snake_case partout.
+- Booléens : préfixe `is_` / `has_`.
+- Dates : `_at` (timestamp) / `_date` (date).
+
+## 4. Pattern SQL
+
+CTE en 2-3 étapes (`source_data` → `cleaned_data` → `select` final) :
+
+```sql
+{{ config(
+    materialized='table',
+    description='<une ligne : quoi + source>'
+) }}
+
+with source_data as (
+    select * from {{ source('oracle_neshu', 'evs_company') }}
+),
+
+cleaned_data as (
+    select
+        cast(idcompany as int64) as idcompany,   -- IDs castés
+        code,
+        name,                                     -- colonnes texte
+        timestamp(creation_date) as created_at,   -- timestamps harmonisés
+        timestamp(coalesce(modification_date, creation_date)) as updated_at,
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+    from source_data
+)
+
+select * from cleaned_data
+```
+
+- **Casting** : `cast(x as int64/float64)`, `timestamp(x)`. Utiliser `safe_cast` /
+  `safe.parse_timestamp` / `safe.parse_date` quand la source est STRING ou sujette
+  au drift (fichiers GCS, taps custom).
+- **Nettoyage** : `nullif(trim(x), '')` pour vider les chaînes vides.
+- **Déduplication** (quand la source a des doublons) : 3ᵉ CTE `deduplicated_data`
+  avec `row_number() over (...)` + `qualify row_number() = 1`.
+
+## 5. Matérialisation
+
+- **`table`** par défaut.
+- **`incremental`** (stratégie `merge`) réservé aux grosses tables événementielles
+  à PK stable — aujourd'hui les `task` Oracle (`stg_oracle_neshu__task`,
+  `stg_oracle_lcdp__task`, `*_has_product`). `unique_key` obligatoire,
+  `partition_by` sur la colonne du filtre incrémental. Clause :
+
+  ```sql
+  {% if is_incremental() %}
+      where updated_at > (select max(updated_at) from {{ this }})
+         or updated_at >= timestamp_sub(current_timestamp(), interval 7 day)
+  {% endif %}
+  ```
+- `partition_by` / `cluster_by` : voir [`../../CONVENTIONS.md`](../../CONVENTIONS.md) (règles BigQuery) — cluster sur les FK les plus jointes en aval.
+
+## 6. Description
+
+- **Obligatoire dans le `{{ config() }}`** (`description='...'`, 1 ligne) — règle
+  historique du projet, présente sur 100% des staging.
+- YAML : description complémentaire (contexte métier) tolérée mais **non
+  obligatoire** ; ne pas dupliquer mot pour mot la ligne du config.
+
+## 7. Tests minimum
+
+Syntaxe dbt ≥ 1.11 : arguments sous `arguments:`, severity sous `config:`.
+
+### Obligatoire (severity `error` par défaut)
+
+```yaml
+columns:
+  - name: <pk>                 # idcompany, ticket_id...
+    tests: [unique, not_null]
+  - name: <fk_obligatoire>
+    tests:
+      - not_null
+      - relationships:
+          arguments: {to: "ref('stg_<source>__<parent>')", field: <pk_parent>}
+```
+
+- PK composite → `dbt_utils.unique_combination_of_columns` (sous `tests:` model-level).
+
+### Recommandé fort
+
+- `accepted_values` sur les colonnes à liste fermée (statuts, types) — **peu
+  répandu aujourd'hui (0/93), à généraliser** : un drift = un nouveau code à
+  connaître.
+- Pour les sources à timestamp STRING (pas de freshness native), test de
+  fraîcheur **méthode B** : `dbt_expectations.expect_row_values_to_have_recent_data`
+  sur `extracted_at` (cf. § 8).
+
+## 8. Freshness
+
+Deux mécanismes selon le type de timestamp source — **détail et état par source :
+[`../freshness.md`](../freshness.md)** (autorité unique, ne pas redupliquer ici).
+
+- **Méthode A** (`dbt source freshness`) : source avec TIMESTAMP/DATE natif →
+  `loaded_at_field` + seuils dans `_<source>__sources.yml`.
+- **Méthode B** (test `dbt_expectations` sur le staging) : source à timestamp
+  STRING → test de récence sur la colonne castée du `stg_*`.
+
+## 9. Anti-patterns
+
+| Anti-pattern | À faire à la place |
+|---|---|
+| Jointure cross-source en staging | Rester sur 1 table source ; joindre en intermediate/marts |
+| Logique métier / agrégation en staging | Pousser en intermediate |
+| `source()` en intermediate/marts | `source()` **uniquement** en staging ; `ref()` ensuite |
+| Oublier une des 4 colonnes système | Les exposer toutes (même `deleted_at` null) |
+| `description` seulement en YAML | Obligatoire dans le `config()` pour le staging |
+| Caster une source STRING fragile en `cast` dur | `safe_cast` / `safe.parse_*` |
+
+## 10. Checklist avant PR
+
+- [ ] Fichier `stg_<source>__<entity>.sql` + entrée dans `_<source>__models.yml`
+- [ ] 4 colonnes système exposées et harmonisées
+- [ ] `description='...'` dans le `config()`
+- [ ] PK testée `unique` + `not_null` ; FK testées `relationships`
+- [ ] Freshness configurée (méthode A ou B) si la table porte des événements
+- [ ] `sqlfluff lint` OK

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -397,7 +397,7 @@ models:
       OBT-like : l'aplatissement multi-dim est volontaire car le BI parc
       machine consomme directement cette table sans jointure côté Power Query.
       Si 3+ rapports répètent ce flatten, voir si on consolide ; sinon on garde.
-      Pattern doc dans `CONVENTIONS.md` § Marts.
+      Pattern doc dans `docs/conventions/marts.md`.
     columns:
       # Informations Machine
       - name: material_id


### PR DESCRIPTION
## Pourquoi

Restructuration du repo pour le rendre « AI-ready » et, surtout, plus lisible pour le prochain analytics engineer. Inspiré d'un modèle d'arborescence dbt+IA, **adapté à notre repo déjà mature** (on n'a pas copié l'arbo générique : on a comblé les vrais manques).

Deux axes :
1. **Versionner et fiabiliser la couche assistant** (CLAUDE.md, MCP, skills, hooks) + garde-fous qui tournent quel que soit l'auteur du code.
2. **Mettre les conventions au propre par couche** — une doc focalisée par couche plutôt qu'un `CONVENTIONS.md` de 700 lignes.

## Ce qui change

### 1. Couche IA versionnée + `.gitignore` affiné
- `CLAUDE.md`, `.mcp.json`, `.claude/{commands,skills,hooks,settings.json}` ne sont plus gitignorés → **partagés avec l'équipe**.
- Restent locaux : `.claude/settings.local.json` (perso) et `.claude/notes/` (notes de travail).
- **Aucun secret committé** (vérifié) : les hooks récupèrent les tokens à la volée (keyfile via env, secret PBI via GCP Secret Manager) ; les IDs tenant/client PBI ne sont pas sensibles.
- Nouvelles slash-commands : `/build-source`, `/new-mart`, `/lint-fix`, `/freshness`.

### 2. Garde-fous pre-commit
- `.pre-commit-config.yaml` : `sqlfluff lint` (au commit) + `dbt parse` (au push), via `./dbt_venv` (pas de version d'outil dupliquée). Miroir des hooks Claude → **une édition humaine hors IA ne peut plus contourner le lint**.
- Install documentée dans `CONTRIBUTING.md` (`pipx`, n'altère pas `dbt_venv`).

### 3. Portabilité MCP/hooks
- Les scripts de hooks s'auto-localisent (`$(dirname "${BASH_SOURCE[0]}")/../..`) — portables sans dépendre d'une variable.
- `.mcp.json` / `settings.json` : chemins absolus. (Essai `${CLAUDE_PROJECT_DIR}` abandonné — non expansé dans `.mcp.json`, cassait les serveurs MCP ; vérifié après restart : bigquery/dbt-local/powerbi reconnectent avec les chemins absolus.)

### 4. Conventions par couche (le gros morceau)
- Nouveau dossier `docs/conventions/` : `staging.md`, `intermediate.md`, `marts.md`, `seeds-snapshots.md`, **même gabarit** (rôle · nommage · colonnes · SQL · matérialisation · description · tests · freshness · anti-patterns · checklist PR).
- `CONVENTIONS.md` **passe de 713 à 148 lignes** : devient un index transversal + table « où trouver quoi ».
- Conventions **inférées du code réel** (agent Explore + diffs de colonnes BigQuery), pas de suppositions.

### 5. Yuman — pas de refacto, reclassé
- Analyse d'impact : le préfixage `client_*`/`site_*`/`material_*` est **load-bearing** (`int_yuman__demands_workorders_enriched` joint 9 entités aux noms génériques, ~190 refs aval). Refacto passthrough = ~29 fichiers + risque, zéro gain. Reclassé en **pattern justifié** dans `staging.md`.

## Corrections honnêtes vs doc précédente (fondées sur le code)
- **Nommage staging = passthrough** (vérifié : Oracle 9/13, Zoho 42/43 colonnes conservées). Seuls renommages : harmonisation des cols système + `id` nu → `<entity>_id` + préfixage entité quand noms génériques co-joints (Yuman).
- **Intermediate = aligné par source, PAS cross-source** (0 modèle cross-source aujourd'hui ; l'unification se fait en marts). Corrigé dans `CLAUDE.md`.
- **`accepted_values` sur enums staging** : 0/93 aujourd'hui → classé « recommandé à généraliser ».

## Vérifications
- `dbt parse` OK après chaque édition YAML.
- Reconnexion des 3 serveurs MCP confirmée après restart.
- Diffs de colonnes raw↔staging via BigQuery pour fonder les règles de nommage.
- Tous les liens inter-docs résolvent ; aucune référence cassée (`§ Nommage des marts`, `docs/migration-marts/` mort, etc. corrigés).

## Hors périmètre (volontairement)
- **Pas de split des workflows GitHub** : le `dbt-ci.yml` unique (jobs PR/push gated par `if`) est déjà propre ; le vrai gain serait une composite action (différé).
- **Pas de refacto Yuman** (cf. §5).

## Pour le reviewer
- Regarder en priorité `docs/conventions/staging.md` et `intermediate.md` (règles formalisées depuis le code).
- Après merge, penser à `pre-commit install` + `pre-commit install --hook-type pre-push` sur sa machine.
- `.mcp.json` utilise des chemins absolus `/mnt/data/transform` (OK sur la VM ; à adapter si checkout ailleurs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)