### PR TITLE
Documentation YAML intermediate (grounding agent NL→SQL) — 7 sources + CHECK_LUNCH comptage

### DIFF
--- a/docs/conventions/intermediate.md
+++ b/docs/conventions/intermediate.md
@@ -73,13 +73,47 @@ select * from enriched
 - Clause `is_incremental()` : même pattern que le staging (`updated_at >` max +
   fenêtre glissante de sécurité).
 
-## 6. Description
+## 6. Description & documentation (grounding agent NL→SQL)
+
+> Les descriptions YAML sont lues par l'agent IA (text-to-SQL) via le manifest dbt :
+> elles déterminent sa capacité à traduire une question métier en SQL correct. On
+> documente donc pour la machine **et** l'humain. Standard aligné sur celui des marts.
 
 - **En YAML uniquement**, pas dans le `{{ config() }}` (`persist_docs` pousse la
   description YAML vers BigQuery). Tout modèle a une entrée YAML.
 - **Dette connue** : une partie des `int_*` existants portent encore une
   `description=` dans le config — à retirer au fil des modifications, ne pas en
   ajouter de nouvelle.
+
+### Description du modèle — trame 4 blocs (comme les marts)
+
+```
+[QUOI MÉTIER]        ce que représente la table, en langage métier
+[COMMENT CONSTRUITE] sources + logique clé (full join, dédup, lookups, filtres)
+[GRAIN]              1 ligne par X  ← obligatoire (+ volumétrie, NULL attendus, fan-out éventuel)
+[NOTES]              filtres implicites, pièges, dépendances aval
+```
+
+### Documentation des colonnes — standard « agent-ready »
+
+Chaque colonne documente, selon son type :
+
+| Type de colonne | À documenter |
+|---|---|
+| FK (`*_id`) | sens + **entité cible** (« FK → `stg_yuman__sites` / `dim_technique__site` ») |
+| Enum / liste fermée | sens + **valeurs possibles et leur signification** (échantillonnées dans BigQuery, pas devinées) |
+| Catégorie haute cardinalité | sens + **motif/pattern** + exemples (pas d'énumération exhaustive) |
+| Mesure | sens + **unité** + additif ou non |
+| Date / timestamp | **quel événement** elle marque |
+| Texte libre | sens métier (pas une paraphrase du nom) |
+| Booléen | la condition exacte qui le met à `true` |
+
+Pour les énums structurantes, ajouter le test `accepted_values` (severity `warn`) —
+il documente ET protège contre les dérives. Signaler les **NULL/valeurs attendus**
+(ex. « renseigné uniquement pour le partenaire NESHU ») et les **données sales** connues.
+
+> Modèle de référence : `int_yuman__demands_workorders_enriched` et
+> `int_yuman__interventions` (`models/intermediate/yuman/_yuman__intermediate_models.yml`).
 
 ## 7. Tests minimum
 

--- a/models/intermediate/mssql_sage/_mssql_sage__intermediate_models.yml
+++ b/models/intermediate/mssql_sage/_mssql_sage__intermediate_models.yml
@@ -75,7 +75,7 @@ models:
         tests:
           - accepted_values:
               arguments:
-                values: ["Chiffre d'Affaires", "Masse Salariale", "Frais Directs & Amortissements", "Consommation MP & SSTT"]
+                values: ["Chiffre d\\'Affaires", "Masse Salariale", "Frais Directs & Amortissements", "Consommation MP & SSTT"]
               config:
                 severity: warn
       # TODO(métier): confirmer avec la finance — (1) sens_ecriture 0=débit / 1=crédit ;

--- a/models/intermediate/mssql_sage/_mssql_sage__intermediate_models.yml
+++ b/models/intermediate/mssql_sage/_mssql_sage__intermediate_models.yml
@@ -3,8 +3,28 @@ version: 2
 models:
   - name: int_mssql_sage__pnl_bu
     description: >
-      Table intermediaire de faits combinant écritures comptables et analytiques issues de SAGE
-      pour la construction du P&L par Business Unit.
+      [QUOI MÉTIER]
+      Brique de compte de résultat (P&L) par Business Unit : chaque ligne est une écriture
+      comptable de charge ou de produit, ventilée analytiquement et rattachée à une BU et à
+      une macro-catégorie P&L. Base de fct_finance__pnl_bu.
+
+      [COMMENT CONSTRUITE]
+      Jointure des écritures comptables (stg_mssql_sage__f_ecriturec, filtrées aux comptes de
+      classe 6 = charges et 7 = produits) avec les écritures analytiques
+      (stg_mssql_sage__f_ecriturea). La BU est dérivée du code analytique via le seed
+      ref_mssql_sage__code_analytique_bu, avec repli sur des préfixes (NUN→NUNSHEN, NES→NESHU,
+      SAV→TECHNIQUE…) ; la macro-catégorie P&L vient du seed ref_mssql_sage__code_comptable_bu.
+      Un remapping historique 2024 (source historic) corrige certaines BU. date_facturation est
+      reconstruite (jm_date + (ec_jour-1) jours).
+
+      [GRAIN]
+      1 ligne par (numero_ecriture_comptable, numero_plan_analytique, numero_ligne_analytique).
+      ~190k lignes, depuis 2021. Clé strictement unique.
+
+      [NOTES]
+      Périmètre limité aux comptes 6 et 7 (le bilan, classes 1-5, est exclu). Une écriture
+      comptable sans ventilation analytique apparaît quand même (is_missing_analytical = true,
+      colonnes analytiques NULL). Pour les agrégats P&L, sommer montant_analytique_signe.
 
     tests:
       - dbt_utils.unique_combination_of_columns:
@@ -15,41 +35,90 @@ models:
               - numero_ligne_analytique
 
     columns:
+      # --- CLES / GRAIN ---
       - name: numero_ecriture_comptable
-        description: Clé de l'écriture comptable (f_ecriturec)
+        description: Numéro de l'écriture comptable Sage (table f_ecriturec). Partie 1 de la clé composite.
         tests:
           - not_null
-
       - name: numero_plan_analytique
-        description: Numéro analytique (f_ecriturea)
-
+        description: Numéro du plan analytique Sage (table f_ecriturea). Partie 2 de la clé. NULL si écriture sans ventilation analytique.
       - name: numero_ligne_analytique
-        description: Ligne du numéro analytique
+        description: Numéro de ligne de la ventilation analytique. Partie 3 de la clé. NULL si écriture sans ventilation analytique.
 
+      # --- AXES D'ANALYSE ---
       - name: code_analytique
-        description: Code de la section analytique (BU, projet, etc.)
-
+        description: Code de la section analytique brut (BU, projet…) tel que saisi dans Sage. Sert à dériver code_analytique_bu.
       - name: code_analytique_bu
-        description: Business Unit (BU) associée à la section analytique
-
-      - name: macro_categorie_pnl_bu
-        description: Macro catégorie P&L associée au compte comptable
-
+        description: >
+          Business Unit déduite du code analytique (via seed + repli préfixe). Valeurs :
+          COMMERCE, NUNSHEN, NESHU, SUPPORT, TECHNIQUE, PIECES DET, ZSITUATION.
+          NULL = code analytique non mappé (cf. is_missing_bu_mapping).
+        tests:
+          - accepted_values:
+              arguments:
+                values: [COMMERCE, NUNSHEN, NESHU, SUPPORT, TECHNIQUE, PIECES DET, ZSITUATION]
+              config:
+                severity: warn
       - name: numero_compte_general
-        description: Numéro de compte général (classes 6 et 7)
+        description: >
+          Numéro de compte général (plan comptable). Filtré aux classes 6 (charges, commence
+          par 6) et 7 (produits, commence par 7). Détermine le sens du montant signé.
         tests:
           - not_null
-
       - name: libelle_ecriture
-        description: Libellé de l'écriture comptable
+        description: Libellé libre de l'écriture comptable.
+      - name: macro_categorie_pnl_bu
+        description: >
+          Macro-catégorie de P&L rattachée au compte général (seed ref_mssql_sage__code_comptable_bu).
+          Valeurs : Chiffre d'Affaires, Masse Salariale, Frais Directs & Amortissements,
+          Consommation MP & SSTT. NULL = compte non mappé (cf. is_missing_comptable_mapping).
+        tests:
+          - accepted_values:
+              arguments:
+                values: ["Chiffre d'Affaires", "Masse Salariale", "Frais Directs & Amortissements", "Consommation MP & SSTT"]
+              config:
+                severity: warn
+      # TODO(métier): confirmer avec la finance — (1) sens_ecriture 0=débit / 1=crédit ;
+      # (2) convention de signe de montant_analytique_signe (crédit positif / débit négatif,
+      # à sommer pour le P&L). Inféré du SQL, non validé métier au 2026-06-20.
+      - name: sens_ecriture
+        description: "Sens comptable de l'écriture (Sage) : 0 = débit, 1 = crédit. Combiné à la classe de compte pour signer le montant."
 
+      # --- MESURES ---
       - name: montant_analytique
-        description: Montant ventilé sur la section analytique
+        description: Montant (€) ventilé sur la section analytique, en valeur absolue (non signé).
+      - name: montant_analytique_signe
+        description: >
+          Montant signé (€) à sommer pour le P&L : positif au crédit (sens_ecriture = 1,
+          typiquement les produits / chiffre d'affaires), négatif au débit (sens_ecriture = 0,
+          typiquement les charges). C'est **la** mesure du résultat par BU.
 
+      # --- DATES ---
       - name: date_facturation
-        description: Date réelle de facturation (reconstruite à partir de jm_date + ec_jour)
+        description: >
+          Date de facturation reconstruite (jm_date + (ec_jour - 1) jours). Clé de
+          partitionnement et axe temporel principal du P&L.
         tests:
           - not_null
+      - name: date_ecriture_comptable
+        description: Date de l'écriture comptable (ec_date Sage).
+      - name: date_periode_facturation
+        description: Date de la période de facturation (jm_date Sage), avant ajout du jour.
+      - name: jour_facturation
+        description: Jour du mois de facturation (ec_jour Sage) utilisé pour reconstruire date_facturation.
 
+      # --- FLAGS QUALITE ---
       - name: is_missing_analytical
-        description: Indique si l'écriture comptable n'a pas de ventilation analytique
+        description: True si l'écriture comptable n'a aucune ventilation analytique (colonnes analytiques NULL).
+      - name: is_missing_bu_mapping
+        description: >
+          True si la ligne a une ventilation analytique mais aucune BU n'a pu être déduite
+          (code_analytique_bu NULL alors que is_missing_analytical = false). À surveiller : trou de mapping.
+      - name: is_missing_comptable_mapping
+        description: True si le compte général n'est rattaché à aucune macro-catégorie P&L (macro_categorie_pnl_bu NULL).
+
+      # --- METADONNEES ---
+      - name: created_at
+        description: Timestamp de création de l'écriture en source (coalesce analytique / comptable).
+      - name: updated_at
+        description: Timestamp de dernière modification en source (coalesce analytique / comptable).

--- a/models/intermediate/nesp_co/_nesp_co__intermediate_models.yml
+++ b/models/intermediate/nesp_co/_nesp_co__intermediate_models.yml
@@ -1,181 +1,189 @@
 version: 2
 
 models:
-  - name: int_nesp_co__activites
-    description: >
-      Modèle intermédiaire des activités commerciales NESP CO.
-      Harmonisation des champs, traduction des typologies et unification des dates.
-
-    columns:
-
-      - name: act_id
-        description: Identifiant unique de l'activité.
-        tests:
-          - not_null
-
-      - name: act_id_resp
-        description: Identifiant du collaborateur responsable.
-
-      - name: act_cree_par
-        description: Identifiant du créateur de l'activité selon le type.
-
-      - name: act_compte_id
-        description: Identifiant C4C du compte lié.
-
-      - name: act_id_nessoft
-        description: Identifiant Nessoft du compte lié.
-
-      - name: act_compte_nom
-        description: Nom du compte principal.
-
-      - name: act_date_debut
-        description: Date de début normalisée de l'activité.
-
-      - name: act_type
-        description: Type d'activité traduit en français.
-
-      - name: act_role
-        description: Rôle du compte (client / prospect).
-
-      - name: act_statut
-        description: Statut du cycle de vie de l'activité.
-
-      - name: act_categorie
-        description: Catégorie métier traduite.
-
-      - name: act_semaine_creation
-        description: Semaine ISO au format SS.AAAA calculée à partir de la date de début.
-
   - name: int_nesp_co__opportunites
     description: >
-      Modèle intermédiaire des opportunités commerciales NESP CO.
-      Harmonisation des noms de colonnes, traduction des statuts et rôles,
-      normalisation des identifiants et indicateurs de performance.
+      [QUOI MÉTIER]
+      Opportunités commerciales Nespresso (pipeline de vente, source C4C/Nessoft) : une ligne
+      par opportunité, avec son statut, le compte, le commercial, la campagne et la valeur attendue.
 
+      [COMMENT CONSTRUITE]
+      stg_nesp_co__opportunite : renommage métier (préfixe opp_), traduction FR des statuts et
+      rôles, normalisation des identifiants (C4C '#' → NULL), probabilité ramenée en [0,1].
+
+      [GRAIN]
+      1 ligne par opp_id (PK). ~27,7k lignes.
+
+      [NOTES]
+      Source commerciale Nespresso, encore en construction (WIP). Les montants et probabilités
+      sont du prévisionnel commercial, pas du réalisé.
     columns:
-
       - name: opp_id
-        description: Identifiant unique de l'opportunité.
+        description: Identifiant unique de l'opportunité (C4C). PK.
         tests:
           - not_null
-
       - name: opp_nom
-        description: Nom de l'opportunité.
-
+        description: Nom / intitulé de l'opportunité.
       - name: opp_ez
-        description: Indicateur équivalent Zenius.
-
+        description: Équivalent Zenius (nombre de machines en équivalent Zenius) rattaché à l'opportunité.
       - name: opp_date_creation
         description: Date de création de l'opportunité.
-
-      - name: opp_date_cloture
-        description: Date de clôture de l'opportunité.
-
-      - name: opp_statut
-        description: Statut de cycle de vie traduit en français.
-
+      - name: opp_source
+        description: >
+          Origine de l'opportunité. Valeurs principales : Not assigned, CRC / CoE, Sales Force,
+          Marketing Campaign, Telephone Prospect, Physical Prospect, Referral, Cold Visit,
+          Member get Member, Cold Calling… (énum ouverte, libellés C4C).
       - name: opp_compte
-        description: Nom du compte associé.
-
+        description: Nom du compte (client/prospect) lié à l'opportunité.
       - name: opp_id_compte
-        description: Identifiant Nessoft du compte.
-
+        description: Identifiant Nessoft du compte lié.
       - name: opp_id_client_c4c
-        description: Identifiant C4C du compte (valeur '#' remplacée par NULL).
-
+        description: Identifiant C4C du compte ('#' source remplacé par NULL).
+      - name: opp_statut
+        description: "Statut du cycle de vie (traduit). Valeurs : Gagné, Perdu, En cours."
+      - name: opp_date_cloture
+        description: Date de clôture de l'opportunité (gagnée ou perdue).
       - name: opp_role
-        description: Rôle du compte (client / prospect).
-
+        description: "Rôle du compte (traduit). Valeurs : Client, Client potentiel (prospect)."
       - name: opp_id_commercial
-        description: Identifiant du commercial responsable.
-
+        description: Identifiant C4C du commercial responsable de l'opportunité.
       - name: opp_campagne
         description: Nom de la campagne marketing associée.
-
       - name: opp_campagne_id
         description: Identifiant numérique de la campagne.
-
       - name: opp_first_order_cafe
-        description: Indicateur première commande café.
-
+        description: Indicateur de première commande de café liée à l'opportunité.
       - name: opp_ns_attendu
-        description: Valeur nette attendue.
-
+        description: Valeur nette attendue (€) de l'opportunité (prévisionnel, mesure).
       - name: opp_probabilite
-        description: Probabilité de succès normalisée entre 0 et 1.
-
+        description: Probabilité de succès, normalisée entre 0 et 1 (chance_of_success / 100).
       - name: opp_nb_opport
-        description: Nombre de machines liées à l'opportunité.
+        description: Nombre de machines liées à l'opportunité (mesure).
+
+  - name: int_nesp_co__activites
+    description: >
+      [QUOI MÉTIER]
+      Activités commerciales Nespresso menées par les commerciaux (appels, rendez-vous, tâches,
+      e-mails) : une ligne par activité, avec son type, sa catégorie, son statut et le compte visé.
+
+      [COMMENT CONSTRUITE]
+      stg_nesp_co__activite : unification des champs selon le type d'activité (Phone Call /
+      Appointment / Task — nom, créateur, date de début), puis traduction FR du type, du rôle,
+      du statut et de la catégorie.
+
+      [GRAIN]
+      1 ligne par act_id (PK). ~140,5k lignes.
+
+      [NOTES]
+      Source commerciale Nespresso (WIP). Certaines catégories C4C restent non traduites
+      (ex. 'Customer Visit') quand elles ne sont pas couvertes par le mapping.
+    columns:
+      - name: act_id
+        description: Identifiant unique de l'activité (C4C). PK.
+        tests:
+          - not_null
+      - name: act_id_resp
+        description: Identifiant C4C du commercial responsable de l'activité.
+      - name: act_cree_par
+        description: Identifiant du créateur de l'activité (selon le type — auteur de l'appel, du RDV, ou employé responsable).
+      - name: act_compte_nom
+        description: Nom du compte principal visé par l'activité.
+      - name: act_compte_id
+        description: Identifiant C4C du compte lié.
+      - name: act_id_nessoft
+        description: Identifiant Nessoft du compte lié.
+      - name: act_note
+        description: Note / commentaire libre saisi sur l'activité.
+      - name: act_mois_creation
+        description: Mois calendaire de l'activité (issu de calendar_month source).
+      - name: act_nom
+        description: Intitulé de l'activité (nom de l'appel ou du rendez-vous selon le type).
+      - name: act_date_debut
+        description: Date de début de l'activité (unifiée selon le type d'activité).
+      - name: act_type
+        description: "Type d'activité (traduit). Valeurs : Rendez-vous, Tâche d'activité, Appel téléphonique, e-mail."
+      - name: act_role
+        description: "Rôle du compte (traduit). Valeurs : Client, Client potentiel."
+      - name: act_statut
+        description: "Statut du cycle de vie (traduit). Valeurs : En cours (Open/In Process), Terminé (Completed)."
+      - name: act_categorie
+        description: >
+          Catégorie métier de l'activité (traduite du libellé C4C). Valeurs fréquentes :
+          Prospection, Suivi client, Visite, Client baissier/fragile, Relance opportunité,
+          R5: Suivis client fidélisation, R1: Decouverte, Demande client, R3: Negociation,
+          Préparation, Plainte client… Quelques libellés restent en anglais si non mappés
+          (ex. 'Customer Visit').
+      - name: act_semaine_creation
+        description: Semaine ISO de l'activité au format SS.AAAA (calculée depuis act_date_debut).
 
   - name: int_nesp_co__clients_enrichis
     description: >
-      Modèle intermédiaire des clients NESP CO.
-      Association du client avec l'identifiant C4C le plus récent
-      issu des opportunités et activités via déduplication par date.
+      [QUOI MÉTIER]
+      Clients Nespresso (tiers) enrichis : coordonnées, contact, segmentation commerciale, et
+      l'identifiant C4C le plus récent rattaché au client.
 
+      [COMMENT CONSTRUITE]
+      stg_nesp_co__client enrichi de l'id C4C déduit : on rapproche le tiers (third) du C4C le
+      plus récent observé dans les opportunités et activités (déduplication par date de référence).
+
+      [GRAIN]
+      1 ligne par third (PK, clé métier client). ~21,3k lignes.
+
+      [NOTES]
+      Source commerciale Nespresso (WIP). third_c4c_id est NULL si aucun C4C n'a pu être déduit.
     columns:
-
       - name: third
-        description: Identifiant tiers (clé métier client).
+        description: Identifiant tiers (clé métier client EVS). PK.
         tests:
           - not_null
           - unique
-
       - name: third_name
-        description: Nom du client.
-
+        description: Nom / raison sociale du client.
       - name: third_status_descr
-        description: Statut du client.
-
+        description: >
+          Statut du client. Valeurs : Active, Inactive automatic (365 days), Deletion due to
+          inactivity, Deletion failure, Inactive unclassified, Active no mailing…
       - name: third_address_1
-        description: Ligne 1 de l'adresse.
-
+        description: Adresse du client (ligne 1).
       - name: third_address_2
-        description: Ligne 2 de l'adresse.
-
+        description: Adresse du client (ligne 2).
       - name: third_post_code
         description: Code postal du client.
-
       - name: third_city
         description: Ville du client.
-
-      - name : order_placer_name,
-        description : Nom Contact
-
-      - name : order_placer_adr_ln1,
-        description : Adresse Contact
-
-      - name : order_placer_post_code,
-        description : Code Postal Contact
-
-      - name : order_placer_city,
-        description : Contact Ville
-
-      - name : order_placer_phone,
-        description : Contact Téléphone
-
+      - name: order_placer_name
+        description: Nom du contact passeur de commande.
+      - name: order_placer_adr_ln1
+        description: Adresse du contact (ligne 1).
+      - name: order_placer_post_code
+        description: Code postal du contact.
+      - name: order_placer_city
+        description: Ville du contact.
+      - name: order_placer_phone
+        description: Téléphone du contact.
       - name: segmentation_hypercare
-        description: Indicateur de segmentation Hypercare.
-
+        description: >
+          Segment commercial / Hypercare du client. Valeurs : SMALL, MEDIUM, GET, HVC,
+          POTENTIEL, REGION/IMAGE, INACTIF-2ans et leurs variantes *_HYPERCARE. NULL si non segmenté.
       - name: metier
-        description: Catégorie métier du client.
-
+        description: "Catégorie métier du client. Valeurs : OFFICE, HORECA."
       - name: region
-        description: Région commerciale.
-
+        description: >
+          Région commerciale. Valeurs : Office IDFGE, Office EVS Lyon, Horeca IDFGE,
+          Horeca EVS Lyon, Vending.
       - name: third_secteur
-        description: Secteur commercial associé.
-
+        description: >
+          Secteur commercial (sectorisation fine, haute cardinalité) — ex. 'OFFICE – EVS IDF FID',
+          'HORECA – EVS LYON FID', 'OFFICE - EVS IDF 5'. Le suffixe 'FID' marque la fidélisation.
       - name: third_groupe
-        description : groupe du client, notamment utile pour la FID
-
+        description: >
+          Groupe du client : région en majuscules si secteur de fidélisation ('FID'), sinon
+          'RS ' + métier (ex. 'OFFICE IDFGE', 'RS OFFICE', 'RS HORECA'). Utile pour la FID.
       - name: third_siret
         description: Numéro SIRET du client.
-
       - name: third_club_date
-        description: Date d'adhésion au club (convertie en DATE).
-
+        description: Date d'adhésion au club (DATE).
       - name: third_c4c_id
         description: >
-          Identifiant C4C le plus récent issu des activités ou opportunités
-          via déduplication par date métier.
+          Identifiant C4C le plus récent rattaché au client, déduit des opportunités/activités
+          (déduplication par date de référence). NULL si aucun C4C trouvé.

--- a/models/intermediate/nesp_tech/_nesp_tech__intermediate_models.yml
+++ b/models/intermediate/nesp_tech/_nesp_tech__intermediate_models.yml
@@ -1,110 +1,289 @@
 version: 2
 
 models:
-  - name: int_nesp_tech__delais_interventions
-    description: >
-      Modèle intermediate calculant les délais ouvrés, heures ouvrées
-      et l éligibilité bonus des interventions techniques.
-
-    columns:
-      - name: n_planning
-        description: "Identifiant unique de l intervention"
-        tests:
-          - not_null
-          - unique
-
-      - name: type
-        description: "Type d intervention"
-
-      - name: code_machine
-        description: "Identifiant machine"
-
-      - name: delai_jours_debut
-        description: "Nombre de jours ouvrés jusqu au début"
-        tests:
-          - not_null
-
-      - name: delai_jours_fin
-        description: "Nombre de jours ouvrés jusqu à la fin"
-        tests:
-          - not_null
-
-      - name: delai_heures_debut
-        description: "Heures entre la pickup Date et le début de l'intervention"
-
-      - name: delai_heures_fin
-        description: "Heures entre la pickup Date et la fin de l'intervention"
-
-      - name: delai_traitement_jours
-        description: "Différence entre jours fin et jours début"
-
-      - name: type_delai_debut
-        description: "Classe SLA début (J+0 à J++) : Utile pour les primes "
-
-      - name: type_delai_fin
-        description: "Classe SLA fin (J+0 à J++) : Utile pour la facturation"
-
-      - name: delai_bonus_bool
-        description: "Indique si intervention éligible bonus"
-
-      - name: delai_bonus_valeur
-        description: "Montant du bonus calculé"
-
-
-  - name: int_nesp_tech__facturation_interventions
-    description: >
-      Modèle intermediate attribuant une clé de facturation aux interventions
-      en fonction du type, machine, zone montagne et règles métier.
-
-    columns:
-      - name: n_planning
-        description: "Identifiant unique de l’intervention"
-        tests:
-          - not_null
-          - unique
-      
-      - name: etat_intervention
-        description: "etat de l'intervention (Terminée, Mise en échec, Signature Différée ... )"
-        tests : 
-          - not_null
-
-      - name: categorie_machine
-        description: "Categorie de machine (AGUILA ou TRANSPORTABLE)"
-        tests : 
-          - not_null
-
-      - name: machine_clean
-        description: "Nom de la machine clean pour lien avec objetifs"
-        tests : 
-          - not_null
-
-      - name: type_inter_libelle
-        description: "Libellé métier du type d’intervention"
-
-      - name: key_factu
-        description: "Clé composite utilisée pour la facturation"
-
-      - name: prod_factu
-        description: "Produit de facturation associé"
-
-      - name: tarif_factu
-        description: "Tarif appliqué à l’intervention"
-
-
   - name: int_nesp_tech__interventions_dedup
-    description: Dédoublonnage des interventions par n_planning
+    description: >
+      [QUOI MÉTIER]
+      Interventions techniques Nespresso (réparation, maintenance via Nomad Repair) —
+      une ligne par intervention, dédupliquée. Table de base de toute la chaîne nesp_tech
+      (délais, facturation).
+
+      [COMMENT CONSTRUITE]
+      stg_nesp_tech__interventions dédupliqué par n_planning (on conserve la ligne la plus
+      récente : date_heure_fin desc, puis extracted_at desc). Passthrough des colonnes staging.
+
+      [GRAIN]
+      1 ligne par n_planning (PK). ~84k lignes.
+
+      [NOTES]
+      Colonnes techniques en fin de table (rn, source_file, extracted_at) = artefacts d'ingestion,
+      sans usage métier.
     columns:
+      # --- IDENTIFIANTS ---
       - name: n_planning
+        description: Identifiant unique de l'intervention (numéro de planning Nomad Repair). PK.
         tests:
           - not_null
           - unique
+      - name: n_client
+        description: Identifiant du client Nespresso.
+      - name: n_site
+        description: Identifiant du site d'intervention.
+      - name: n_tech
+        description: Identifiant du technicien intervenant.
+      - name: nom_tech
+        description: Nom du technicien.
+      - name: prenom_tech
+        description: Prénom du technicien.
+
+      # --- CLIENT ---
+      - name: raison_sociale_client
+        description: Raison sociale du client.
+      - name: adresse_client
+        description: Adresse du client.
+      - name: code_postal_client
+        description: Code postal du client.
+      - name: ville_client
+        description: Ville du client.
+
+      # --- SITE ---
+      - name: nom_site
+        description: Nom du site d'intervention.
+      - name: adresse_site
+        description: Adresse du site.
+      - name: code_postal_site
+        description: Code postal du site (sert à dériver le département / zone montagne en facturation).
+      - name: ville_site
+        description: Ville du site.
+
+      # --- MACHINE ---
+      - name: code_machine
+        description: Code de la machine intervenue.
+      - name: nom_machine
+        description: Nom / modèle de la machine (normalisé via ref_nesp_tech__machines_clean en facturation).
+      - name: num_serie_machine
+        description: Numéro de série de la machine.
+
+      # --- INTERVENTION ---
+      - name: intervention_type
+        description: >
+          Code numérique du type d'intervention (1 à 8). '5' = Curative (majoritaire ; hors
+          machine Aguila, conditionne le bonus de délai). Les autres codes sont mappés en
+          libellés métier (Preventive, Installation, Mini preventive, Desinstallation,
+          Enlevement, Mise a jour) via ref_nesp_tech__key_type_inter — voir les libellés
+          exacts dans int_nesp_tech__facturation_interventions.type_inter_libelle.
+      - name: etat_intervention
+        description: >
+          État de l'intervention. Valeurs : 'terminée signée' (réalisée et signée, ~69k),
+          'annulée', 'mise en échec' (intervention non aboutie), 'signature différée',
+          'terminée non signée'. Les modèles aval ne gardent que les états facturables.
+      - name: observations
+        description: Observations libres saisies par le technicien.
+      - name: agency
+        description: >
+          Agence en charge de l'intervention. Valeurs : 'evs', 'evs idf', 'evs paris',
+          'evs paris 2' (agences EVS), 'nespresso sud' (sous-traitant). Les modèles
+          délais/facturation filtrent sur les agences EVS.
+      - name: repair_code_1
+        description: Code réparation principal (Nomad Repair) — sert à la résolution de la clé de facturation.
+      - name: repair_code_2
+        description: Code réparation secondaire.
+      - name: repair_code_3
+        description: Code réparation tertiaire.
+      - name: failure_code
+        description: Code panne (Nomad Repair) — sert à la résolution de la clé de facturation.
+      - name: consignes
+        description: Consignes données pour l'intervention.
+
+      # --- DATES ---
+      - name: date_heure_debut
+        description: Date/heure de début réel de l'intervention.
+      - name: date_heure_fin
+        description: Date/heure de fin de l'intervention (sert à la déduplication et au calcul de délai).
+      - name: creation_date
+        description: Date de création de l'intervention.
+      - name: pickup_date
+        description: Date de prise en charge (pickup) — point de départ du calcul de délai.
+      - name: date_planning_nomadrepair
+        description: Date de planification dans Nomad Repair.
+
+      # --- TECHNIQUE (artefacts d'ingestion) ---
+      - name: extracted_at
+        description: Timestamp d'extraction Meltano.
+      - name: source_file
+        description: Fichier source d'origine (ingestion). Technique.
+      - name: rn
+        description: Rang technique issu de la déduplication staging. Sans usage métier.
 
   - name: int_nesp_tech__articles_dedup
-    description: Dédoublonnage des articles par intervention + article
+    description: >
+      [QUOI MÉTIER]
+      Articles (pièces détachées, consommables) posés ou utilisés lors des interventions
+      techniques Nespresso.
+
+      [COMMENT CONSTRUITE]
+      stg_nesp_tech__articles dédupliqué par (n_planning, code_article), en gardant la ligne
+      au extracted_at le plus récent.
+
+      [GRAIN]
+      1 ligne par (n_planning, code_article).
+
+      [NOTES]
+      code_article = 'miniprev' est utilisé par int_nesp_tech__facturation_interventions pour
+      flagguer les mini-préventives (mini_prev_bool).
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
               - n_planning
               - code_article
+    columns:
+      - name: n_planning
+        description: "Intervention concernée. FK → int_nesp_tech__interventions_dedup."
+        tests:
+          - not_null
+      - name: n_client
+        description: Identifiant du client Nespresso.
+      - name: n_site
+        description: Identifiant du site.
+      - name: n_tech
+        description: Identifiant du technicien.
+      - name: nom_tech
+        description: Nom du technicien.
+      - name: prenom_tech
+        description: Prénom du technicien.
+      - name: raison_sociale_client
+        description: Raison sociale du client.
+      - name: nom_site
+        description: Nom du site.
+      - name: code_machine
+        description: Code de la machine.
+      - name: nom_machine
+        description: Nom / modèle de la machine.
+      - name: num_serie_machine
+        description: Numéro de série de la machine.
+      - name: code_article
+        description: >
+          Code de l'article posé. Haute cardinalité (codes type '0000100', 'zn96717'…).
+          Valeur spéciale 'miniprev' = pose d'une mini-préventive (utilisée comme flag en facturation).
+      - name: nom_article
+        description: Libellé de l'article.
+      - name: quantite_article
+        description: Quantité de l'article posée (mesure additive).
+      - name: date_intervention
+        description: Date de l'intervention associée à la pose de l'article.
+      - name: extracted_at
+        description: Timestamp d'extraction Meltano.
+      - name: source_file
+        description: Fichier source d'origine. Technique.
+      - name: rn
+        description: Rang technique issu de la déduplication staging. Sans usage métier.
 
+  - name: int_nesp_tech__delais_interventions
+    description: >
+      [QUOI MÉTIER]
+      Délais de traitement (jours et heures ouvrés) des interventions techniques Nespresso,
+      classes de SLA (J+0 … J++) et éligibilité au bonus curatif.
+
+      [COMMENT CONSTRUITE]
+      À partir de int_nesp_tech__interventions_dedup filtré (états 'terminée signée' /
+      'signature différée', agences EVS uniquement). Explosion jour par jour de la fenêtre
+      d'intervention, exclusion week-ends et jours fériés (ref_general__feries_metropole),
+      puis comptage des jours/heures ouvrés jusqu'au début et jusqu'à la fin.
+
+      [GRAIN]
+      1 ligne par n_planning.
+
+      [NOTES]
+      Le délai de référence part de pickup_date (ou creation_date si postérieure). Bonus = 15 €
+      si délai ≤ J+2 sur un curatif (intervention_type '5') hors machine Aguila.
+    columns:
+      - name: n_planning
+        description: "Intervention concernée. FK → int_nesp_tech__interventions_dedup. PK ici."
+        tests:
+          - not_null
+          - unique
+      - name: intervention_type
+        description: Code du type d'intervention (cf. int_nesp_tech__interventions_dedup). '5' = curatif (éligible bonus).
+      - name: code_machine
+        description: Code de la machine intervenue.
+      - name: delai_jours_debut
+        description: Nombre de jours ouvrés entre la prise en charge et le début de l'intervention.
+        tests:
+          - not_null
+      - name: delai_heures_debut
+        description: Nombre d'heures ouvrées entre la prise en charge et le début de l'intervention.
+      - name: type_delai_debut
+        description: >
+          Classe SLA jusqu'au début. Valeurs : J+0 (≤ 1 j ouvré), J+1 (2), J+2 (3), J+3 (4),
+          J++ (> 4). Utile pour les primes.
+      - name: delai_jours_fin
+        description: Nombre de jours ouvrés entre la prise en charge et la fin de l'intervention.
+        tests:
+          - not_null
+      - name: delai_heures_fin
+        description: Nombre d'heures ouvrées entre la prise en charge et la fin de l'intervention.
+      - name: type_delai_fin
+        description: >
+          Classe SLA jusqu'à la fin. Valeurs : J+0 (≤ 1 j ouvré), J+1 (2), J+2 (3), J+3 (4),
+          J++ (> 4). Utile pour la facturation.
+      - name: delai_traitement_jours
+        description: Durée de traitement en jours ouvrés (delai_jours_fin − delai_jours_debut).
+      - name: delai_bonus_bool
+        description: True si l'intervention est éligible au bonus (≤ J+2, curatif type '5', hors machine Aguila).
+      - name: delai_bonus_valeur
+        description: Montant du bonus en euros (15 € si éligible, sinon 0).
+
+  - name: int_nesp_tech__facturation_interventions
+    description: >
+      [QUOI MÉTIER]
+      Clé et tarif de facturation par intervention technique Nespresso, déterminés par la
+      typologie d'intervention, le type de machine et la zone (montagne ou non).
+
+      [COMMENT CONSTRUITE]
+      int_nesp_tech__interventions_dedup (états facturables) enrichi du flag mini-préventive
+      (jointure int_nesp_tech__articles_dedup sur code_article = 'miniprev'), machine normalisée
+      (ref_nesp_tech__machines_clean), type d'intervention (ref_nesp_tech__key_type_inter), zone
+      montagne (ref_nesp_tech__dpts_montagne_factu). La clé key_factu est rapprochée du tarif via
+      ref_nesp_tech__key_facturation. Une intervention est gardée sur sa meilleure correspondance de clé.
+
+      [GRAIN]
+      1 ligne par n_planning.
+
+      [NOTES]
+      Périmètre : états 'terminée signée', 'signature différée', 'mise en échec'.
+      categorie_machine / machine_clean = 'UNDEFINED' quand la machine n'est pas mappée.
+    columns:
+      - name: n_planning
+        description: "Intervention concernée. FK → int_nesp_tech__interventions_dedup. PK ici."
+        tests:
+          - not_null
+          - unique
+      - name: etat_intervention
+        description: >
+          État de l'intervention (périmètre facturable). Valeurs : 'terminée signée',
+          'mise en échec', 'signature différée'.
+        tests:
+          - not_null
+      - name: categorie_machine
+        description: >
+          Catégorie de machine. Valeurs : 'Transportable', 'Momento', 'AGUILA', 'UNDEFINED'
+          (machine non mappée). Détermine la grille tarifaire.
+        tests:
+          - not_null
+      - name: machine_clean
+        description: Nom de machine normalisé (ref_nesp_tech__machines_clean), 'UNDEFINED' si non mappé. Lien avec les objectifs.
+        tests:
+          - not_null
+      - name: type_inter_libelle
+        description: >
+          Libellé métier du type d'intervention. Valeurs : Curative, Preventive, Installation,
+          Mini preventive, Desinstallation, Enlevement, Mise a jour.
+      - name: key_factu
+        description: >
+          Clé composite de facturation reconstruite : `<type_code> - <type_inter_libelle> -
+          <machine_clean>[ - Montagne]`. Rapprochée de ref_nesp_tech__key_facturation.
+      - name: prod_factu
+        description: Code produit de facturation associé à la clé (null si clé non trouvée).
+      - name: tarif_factu
+        description: Tarif (€) appliqué à l'intervention selon la clé de facturation (null si clé non trouvée).

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1094,101 +1094,98 @@ models:
 
   - name: int_oracle_lcdp__inter_technique_tasks
     description: >
-      Table intermédiaire des tâches d'intervention technique.
-      Filtrée sur les tâches de type INTERVENTION TECHNIQUE (idtask_type=131)
-      avec code_status_record=1 et real_start_date non null.
-      Enrichie avec les labels pivotés (Statut inter, Objet intervent, DEVICE_CANCEL_REASON)
-      et les ressources de type personne (idresources_type=2).
+      [QUOI MÉTIER]
+      Interventions techniques sur les distributeurs LCDP : une ligne par intervention (idtask_type
+      131), avec le technicien rattaché, le statut de traitement et les labels métier. Suivi de la
+      maintenance technique.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 131, code_status_record = '1', avec une ressource
+      technicien — resources type 2), enrichi company/device/location, puis pivot des labels EAV
+      (statut_inter, objet_intervent, device_cancel_reason). Déduplication sur task_id (priorité au
+      plus petit resources_id). Incrémental (merge sur task_id).
+
+      [GRAIN]
+      1 ligne par task_id (intervention). ~1 176 lignes, 393 distributeurs, depuis fin 2024.
+
+      [NOTES]
+      Diffère de int_oracle_neshu__inter_techinique_tasks : ici pas de ligne produit, un technicien
+      rattaché (resources_id), labels statut_inter / objet_intervent / device_cancel_reason (pas de
+      dc04/mission_type), et **aucun filtre sur objet_intervent** (neshu filtrait OC04).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_id
-        description: "Clé primaire - Identifiant unique de la tâche d'intervention technique"
-        data_type: int64
+        description: "Identifiant de la tâche d'intervention Oracle LCDP (EVS.TASK). PK."
         tests:
           - unique
           - not_null
-
       - name: device_id
-        description: "ID du device associé à la tâche"
-        data_type: int64
-
+        description: "Distributeur (machine) concerné. FK → dim_lcdp__device."
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
-        data_type: int64
-
+        description: "Client (peer company). FK → dim_lcdp__company."
       - name: resources_id
-        description: "ID de la ressource personne (idresources_type=2) associée à la tâche"
-        data_type: int64
+        description: "Technicien intervenant. FK → dim_lcdp__resource (idresources, type 2 = PERSON)."
 
+      # --- CODES / NOMS ---
       - name: company_code
-        description: "Code client de l'entreprise"
-        data_type: string
-
+        description: "Code client de l'entreprise."
       - name: device_code
-        description: "Code métier du device (numéro de série)"
-        data_type: string
-
+        description: "Code métier du device (numéro de série)."
       - name: company_name
-        description: "Nom de l'entreprise cliente"
-        data_type: string
-
+        description: "Nom du client (libellé d'affichage, aplati depuis company)."
       - name: device_name
-        description: "Nom du device"
-        data_type: string
+        description: "Nom / modèle du distributeur (libellé d'affichage, aplati depuis device)."
 
+      # --- INFOS MÉTIER ---
       - name: task_location_info
-        description: "Informations d'accès de la localisation de la tâche"
-        data_type: string
-
+        description: "Informations d'accès / localisation de la tâche."
       - name: comments_self
-        description: "Commentaires internes de la tâche"
-        data_type: string
-
+        description: "Commentaire interne EVS sur l'intervention (texte libre)."
       - name: comments_peer
-        description: "Commentaires peer de la tâche"
-        data_type: string
-
-      - name: task_start_date
-        description: "Date et heure réelle de début de l'intervention technique"
-        data_type: timestamp
-        tests:
-          - not_null
-
-      - name: task_end_date
-        description: "Date et heure réelle de fin de l'intervention technique"
-        data_type: timestamp
-
+        description: "Commentaire côté client/partenaire sur l'intervention (texte libre)."
       - name: task_status_code
-        description: "Code statut de la tâche (depuis task_status)"
-        data_type: string
+        description: >
+          Code du statut de la tâche. Valeurs : FAIT (réalisé, majoritaire), ANNULE, PREVU,
+          ENCOURS, ACQUITTE.
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, ANNULE, PREVU, ENCOURS, ANOMALIE, VALIDE, ACQUITTE, ENATTENTE]}
+              config: {severity: warn}
 
+      # --- LABELS PIVOTÉS ---
       - name: statut_inter
-        description: "Label pivoté - Code du statut de l'intervention (famille 'Statut inter')"
-        data_type: string
-
+        description: >
+          Statut de traitement de l'intervention (label 'Statut inter'). Valeurs : TERMINATED
+          (traitée sur place, majoritaire), TOTECH (non résolue sur place → renvoyée à l'équipe
+          technique), NULL.
       - name: objet_intervent
-        description: "Label pivoté - Code de l'objet de l'intervention (famille 'Objet intervent')"
-        data_type: string
-
+        description: >
+          Objet de l'intervention (label 'Objet intervent'). Majoritairement NULL ; quelques OC1 / OC2
+          (référentiel métier, non filtré ici contrairement à neshu).
       - name: device_cancel_reason
-        description: "Label pivoté - Code de la raison d'annulation du device (famille 'DEVICE_CANCEL_REASON')"
-        data_type: string
+        description: >
+          Raison d'annulation côté device (label 'DEVICE_CANCEL_REASON'). Majoritairement NULL ;
+          valeur observée : OTHERS.
 
+      # --- DATES ---
+      - name: task_start_date
+        description: "Date et heure réelle de début de l'intervention. Clé de partitionnement."
+        tests:
+          - not_null
+      - name: task_end_date
+        description: "Date et heure réelle de fin de l'intervention."
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
-        data_type: timestamp
+        description: "Timestamp de dernière modification (filtre incrémental)."
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
-        data_type: timestamp
+        description: "Timestamp de création en source."
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
-        data_type: timestamp
+        description: "Timestamp d'extraction depuis Oracle."
         tests:
           - not_null
 

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -937,123 +937,135 @@ models:
 
   - name: int_oracle_lcdp__commande_interne_tasks
     description: >
-      Table intermédiaire des mouvements internes (commandes internes).
-      Filtrée sur les tâches de type LIVRAISON INTERNE (idtask_type = 132)
-      avec statut FAIT / VALIDE / ANNULE, et labels de la famille STATUT_LIVRAISON.
-      Contient les métriques de quantité et valorisation, avec les codes source et destination
-      (entreprise ou ressource) associés.
+      [QUOI MÉTIER]
+      Commandes / livraisons internes LCDP (type 132) : une ligne par produit d'une commande
+      interne, avec son statut de livraison. Approvisionnement interne, typiquement dépôt → véhicule.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 132, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      Source ET destination résolues selon leur type (COMPANY → company, RESOURCES → resources).
+      Le statut de livraison vient du label de famille STATUT_LIVRAISON. Déduplication sur
+      task_product_id en priorisant le label LIVRE.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une commande interne). ~44,5k lignes (~2 080 tâches),
+      depuis fin 2024.
+
+      [NOTES]
+      Distinct de int_oracle_lcdp__livraison_interne_tasks (idtask_type 161) : ici type 132, avec
+      suivi de statut de livraison (label_code). Flux dominant COMPANY (dépôt) → RESOURCES (véhicule).
+      Seules les lignes dont source ET destination se résolvent sont conservées.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation tâche-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "Identifiant de la tâche (référence EVS.TASK)"
+        description: "Tâche de commande interne Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "Identifiant de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "Identifiant du produit concerné"
+        description: "Produit commandé. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "Identifiant du produit source (COMPANY ou RESOURCES)"
+        description: >
+          Identifiant de l'entité **source**. Référence polymorphe : table cible nommée par
+          product_source_type — COMPANY → company (dépôt), RESOURCES → resources (véhicule).
+          Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source (COMPANY ou RESOURCES)"
+        description: "Type de l'entité source = table cible de product_source_id. Valeur : COMPANY (dépôt)."
         data_type: string
-
       - name: product_destination_id
-        description: "Identifiant du produit destination (COMPANY ou RESOURCES)"
+        description: >
+          Identifiant de l'entité **destination**. Référence polymorphe : table cible nommée par
+          product_destination_type (COMPANY → company, RESOURCES → resources).
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit destination (COMPANY ou RESOURCES)"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeurs : RESOURCES (véhicule, majoritaire), COMPANY (dépôt)."
         data_type: string
 
+      # --- CODES ---
       - name: source_code
-        description: "Code de la source du mouvement (entreprise ou ressource)"
+        description: "Code de l'entité source, résolu selon product_source_type (company.code si COMPANY, resources.code si RESOURCES). Toujours renseigné (filtre du modèle)."
         data_type: string
         tests:
           - not_null
-
       - name: destination_code
-        description: "Code de la destination du mouvement (entreprise ou ressource)"
+        description: "Code de l'entité destination, résolu selon product_destination_type. Toujours renseigné (filtre du modèle)."
         data_type: string
         tests:
           - not_null
-
       - name: product_code
-        description: "Code métier du produit (référence EVS.PRODUCT)"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), ANNULE, FAIT, ANOMALIE.
         data_type: string
-
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, VALIDE, ANNULE, ANOMALIE]}
+              config: {severity: warn}
       - name: label_code
-        description: "Code du label associé à la tâche (famille STATUT_LIVRAISON)"
+        description: >
+          Statut de livraison de la commande interne (label de famille STATUT_LIVRAISON). Valeurs :
+          LIVRE (livré, majoritaire), LIVRE_PARTIEL (livraison partielle), EN_ATTENTE (en attente).
+          La déduplication priorise la ligne LIVRE.
         data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [LIVRE, LIVRE_PARTIEL, EN_ATTENTE]}
+              config: {severity: warn}
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de début de la tâche"
+        description: "Date et heure réelle de la commande interne."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
       - name: unit_coeff_multi
-        description: "Coefficient multiplicateur d'unité du produit"
-        data_type: int64
-
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
       - name: unit_coeff_div
-        description: "Coefficient diviseur d'unité du produit"
-        data_type: int64
-
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité totale du produit transféré (avec coefficients unitaires)"
-        data_type: numeric
-
+        description: "Quantité commandée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation totale (quantité * prix unitaire net)"
-        data_type: numeric
+        description: "Valorisation de la commande en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière mise à jour de la tâche"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création de la tâche"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle (suivi de synchronisation)"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -710,105 +710,124 @@ models:
 
   - name: int_oracle_lcdp__livraison_interne_tasks
     description: >
-      Table intermédiaire des tâches de Livraison interne.
-      Filtrée sur les tâches de type LIVRAISON INTERNE (idtask_type=161)
-      avec statut FAIT/VALIDE/ANNULE.
+      [QUOI MÉTIER]
+      Livraisons internes LCDP : une ligne par produit déplacé lors d'un mouvement de stock interne
+      (typiquement dépôt → véhicule pour approvisionner les roadmen). Suivi des quantités et valeurs
+      transférées entre entités internes.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 161 LIVRAISONS INTERNE, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      Source ET destination résolues selon leur type (COMPANY → company, RESOURCES → resources).
+      Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un mouvement interne). ~55,6k lignes (~4 162 tâches),
+      depuis fin 2024.
+
+      [NOTES]
+      Seules les lignes dont la source ET la destination se résolvent sont conservées. Flux dominant
+      COMPANY (dépôt) → RESOURCES (véhicule/roadman).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de livraison interne Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit déplacé. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source**. Référence polymorphe : table cible nommée par
+          product_source_type — COMPANY → company (dépôt), RESOURCES → resources (véhicule).
+          Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : COMPANY (dépôt, majoritaire), RESOURCES (véhicule)."
         data_type: string
-
       - name: product_destination_id
-        description: "ID du produit de destination"
+        description: >
+          Identifiant de l'entité **destination**. Référence polymorphe : table cible nommée par
+          product_destination_type (COMPANY → company, RESOURCES → resources).
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit de destination"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeurs : RESOURCES (véhicule, majoritaire), COMPANY (dépôt)."
         data_type: string
 
-      - name: destination_code
-        description: "Code de destination du produit"
-        data_type: string
-
+      # --- CODES ---
       - name: source_code
-        description: "Code source du produit"
+        description: "Code de l'entité source, résolu selon product_source_type (company.code si COMPANY, resources.code si RESOURCES). Toujours renseigné (filtre du modèle)."
         data_type: string
-
+        tests:
+          - not_null
+      - name: destination_code
+        description: "Code de l'entité destination, résolu selon product_destination_type (company.code si COMPANY, resources.code si RESOURCES). Toujours renseigné (filtre du modèle)."
+        data_type: string
+        tests:
+          - not_null
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), FAIT, ANNULE, ANOMALIE.
         data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, VALIDE, ANNULE, ANOMALIE]}
+              config: {severity: warn}
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle du mouvement interne."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité déplacée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
+        description: "Valorisation du mouvement en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -601,97 +601,112 @@ models:
 
   - name: int_oracle_lcdp__reception_tasks
     description: >
-      Table intermédiaire des tâches de RECEPTION.
-      Filtrée sur les tâches de type RECEPTION (idtask_type=121)
-      avec statut FAIT/VALIDE/ANNULE.
+      [QUOI MÉTIER]
+      Réceptions de marchandises LCDP : une ligne par produit sur un bon de réception
+      (entrée de stock dans un dépôt). Suivi des quantités et valeurs reçues.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 121 BON RECEPTION, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      La destination est résolue quand product_destination_type = COMPANY → code dépôt (company).
+      Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un bon de réception). ~8,7k lignes (~636 bons),
+      depuis début 2025.
+
+      [NOTES]
+      Symétrique de la livraison côté entrée : product_destination_id est polymorphe et vaut
+      toujours COMPANY ici (réception dans un dépôt). Pas de source.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de bon de réception Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit reçu. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_destination_id
-        description: "ID du produit de destination"
+        description: >
+          Identifiant de l'entité **destination** (lieu de réception). Référence polymorphe : table
+          cible nommée par product_destination_type. Ici toujours COMPANY → company (dépôt).
+          Pas une FK produit malgré le nom.
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit de destination"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeur : COMPANY (dépôt de réception)."
         data_type: string
 
+      # --- CODES ---
       - name: destination_code
-        description: "Code de destination du produit"
+        description: "Code du dépôt de réception (company.code), résolu via product_destination_type = COMPANY."
         data_type: string
-
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), ANNULE, FAIT
+          (ANOMALIE autorisé par le filtre).
         data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, VALIDE, ANNULE, ANOMALIE]}
+              config: {severity: warn}
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de la réception."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité reçue en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
+        description: "Valorisation de la réception en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null
-
 
   - name: int_oracle_lcdp__livraison_interne_tasks
     description: >

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -102,122 +102,160 @@ models:
 
   - name: int_oracle_lcdp__chargement_tasks
     description: >
-      Table intermédiaire des tâches de chargement machine.
-      Filtrée sur les tâches de type CHARGEMENT (idtask_type=13)
-      avec statut FAIT/VALIDE/ANNULE et label du chargement (LOADING / REMOVING).
+      [QUOI MÉTIER]
+      Chargements (et retraits) de produits dans les distributeurs LCDP : une ligne par produit
+      chargé lors d'une tâche de chargement machine. Brique de base de l'analyse consommation / réassort LCDP.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 13 CHARGEMENT MACHINE, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi
+      company/device/product/location, label de chargement, roadman (resources type 2) et véhicule
+      (resources type 3). Quantité ramenée en unités de base ; valorisation = quantité × prix d'achat.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une tâche). ~313k lignes (~42,6k tâches), depuis
+      fin 2023. Incrémental (merge sur task_product_id).
+
+      [NOTES]
+      ⚠️ Deux indicateurs de sens : `load_type_code` (issu du label) et `movement_type` (dérivé du
+      SIGNE de load_quantity). Ils divergent sur quelques lignes — **privilégier movement_type**
+      (vérité terrain). product_source/destination_id = références polymorphes (cf. leur _type).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de chargement Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
+      - name: device_id
+        description: "Distributeur (machine) chargé. FK → dim_lcdp__device."
+        data_type: int64
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company). FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit chargé/retiré. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
-      - name: roadman_id
-        description: "ID du roadman associé à la tâche, lien avec la table RESOURCES"
-        data_type: int64
-
-      - name: vehicle_id
-        description: "ID du véhicule associé à la tâche, lien avec la table RESOURCES"
-        data_type: int64
-
       - name: location_id
-        description: "ID de la localisation de la tâche"
+        description: "Localisation de la tâche. FK → stg_oracle_lcdp__location."
+        data_type: int64
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité source. Référence polymorphe : table cible nommée par
+          product_source_type (RESOURCES → resources, DEVICE → device, COMPANY → company). Pour le
+          chargement, type = RESOURCES (stock véhicule/roadman). Pas une FK produit malgré le nom.
+        data_type: int64
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité destination. Référence polymorphe : table cible nommée par
+          product_destination_type. Pour le chargement, type = DEVICE → le distributeur rempli.
+        data_type: int64
+      - name: roadman_id
+        description: "Roadman ayant effectué le chargement. FK → dim_lcdp__resource (idresources, type 2 = PERSON)."
+        data_type: int64
+      - name: vehicle_id
+        description: "Véhicule utilisé. FK → dim_lcdp__resource (idresources, type 3 = VEHICLE)."
         data_type: int64
 
-      - name: device_code
-        description: "Code métier du device (numéro de série)"
-        data_type: string
-
-      - name: product_code
-        description: "Code métier du produit"
-        data_type: string
-
+      # --- CODES / LIBELLÉS ---
       - name: company_code
-        description: "Code client de l'entreprise"
+        description: "Code client de l'entreprise."
         data_type: string
-
-      - name: task_start_date
-        description: "Date et heure réelle de la tâche"
-        data_type: timestamp
+      - name: device_code
+        description: "Code métier du device (numéro de série)."
+        data_type: string
+      - name: product_code
+        description: "Code métier du produit."
+        data_type: string
+      - name: roadman_code
+        description: "Code métier du roadman."
+        data_type: string
+      - name: vehicle_code
+        description: "Code métier du véhicule."
+        data_type: string
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche. Valeurs : FAIT (réalisé, majoritaire), VALIDE, ANNULE, ANOMALIE.
+        data_type: string
         tests:
-          - not_null
-
-      - name: unit_coeff_multi
-        description: "Coefficient multiplicateur d'unité du produit"
-        data_type: int64
-
-      - name: unit_coeff_div
-        description: "Coefficient diviseur d'unité du produit"
-        data_type: int64
-
-      - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
-      - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
-      - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-
+          - accepted_values:
+              arguments: {values: [FAIT, ANNULE, VALIDE, ANOMALIE]}
+              config: {severity: warn}
       - name: load_type_code
-        description: "Label source du mouvement (LOADING / REMOVING). Indicatif : peut être incohérent avec le signe de la quantité — utiliser movement_type pour le sens réel."
+        description: >
+          Type d'opération issu du **label** de la tâche. Valeurs : LOADING (chargement, ~99%),
+          REMOVING (retrait). Peut diverger du sens réel — voir movement_type.
         data_type: string
-
+        tests:
+          - accepted_values:
+              arguments: {values: [LOADING, REMOVING]}
+              config: {severity: warn}
       - name: movement_type
         description: >
-          Sens réel du mouvement de stock, dérivé du SIGNE de load_quantity
-          (vérité terrain) et non du label load_type_code : load_quantity < 0
-          => 'REMOVING' (retrait), sinon 'LOADING' (chargement).
-          Corrige les cas LOADING à quantité négative et REMOVING à quantité positive.
+          **Sens réel du mouvement de stock**, dérivé du SIGNE de load_quantity : REMOVING si
+          load_quantity < 0, sinon LOADING. Plus fiable que load_type_code (un label LOADING à
+          quantité négative est en réalité un retrait). À privilégier pour distinguer chargement / retrait.
         data_type: string
         tests:
-          - not_null
           - accepted_values:
-              arguments:
-                values: ['LOADING', 'REMOVING']
+              arguments: {values: [LOADING, REMOVING]}
+              config: {severity: warn}
+      - name: product_source_type
+        description: "Type de l'entité source = table cible de product_source_id. Chargement : surtout RESOURCES (stock véhicule)."
+        data_type: string
+      - name: product_destination_type
+        description: "Type de l'entité destination = table cible de product_destination_id. Chargement : surtout DEVICE (le distributeur)."
+        data_type: string
+      - name: task_location_info
+        description: "Informations d'accès / localisation de la tâche."
+        data_type: string
 
+      # --- DATE ---
+      - name: task_start_date
+        description: "Date et heure réelle du chargement. Clé de partitionnement."
+        data_type: timestamp
+        tests:
+          - not_null
+
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
+      - name: base_unit_quantity
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
+      - name: product_unit_price_task
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
+      - name: product_unit_price_latest
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
+
+      # --- MESURES ---
       - name: load_quantity
-        description: "Quantité produit chargée (positive) ou retirée (négative), conditionnement appliqué"
-        data_type: int64
-
+        description: "Quantité en unités de base = real_quantity × coeff_multi / coeff_div. **Peut être négative** (retrait → movement_type = REMOVING). Mesure additive."
       - name: load_valuation
-        description: "Valorisation du chargement (quantité * prix unitaire)"
-        data_type: int64
+        description: "Valorisation en euros = load_quantity × prix d'achat unitaire. Mesure additive (négative sur les retraits)."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification (filtre incrémental)."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -691,78 +691,103 @@ models:
 
   - name: int_oracle_lcdp__appro_tasks
     description: >
-      Table intermédiaire des passages approvisionneurs.
-      Filtrée sur les tâches de type PASSAGE APPRO (idtask_type=32)
-      avec statut actif (code_status_record=1) et enrichie avec ressources (roadman, véhicule).
+      [QUOI MÉTIER]
+      Passages d'approvisionnement (réassort) des distributeurs LCDP : une ligne par tâche
+      de type « PASSAGE APPROVISIONNEURS ». Brique de base de la chaîne appro LCDP.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task filtré sur idtask_type = 32, statut d'enregistrement actif
+      (code_status_record = '1') et real_start_date renseignée ; jointures company (client),
+      task_status (code statut) et location (info d'accès).
+
+      [GRAIN]
+      1 ligne par task_id (PK). ~51,4k lignes, depuis fin 2023.
+
+      [NOTES]
+      Modèle de base. task_status_code couvre tout le cycle (PREVU → FAIT/ANNULE…), pas seulement
+      les passages réalisés. Source/destination = références polymorphes (cf. leur _type).
     columns:
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Identifiant de la tâche Oracle LCDP (EVS.TASK). PK."
         data_type: int64
         tests:
           - unique
           - not_null
 
       - name: device_id
-        description: "ID du device associé à la tâche"
+        description: "Distributeur (machine) concerné. FK → dim_lcdp__device."
         data_type: int64
 
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
         data_type: int64
 
       - name: product_source_id
-        description: "ID du produit source de la tâche"
+        description: >
+          Identifiant de l'entité source du flux. Référence polymorphe : table cible nommée par
+          product_source_type (RESOURCES → resources, DEVICE → device, COMPANY → company). Pour
+          l'appro, type = RESOURCES (stock du véhicule/roadman). Pas une FK produit malgré le nom.
         data_type: int64
 
       - name: product_destination_id
-        description: "ID du produit destination de la tâche"
+        description: >
+          Identifiant de l'entité destination du flux. Référence polymorphe : table cible nommée par
+          product_destination_type. Pour l'appro, type = DEVICE → le distributeur rempli.
         data_type: int64
 
       - name: company_code
-        description: "Code client de l'entreprise (company.code)"
+        description: "Code client de l'entreprise (company.code)."
         data_type: string
 
       - name: product_source_type
-        description: "Type de la source produit"
+        description: "Type de l'entité source = table cible de product_source_id. Appro : RESOURCES (stock véhicule), ou NULL."
         data_type: string
 
       - name: product_destination_type
-        description: "Type de la destination produit"
+        description: "Type de l'entité destination = table cible de product_destination_id. Appro : DEVICE (le distributeur), ou NULL."
         data_type: string
 
       - name: task_location_info
-        description: "Informations de localisation de la tâche"
+        description: "Informations d'accès / localisation de la tâche."
         data_type: string
 
       - name: task_status_code
-        description: "Code du statut de la tâche (task_status.code)"
+        description: >
+          Code du statut de la tâche (task_status.code). Valeurs : FAIT (réalisé, majoritaire),
+          PREVU (planifié), ANNULE, ANOMALIE, ENCOURS, VALIDE.
+          Filtrer task_status_code = 'FAIT' pour les passages réellement réalisés.
         data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, ANNULE, PREVU, ENCOURS, ANOMALIE, VALIDE, ACQUITTE, ENATTENTE]
+              config:
+                severity: warn
 
       - name: task_start_date
-        description: "Date et heure de début réel du passage appro"
+        description: "Date et heure de début réel du passage. Clé de partitionnement."
         data_type: timestamp
         tests:
           - not_null
 
       - name: task_end_date
-        description: "Date et heure de fin réel du passage appro"
+        description: "Date et heure de fin réel du passage."
         data_type: timestamp
 
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification (filtre incrémental)."
         data_type: timestamp
         tests:
           - not_null
 
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
 
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -378,97 +378,114 @@ models:
 
   - name: int_oracle_lcdp__inventaire_tasks
     description: >
-      Table intermédiaire des tâches de d'inventaire.
-      Filtrée sur les tâches de type INVENTAIRE (idtask_type=162)
-      avec statut FAIT/VALIDE/ANNULE.
+      [QUOI MÉTIER]
+      Inventaires de stock LCDP : une ligne par produit inventorié sur une tâche d'inventaire.
+      Photographie des quantités constatées par source de stock (véhicule ou dépôt).
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 162 INVENTAIRE, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      La source est résolue selon son type : product_source_type = COMPANY → code dépôt (company),
+      RESOURCES → code ressource (véhicule/roadman). Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un inventaire). ~18,1k lignes (~331 inventaires),
+      depuis fin 2024.
+
+      [NOTES]
+      Pas de destination (un inventaire constate un stock, il ne le déplace pas). Les lignes dont
+      la source ne se résout pas (source_code NULL) sont exclues.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche d'inventaire Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit inventorié. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source** du stock inventorié. Référence polymorphe : table cible
+          nommée par product_source_type — COMPANY → company (dépôt), RESOURCES → resources
+          (véhicule/roadman). Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : RESOURCES (stock véhicule), COMPANY (stock dépôt)."
         data_type: string
 
+      # --- CODES ---
       - name: source_code
-        description: "Code source du produit"
+        description: >
+          Code de l'entité source, résolu selon product_source_type : company.code si COMPANY,
+          resources.code si RESOURCES. Les lignes sans source résolue sont exclues du modèle.
         data_type: string
-
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), FAIT, ANNULE
+          (ANOMALIE autorisé par le filtre).
         data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, VALIDE, ANNULE, ANOMALIE]}
+              config: {severity: warn}
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de l'inventaire."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité inventoriée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
+        description: "Valorisation du stock inventorié en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null
-
 
   - name: int_oracle_lcdp__ecart_inventaire_tasks
     description: >

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -262,81 +262,116 @@ models:
 
   - name: int_oracle_lcdp__livraison_tasks
     description: >
-      Table intermédiaire des tâches de bon de livraison.
-      Filtrée sur les tâches de type BON LIVRAISON (idtask_type=101)
-      avec statut FAIT/VALIDE/ANNULE.
+      [QUOI MÉTIER]
+      Lignes de bons de livraison LCDP : une ligne par produit livré sur une tâche de type
+      BON LIVRAISON. Suivi des livraisons de produits (hors chargement machine).
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 101 BON LIVRAISON, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi company
+      et product. Quantité ramenée en unités de base ; valorisation = quantité × prix d'achat.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un bon de livraison). ~8,4k lignes (~3,3k bons),
+      depuis fin 2024.
+
+      [NOTES]
+      En pratique surtout des bons VALIDE. product_source_id / product_destination_id sont des
+      références polymorphes (cf. leur _type) ; pour la livraison, source et destination = COMPANY.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de bon de livraison Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company). FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit livré. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
-      - name: product_code
-        description: "Code métier du produit"
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité source. Référence polymorphe : table cible nommée par
+          product_source_type (COMPANY → company, RESOURCES → resources, DEVICE → device).
+          Pour la livraison, type = COMPANY. Pas une FK produit malgré le nom.
+        data_type: int64
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité destination. Référence polymorphe : table cible nommée par
+          product_destination_type. Pour la livraison, type = COMPANY.
+        data_type: int64
+      - name: product_source_type
+        description: "Type de l'entité source = table cible de product_source_id. Livraison : COMPANY."
+        data_type: string
+      - name: product_destination_type
+        description: "Type de l'entité destination = table cible de product_destination_id. Livraison : COMPANY."
         data_type: string
 
+      # --- CODES ---
       - name: company_code
-        description: "Code client de l'entreprise"
+        description: "Code client de l'entreprise."
         data_type: string
+      - name: product_code
+        description: "Code métier du produit."
+        data_type: string
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), ANNULE, FAIT
+          (et ANOMALIE autorisé par le filtre).
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, VALIDE, ANNULE, ANOMALIE]}
+              config: {severity: warn}
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de la livraison."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité livrée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
+        description: "Valorisation de la livraison en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -489,93 +489,112 @@ models:
 
   - name: int_oracle_lcdp__ecart_inventaire_tasks
     description: >
-      Table intermédiaire des tâches de d'ecart inventaire.
-      Filtrée sur les tâches de type ECART INVENTAIRE (idtask_type=163)
-      avec statut FAIT/VALIDE/ANNULE.
+      [QUOI MÉTIER]
+      Écarts d'inventaire LCDP : une ligne par produit sur une tâche d'écart d'inventaire
+      (ajustement constaté entre le stock théorique et le stock compté), par source (véhicule ou dépôt).
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 163 ECART INVENTAIRE, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      Source résolue selon son type : COMPANY → code dépôt (company), RESOURCES → code ressource
+      (véhicule/roadman). Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un écart). ~46,5k lignes (~1 404 tâches),
+      depuis fin 2024.
+
+      [NOTES]
+      Pas de destination. La majorité des tâches d'écart sont en statut ANNULE (écart non retenu) ;
+      filtrer task_status_code = 'FAIT'/'VALIDE' pour les écarts effectifs. Lignes sans source
+      résolue (source_code NULL) exclues.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche d'écart d'inventaire Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit concerné par l'écart. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source** du stock. Référence polymorphe : table cible nommée par
+          product_source_type — COMPANY → company (dépôt), RESOURCES → resources (véhicule/roadman).
+          Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : RESOURCES (stock véhicule), COMPANY (stock dépôt)."
         data_type: string
 
+      # --- CODES ---
       - name: source_code
-        description: "Code source du produit"
+        description: >
+          Code de l'entité source, résolu selon product_source_type : company.code si COMPANY,
+          resources.code si RESOURCES. Lignes sans source résolue exclues du modèle.
         data_type: string
-
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : ANNULE (écart non retenu, majoritaire), VALIDE, FAIT
+          (ANOMALIE autorisé par le filtre).
         data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [FAIT, VALIDE, ANNULE, ANOMALIE]}
+              config: {severity: warn}
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de la tâche d'écart."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité d'écart en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive (peut être négative = manquant)."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
+        description: "Valorisation de l'écart en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1264,23 +1264,27 @@ models:
     description: >
       [QUOI MÉTIER]
       Comptages de caisse LCDP : une ligne par tâche de comptage (relève de l'argent physique d'un
-      monnayeur). Expose le **CA cash** (pièces + billets) par machine et par date de comptage.
-      Complète le CA électronique de la télémétrie Nayax (les ventes en espèces sont invisibles côté
-      Nayax). Synonymes : CA espèces, recette cash, comptage caisse / monnayeur.
+      monnayeur). Expose le **CA encaissé** (pièces + billets + titres-restaurant) par machine et par
+      date de comptage. Complète le CA électronique de la télémétrie Nayax (les paiements physiques
+      sont invisibles côté Nayax). Synonymes : CA espèces / cash, recette monnayeur, comptage caisse.
 
       [COMMENT CONSTRUITE]
       stg_oracle_lcdp__task (idtask_type = 30 REGL COMPTAGE, code_status_record = '1') × task_has_product
-      filtré sur les lignes PIECES / BILLET (montants encaissés, TTC par nature), enrichi company/device/
-      location. La ventilation HT / TVA vient de task_has_amount (somme par tâche). Incrémental.
+      filtré sur les moyens de paiement physiques PIECES / BILLET / CHECK_LUNCH (montants encaissés,
+      TTC par nature ; JETON exclu car valeur nulle), enrichi company/device/location. La ventilation
+      HT / TVA vient de task_has_amount (somme des taux par tâche). Incrémental.
 
       [GRAIN]
       1 ligne par task_id (un comptage = une relève sur une machine à une date). ~9,2k lignes,
-      308 distributeurs, depuis début 2025.
+      ~308 distributeurs, depuis début 2025.
 
       [NOTES]
-      Pour le **CA total** d'une machine, combiner ce CA cash (espèces) avec le CA Nayax de
+      Pour le **CA total** d'une machine, combiner ce CA encaissé (physique) avec le CA Nayax de
       int_oracle_lcdp__telemetry_tasks (électronique). ca_cash_eur est TTC ; ca_cash_ht_eur /
-      ca_cash_tva_eur viennent de task_has_amount (NULL sur ~10 tâches sans ventilation).
+      ca_cash_tva_eur viennent de task_has_amount. CHECK_LUNCH (titres-restaurant) est inclus dans le
+      CA encaissé (montant marginal mais rétablit la cohérence ca_cash_eur = ca_cash_ht + ca_cash_tva).
+      ⚠️ Suppose des titres-resto **papier** comptés au monnayeur ; si des titres dématérialisés
+      passaient par Nayax, ils seraient déjà dans telemetry_tasks (risque de double-compte à surveiller).
     columns:
       # --- IDENTIFIANTS ---
       - name: task_id
@@ -1320,21 +1324,24 @@ models:
         tests:
           - not_null
 
-      # --- MESURES (CA cash) ---
+      # --- MESURES (CA encaissé) ---
       - name: ca_pieces_eur
         description: "CA encaissé en pièces (€, TTC) sur la machine au comptage. Synonyme : recette pièces. Mesure additive."
         data_type: float64
       - name: ca_billets_eur
         description: "CA encaissé en billets (€, TTC) sur la machine au comptage. Synonyme : recette billets. Mesure additive."
         data_type: float64
+      - name: ca_titres_resto_eur
+        description: "CA encaissé en titres-restaurant (€, TTC, code CHECK_LUNCH). Marginal mais inclus dans le CA encaissé total. Mesure additive."
+        data_type: float64
       - name: ca_cash_eur
-        description: "CA cash total (€, TTC) = ca_pieces_eur + ca_billets_eur. Synonymes : CA espèces, recette cash. Mesure additive."
+        description: "CA encaissé total (€, TTC) = ca_pieces_eur + ca_billets_eur + ca_titres_resto_eur. Synonymes : CA espèces, recette monnayeur. Mesure additive."
         data_type: float64
       - name: ca_cash_ht_eur
-        description: "CA cash HT (€), ventilé depuis task_has_amount. NULL si la tâche n'a pas de ventilation HT/TVA (~10 tâches)."
+        description: "CA encaissé HT (€), ventilé depuis task_has_amount (somme sur les taux de TVA). NULL si la tâche n'a pas de ventilation HT/TVA (~10 tâches)."
         data_type: float64
       - name: ca_cash_tva_eur
-        description: "Montant de TVA (€) du CA cash, depuis task_has_amount. NULL si pas de ventilation."
+        description: "Montant de TVA (€) du CA encaissé, depuis task_has_amount. NULL si pas de ventilation."
         data_type: float64
 
       # --- MÉTADONNÉES ---
@@ -1353,4 +1360,3 @@ models:
         data_type: timestamp
         tests:
           - not_null
-

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1262,71 +1262,95 @@ models:
 
   - name: int_oracle_lcdp__comptage_tasks
     description: >
-      Comptages de caisse (REGL COMPTAGE, idtask_type=30) : CA encaissé en espèces
-      (pièces + billets) par machine et par date de comptage. Sert à compléter le CA
-      des machines à monnayeur (ventes en pièces invisibles côté télémétrie Nayax).
-      1 ligne par comptage (task_id). Montants = argent physique relevé (TTC par nature,
-      tax_rate=0). Cadence ~1 comptage / 1-2 semaines → analyser à un grain >= mensuel.
+      [QUOI MÉTIER]
+      Comptages de caisse LCDP : une ligne par tâche de comptage (relève de l'argent physique d'un
+      monnayeur). Expose le **CA cash** (pièces + billets) par machine et par date de comptage.
+      Complète le CA électronique de la télémétrie Nayax (les ventes en espèces sont invisibles côté
+      Nayax). Synonymes : CA espèces, recette cash, comptage caisse / monnayeur.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 30 REGL COMPTAGE, code_status_record = '1') × task_has_product
+      filtré sur les lignes PIECES / BILLET (montants encaissés, TTC par nature), enrichi company/device/
+      location. La ventilation HT / TVA vient de task_has_amount (somme par tâche). Incrémental.
+
+      [GRAIN]
+      1 ligne par task_id (un comptage = une relève sur une machine à une date). ~9,2k lignes,
+      308 distributeurs, depuis début 2025.
+
+      [NOTES]
+      Pour le **CA total** d'une machine, combiner ce CA cash (espèces) avec le CA Nayax de
+      int_oracle_lcdp__telemetry_tasks (électronique). ca_cash_eur est TTC ; ca_cash_ht_eur /
+      ca_cash_tva_eur viennent de task_has_amount (NULL sur ~10 tâches sans ventilation).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_id
-        description: "Identifiant de la tâche de comptage (clé primaire)."
+        description: "Identifiant de la tâche de comptage Oracle LCDP (EVS.TASK). PK."
         data_type: int64
         tests:
           - unique
           - not_null
       - name: device_id
-        description: "ID de la machine comptée (NULL pour de rares comptages orphelins non rattachés à une machine — anomalie source immatérielle)."
+        description: "Distributeur (machine) compté. FK → dim_lcdp__device."
         data_type: int64
-        tests:
-          - not_null:
-              config:
-                severity: warn
       - name: company_id
-        description: "ID de l'entreprise cliente (peer)."
+        description: "Client (peer company). FK → dim_lcdp__company."
         data_type: int64
       - name: location_id
-        description: "ID de la localisation."
+        description: "Localisation de la tâche. FK → stg_oracle_lcdp__location."
         data_type: int64
+
+      # --- CODES / NOMS ---
       - name: device_code
-        description: "Code métier de la machine."
+        description: "Code métier du device (numéro de série)."
         data_type: string
       - name: company_code
-        description: "Code client."
+        description: "Code client de l'entreprise."
         data_type: string
       - name: company_name
-        description: "Nom du client."
+        description: "Nom du client (libellé d'affichage, aplati depuis company)."
         data_type: string
       - name: task_location_info
-        description: "Informations d'accès de la localisation."
+        description: "Informations d'accès / localisation de la tâche."
         data_type: string
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure du comptage (récupération des espèces)."
+        description: "Date du comptage (relève de l'argent). Clé de partitionnement."
         data_type: timestamp
         tests:
           - not_null
+
+      # --- MESURES (CA cash) ---
       - name: ca_pieces_eur
-        description: "CA encaissé en pièces sur la période depuis le dernier comptage (€, code PIECES / Total Cash)."
+        description: "CA encaissé en pièces (€, TTC) sur la machine au comptage. Synonyme : recette pièces. Mesure additive."
         data_type: float64
       - name: ca_billets_eur
-        description: "CA encaissé en billets (€, code BILLET)."
+        description: "CA encaissé en billets (€, TTC) sur la machine au comptage. Synonyme : recette billets. Mesure additive."
         data_type: float64
       - name: ca_cash_eur
-        description: "CA cash total encaissé = pièces + billets (€). Complément du CA Nayax pour les machines à monnayeur. TTC par nature (tax_rate=0)."
+        description: "CA cash total (€, TTC) = ca_pieces_eur + ca_billets_eur. Synonymes : CA espèces, recette cash. Mesure additive."
         data_type: float64
       - name: ca_cash_ht_eur
-        description: "CA cash HT (€) = somme des AMOUNT_WITHOUT_TAX (ventilation par taux de TVA) de la tâche de comptage. Issu de stg_oracle_lcdp__task_has_amount."
+        description: "CA cash HT (€), ventilé depuis task_has_amount. NULL si la tâche n'a pas de ventilation HT/TVA (~10 tâches)."
         data_type: float64
       - name: ca_cash_tva_eur
-        description: "Montant de TVA cash (€) = somme des TAX_AMOUNT de la tâche. Réconciliation : ca_cash_ht_eur + ca_cash_tva_eur ≈ ca_cash_eur (TTC)."
+        description: "Montant de TVA (€) du CA cash, depuis task_has_amount. NULL si pas de ventilation."
         data_type: float64
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)."
+        description: "Timestamp de dernière modification (filtre incrémental)."
         data_type: timestamp
         tests:
           - not_null
       - name: created_at
-        description: "Timestamp de création."
+        description: "Timestamp de création en source."
         data_type: timestamp
+        tests:
+          - not_null
       - name: extracted_at
         description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
+        tests:
+          - not_null
+

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1191,48 +1191,72 @@ models:
 
   - name: int_oracle_lcdp__pointage_tasks
     description: >
-      Table intermédiaire des tâches des pointages roadman sur les débuts et fin de journées
-      1 ligne = 1 tâche pointage.
-      Filtrée sur les tâches de type POINTAGE et FILTRER sur label START_DAY (idtask_type=194, idlabel=2685,2686) et filtrage sur les tâches associé à des idresources
-      avec code_status_record=1
+      [QUOI MÉTIER]
+      Pointages des roadmen LCDP : une ligne par pointage de début (START_DAY) ou de fin (END_DAY)
+      de journée. Sert au suivi du temps de travail / amplitude des tournées roadman.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 194 POINTAGE, code_status_record = '1'), filtré aux labels
+      START_DAY / END_DAY (idlabel 2685 / 2686), rattaché au roadman via task_has_resources × resources
+      (type 2 = PERSON). Conservé uniquement si un roadman est rattaché.
+
+      [GRAIN]
+      1 ligne par task_id (un pointage). ~10k lignes, 14 roadmen, depuis fin 2024. Une journée de
+      roadman = typiquement 2 pointages (un START_DAY + un END_DAY).
+
+      [NOTES]
+      Pas de notion de produit ni de flux. Pour reconstruire une amplitude de journée, apparier
+      START_DAY et END_DAY d'un même roadman sur date_pointage_jour.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_id
-        description: >
-          Identifiant unique de la tâche de pointage.
+        description: "Identifiant de la tâche de pointage Oracle LCDP (EVS.TASK). PK de ce modèle."
         tests:
+          - unique
           - not_null
-
       - name: company_id
-        description: >
-          Identifiant de l'entreprise (idcompany_peer de la tâche).
+        description: "Client (peer company) rattaché à la tâche. FK → dim_lcdp__company."
+      - name: resources_roadman_id
+        description: "Roadman ayant pointé. FK → dim_lcdp__resource (idresources, type 2 = PERSON). Toujours renseigné (filtre du modèle)."
         tests:
           - not_null
-
-      - name: resources_roadman_id
-        description: >
-          Identifiant de la ressource roadman (idresources_type=2) associée à la tâche.
-
       - name: roadman_code
-        description: >
-          Code métier du roadman associé à la tâche.
+        description: "Code métier du roadman."
 
+      # --- STATUT / TYPE ---
       - name: status_code
         description: >
-          Code statut de la tâche (depuis task_status).
-
+          Code du statut de la tâche de pointage (task_status.code). En pratique toujours VALIDE.
+        tests:
+          - accepted_values:
+              arguments: {values: [VALIDE, FAIT, ANNULE, ANOMALIE, PREVU, ENCOURS, ACQUITTE, ENATTENTE]}
+              config: {severity: warn}
       - name: label_code
-        description: >
-          Code du label de la tâche. Filtré sur START_DAY (idlabel=2685).
+        description: "Type de pointage. Valeurs : START_DAY (début de journée), END_DAY (fin de journée)."
+        tests:
+          - accepted_values:
+              arguments: {values: [START_DAY, END_DAY]}
+              config: {severity: warn}
 
-      - name: date_pointage_jour
-        description: >
-          Date du jour du pointage (sans l'heure), extraite de real_start_date.
+      # --- DATES ---
+      - name: date_pointage
+        description: "Date et heure réelle du pointage (real_start_date)."
         tests:
           - not_null
+      - name: date_pointage_jour
+        description: "Jour du pointage (date_pointage tronqué au jour) — clé d'appariement START_DAY/END_DAY par roadman."
 
-      - name: date_pointage
-        description: >
-          Timestamp du pointage
+      # --- MÉTADONNÉES ---
+      - name: created_at
+        description: "Timestamp de création en source."
+        tests:
+          - not_null
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
         tests:
           - not_null
 

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -4,98 +4,120 @@ version: 2
 models:
   - name: int_oracle_lcdp__telemetry_tasks
     description: >
-      Table intermédiaire des tâches de télémétrie.
-      Filtrée sur les tâches de type télémétrie (idtask_type=3)
-      avec statut FAIT/VALIDE et label TELEM_SOURCE.
+      [QUOI MÉTIER]
+      Relevés de télémétrie des distributeurs LCDP : une ligne par produit vendu / remonté par la
+      télémétrie d'une machine. **Porte la valorisation des ventes** (prix/montant Nayax) — base des
+      analyses de consommation ET de chiffre d'affaires télémétrique (DA FROID / Nayax). Synonymes :
+      ventes télémétriques, CA télémétrie.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 3 télémétrie, statuts FAIT/VALIDE, code_status_record = '1')
+      croisé avec task_has_product (grain ligne produit), enrichi company/device/location, + pivot des
+      labels TELEM_SOURCE / TELEM_SEND_CAUSE. Filtré aux tâches ayant un label TELEM_SOURCE. La donnée
+      provient du système de paiement NAYAX via l'ERP Distrilog. Incrémental (merge sur task_product_id).
+
+      [GRAIN]
+      1 ligne par task_product_id (1 relevé = 1 produit). **~4,36M lignes** (très volumineux),
+      446 distributeurs, depuis novembre 2024.
+
+      [NOTES]
+      Périmètre actuel = 100% Nayax (telemetry_source TELEM_NAYAX), donc les champs de vente sont
+      renseignés sur quasi toutes les lignes. telemetry_quantity vaut toujours 1.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de télémétrie Oracle LCDP (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: device_id
-        description: "ID du device associé à la tâche"
+        description: "Distributeur (machine) ayant remonté la télémétrie. FK → dim_lcdp__device."
         data_type: int64
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la machine. FK → dim_lcdp__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit télémétrique"
+        description: "Produit vendu / télémétré. FK → dim_lcdp__product."
         data_type: int64
         tests:
           - not_null
-
       - name: location_id
-        description: "ID de la localisation de la tâche"
+        description: "Localisation de la tâche. FK → stg_oracle_lcdp__location."
         data_type: int64
 
+      # --- CODES / LIBELLÉS ---
       - name: device_code
-        description: "Code métier du device (numéro de série)"
+        description: "Code métier du device (numéro de série)."
         data_type: string
-
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: company_code
-        description: "Code client de l'entreprise"
+        description: "Code client de l'entreprise."
         data_type: string
-
       - name: company_name
-        description: "Nom de l'entreprise cliente"
+        description: "Nom de l'entreprise cliente (libellé d'affichage, aplati depuis company)."
         data_type: string
-
       - name: task_location_info
-        description: "Informations d'accès de la localisation de la tâche"
+        description: "Informations d'accès / localisation de la tâche."
         data_type: string
 
+      # --- LABELS TÉLÉMÉTRIE (pivotés) ---
+      - name: telemetry_source
+        description: >
+          Source de la télémétrie (label de famille TELEM_SOURCE). Valeur actuelle : TELEM_NAYAX
+          (système de paiement Nayax). Constant sur le périmètre actuel.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments: {values: [TELEM_NAYAX]}
+              config: {severity: warn}
+      - name: telemetry_send_cause
+        description: >
+          Cause d'émission de la télémétrie (label de famille TELEM_SEND_CAUSE). Valeur actuelle :
+          PLANIFIED_SAILS (envoi planifié des ventes). Constant sur le périmètre actuel.
+        data_type: string
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche télémétrique"
+        description: "Date et heure réelle du relevé de télémétrie / de la vente. Clé de partitionnement."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- MESURES ---
       - name: telemetry_quantity
-        description: "Quantité télémétrique (toujours 1 par convention métier)"
+        description: "Toujours 1 (1 tâche = 1 unité de télémétrie). Sommer pour compter les relevés/ventes. Mesure additive."
         data_type: int64
-
       - name: sale_unit_price_eur
-        description: "Prix de vente unitaire HT remonté par Nayax sur l'event (€). Rempli à ~100% sur DA FROID, NULL sur autres catégories."
+        description: "Prix de vente unitaire HT remonté par Nayax sur l'event (€). Synonymes : prix de vente, prix unitaire."
         data_type: float64
-
       - name: sale_amount_net_eur
-        description: "Montant de vente net HT (€) — équivalent à sale_unit_price_eur car telemetry_quantity = 1."
+        description: "Montant de vente net HT (€) — égal à sale_unit_price_eur car telemetry_quantity = 1. Synonymes : CA HT, montant de vente HT. Mesure additive."
         data_type: float64
-
       - name: sale_amount_net_tax_eur
-        description: "Montant de vente net TTC (€) — inclut la TVA applicable au produit."
+        description: "Montant de vente net TTC (€) — inclut la TVA applicable au produit. Synonyme : CA TTC. Mesure additive."
         data_type: float64
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification (filtre incrémental)."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__comptage_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__comptage_tasks.sql
@@ -4,8 +4,9 @@
         unique_key='task_id',
         partition_by={'field': 'task_start_date', 'data_type': 'timestamp'},
         incremental_strategy='merge',
+        on_schema_change='append_new_columns',
         cluster_by=['company_id', 'device_id'],
-        description='Table intermédiaire des comptages de caisse (REGL COMPTAGE, idtask_type=30) - CA cash (pièces + billets) par machine et par date de comptage. Sert à compléter le CA des machines équipées d''un monnayeur (ventes pièces invisibles côté télémétrie Nayax).'
+        description='Table intermédiaire des comptages de caisse (REGL COMPTAGE, idtask_type=30) - CA encaissé (pièces + billets + titres-restaurant) par machine et par date de comptage. Sert à compléter le CA des machines équipées d''un monnayeur (paiements physiques invisibles côté télémétrie Nayax).'
     )
 }}
 
@@ -30,10 +31,15 @@ with comptage_base as (
         -- Montants encaissés (argent physique relevé au comptage).
         -- sale_amount_net = sale_amount_net_tax et tax_rate = 0 → montant brut encaissé,
         -- donc TTC par nature (ce que le client a payé). À combiner au CA Nayax TTC.
+        -- JETON exclu (valeur 0). CHECK_LUNCH (titres-restaurant) inclus dans le CA encaissé.
         sum(case when thp.code = 'PIECES' then thp.sale_amount_net else 0 end) as ca_pieces_eur,
         sum(case when thp.code = 'BILLET' then thp.sale_amount_net else 0 end) as ca_billets_eur,
+        sum(case when thp.code = 'CHECK_LUNCH' then thp.sale_amount_net else 0 end) as ca_titres_resto_eur,
         sum(
-            case when thp.code in ('PIECES', 'BILLET') then thp.sale_amount_net else 0 end
+            case
+                when thp.code in ('PIECES', 'BILLET', 'CHECK_LUNCH') then thp.sale_amount_net
+                else 0
+            end
         ) as ca_cash_eur,
 
         -- Timestamps techniques
@@ -53,7 +59,7 @@ with comptage_base as (
         and t.idtask_type = 30  -- REGL COMPTAGE
         and t.code_status_record = '1'
         and t.real_start_date is not null
-        and thp.code in ('PIECES', 'BILLET')
+        and thp.code in ('PIECES', 'BILLET', 'CHECK_LUNCH')
 
     group by
         t.idtask, t.iddevice, t.idcompany_peer, t.idlocation,
@@ -85,6 +91,7 @@ comptage_enrichi as (
         cb.task_start_date,
         cb.ca_pieces_eur,
         cb.ca_billets_eur,
+        cb.ca_titres_resto_eur,
         cb.ca_cash_eur,
         a.ca_cash_ht_eur,
         a.ca_cash_tva_eur,

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -820,11 +820,18 @@ models:
         data_type: int64
 
       - name: product_source_id
-        description: "Produit source de la tâche. FK → dim_neshu__product."
+        description: >
+          Identifiant de l'entité **source** du flux. Référence **polymorphe** : la table cible est
+          celle nommée par product_source_type — COMPANY → stg_oracle_neshu__company,
+          RESOURCES → stg_oracle_neshu__resources, DEVICE → stg_oracle_neshu__device. Pour l'appro,
+          type = RESOURCES (stock du véhicule/roadman). Malgré son nom, ce n'est pas une FK produit.
         data_type: int64
 
       - name: product_destination_id
-        description: "Produit destination de la tâche. FK → dim_neshu__product."
+        description: >
+          Identifiant de l'entité **destination** du flux. Référence **polymorphe** : table cible
+          nommée par product_destination_type (mêmes valeurs : COMPANY/RESOURCES/DEVICE…). Pour
+          l'appro, type = DEVICE → le distributeur (machine remplie).
         data_type: int64
 
       - name: company_code
@@ -886,12 +893,25 @@ models:
 
 
   - name: int_oracle_neshu__appro_tasks_enriched
-    description: |
-      Tâches appro enrichies du référentiel (company, device, roadman, GEA)
-      et du statut normalisé (ENCOURS reclassé en FAIT après validation métier).
-      Base partagée entre fct_neshu__appro (analyse roadman/jour avec pointage
-      et métriques journalières) et tout fact dérivé au grain machine.
-      Grain : 1 ligne par task_id (passage appro).
+    description: >
+      [QUOI MÉTIER]
+      Passages d'approvisionnement enrichis : tâche appro + roadman affecté, référentiels
+      company/device/GEA, statut normalisé et durée du passage. Base de fct_neshu__appro
+      (analyse roadman/jour avec pointage) et des faits dérivés au grain machine.
+
+      [COMMENT CONSTRUITE]
+      int_oracle_neshu__appro_tasks enrichi du roadman (stg_oracle_neshu__task_has_resources ×
+      resources type=2 = PERSON), du GEA (ref_oracle_neshu__roadman_gea) et des libellés
+      company/device. Statut normalisé : ENCOURS reclassé en FAIT (validation métier). Durée
+      du passage calculée (fin − début) pour les tâches FAIT.
+
+      [GRAIN]
+      1 ligne par task_id (passage appro). ~555k lignes.
+
+      [NOTES]
+      Filtré aux passages ayant un roadman rattaché (resources_roadman_id non NULL) — ~327
+      passages sans roadman exclus vs int_oracle_neshu__appro_tasks. Pas de véhicule ici :
+      seul le roadman (resources type=2) est joint.
     columns:
       - name: task_id
         description: "ID de la tâche"
@@ -899,19 +919,19 @@ models:
           - unique
           - not_null
       - name: device_id
-        description: "ID du device (NULL toléré, cf. task_id 11460408 - source Oracle)"
+        description: "Distributeur (machine) concerné. FK → dim_neshu__device. NULL toléré (cf. task_id 11460408, source Oracle)."
       - name: company_id
-        description: "ID de la company cliente"
+        description: "Client (peer company). FK → dim_neshu__company."
         tests:
           - not_null
       - name: resources_roadman_id
-        description: "ID du roadman (resources type=2)"
+        description: "Roadman (approvisionneur) affecté. FK → stg_oracle_neshu__resources (idresources, type=2 = PERSON)."
         tests:
           - not_null
       - name: roadman_code
-        description: "Code roadman"
+        description: "Code métier du roadman."
       - name: gea_code
-        description: "Code GEA mappé depuis ref_oracle_neshu__roadman_gea"
+        description: "Code GEA du roadman (mappé depuis ref_oracle_neshu__roadman_gea)."
       - name: device_code
         description: "Code device"
       - name: device_name
@@ -925,13 +945,21 @@ models:
       - name: company_info
         description: "Libellé concat 'nom - code'"
       - name: task_status_code
-        description: "Statut normalisé (ENCOURS reclassé en FAIT)"
+        description: >
+          Statut de la tâche, **normalisé** : ENCOURS reclassé en FAIT (donc pas de ENCOURS ici,
+          contrairement à int_oracle_neshu__appro_tasks). Valeurs : FAIT (réalisé, majoritaire),
+          ANNULE, PREVU, ANOMALIE, VALIDE, ACQUITTE, ENATTENTE.
         tests:
           - not_null
+          - accepted_values:
+              arguments:
+                values: [FAIT, ANNULE, PREVU, ANOMALIE, VALIDE, ACQUITTE, ENATTENTE]
+              config:
+                severity: warn
       - name: is_done
-        description: "Indicateur binaire : 1 si FAIT ou ENCOURS"
+        description: "Indicateur binaire : 1 si la tâche est réalisée (statut brut FAIT ou ENCOURS), sinon 0."
       - name: is_planned
-        description: "Indicateur binaire : 1 si PREVU, FAIT ou ENCOURS"
+        description: "Indicateur binaire : 1 si la tâche est planifiée ou réalisée (statut brut PREVU, FAIT ou ENCOURS), sinon 0."
       - name: task_start_date
         description: "Date début passage"
         tests:
@@ -947,13 +975,20 @@ models:
       - name: passage_duration_interval
         description: "Durée brute en INTERVAL (audit)"
       - name: product_source_id
-        description: "ID source du produit (idresources)"
+        description: >
+          Identifiant de l'entité **source** du flux. Référence **polymorphe** : la table cible est
+          celle nommée par product_source_type — COMPANY → stg_oracle_neshu__company,
+          RESOURCES → stg_oracle_neshu__resources, DEVICE → stg_oracle_neshu__device. Pour l'appro,
+          type = RESOURCES (stock du véhicule/roadman). Malgré son nom, ce n'est pas une FK produit.
       - name: product_destination_id
-        description: "ID destination du produit"
+        description: >
+          Identifiant de l'entité **destination** du flux. Référence **polymorphe** : table cible
+          nommée par product_destination_type (mêmes valeurs : COMPANY/RESOURCES/DEVICE…). Pour
+          l'appro, type = DEVICE → le distributeur (machine remplie).
       - name: product_source_type
-        description: "Type de la source produit (RESOURCES, etc.)"
+        description: "Type de l'entité source = table cible de product_source_id. Pour l'appro : RESOURCES (stock véhicule/roadman), ou NULL."
       - name: product_destination_type
-        description: "Type de la destination produit"
+        description: "Type de l'entité destination = table cible de product_destination_id. Pour l'appro : DEVICE (le distributeur), ou NULL."
       - name: task_location_info
         description: "Infos de localisation de la tâche"
       - name: created_at

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -1027,16 +1027,16 @@ models:
       consommateurs.
     columns:
       - name: device_id
-        description: "ID du device (PK)"
+        description: "Machine (distributeur). PK de ce modèle. FK → dim_neshu__device."
         tests:
           - unique
           - not_null
       - name: company_id
-        description: "ID company stable par device (any_value sur les tasks)"
+        description: "Client de la machine (any_value, normalement stable par device). FK → dim_neshu__company."
         tests:
           - not_null
       - name: last_appro_task_id
-        description: "ID du dernier passage FAIT (NULL si jamais d'appro FAIT)"
+        description: "Tâche du dernier passage FAIT (NULL si jamais d'appro FAIT). FK → int_oracle_neshu__appro_tasks_enriched."
       - name: last_appro_date
         description: "Date du dernier passage FAIT"
       - name: last_appro_roadman_id

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -4,86 +4,96 @@ version: 2
 models:
   - name: int_oracle_neshu__telemetry_tasks
     description: >
-      Table intermédiaire des tâches de télémétrie.
-      Filtrée sur les tâches de type télémétrie (idtask_type=3) 
-      avec statut FAIT/VALIDE et label TELEM_SOURCE.
-      
+      [QUOI MÉTIER]
+      Relevés de télémétrie des distributeurs NESHU : une ligne par produit remonté par la
+      télémétrie d'une machine (consommation détectée). Origine : système de paiement NAYAX,
+      remonté dans l'ERP Distrilog Easy Web. Base des analyses de consommation télémétrique
+      par machine / produit.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 3 télémétrie, statuts FAIT/VALIDE uniquement,
+      code_status_record = '1', label de famille TELEM_SOURCE) croisé avec task_has_product
+      (grain ligne produit), enrichi company/device/location. La donnée provient de NAYAX
+      (paiement) via l'ERP Distrilog. Incrémental (merge sur task_product_id).
+
+      [GRAIN]
+      1 ligne par task_product_id (1 relevé = 1 produit télémétré). **~24,4M lignes** (très volumineux),
+      ~1 269 distributeurs, depuis fin 2022.
+
+      [NOTES]
+      Aucune colonne de statut exposée (déjà filtré FAIT/VALIDE). telemetry_quantity vaut toujours 1
+      (1 tâche = 1 unité de télémétrie) — sommer pour compter les relevés. Pas de notion de
+      source/destination ici (contrairement aux tâches de flux produit).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de télémétrie Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-          
       - name: device_id
-        description: "ID du device associé à la tâche"
+        description: "Distributeur (machine) ayant remonté la télémétrie. FK → dim_neshu__device."
         data_type: int64
-        
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la machine. FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit télémétrique"
+        description: "Produit télémétré. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-          
       - name: location_id
-        description: "ID de la localisation de la tâche"
+        description: "Localisation de la tâche. FK → stg_oracle_neshu__location."
         data_type: int64
-        
+
+      # --- CODES / LIBELLÉS ---
       - name: device_code
-        description: "Code métier du device (numéro de série)"
+        description: "Code métier du device (numéro de série)."
         data_type: string
-        
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-        
       - name: company_code
-        description: "Code client de l'entreprise"
+        description: "Code client de l'entreprise."
         data_type: string
-        
       - name: company_name
-        description: "Nom de l'entreprise cliente"
+        description: "Nom de l'entreprise cliente (libellé d'affichage, aplati depuis company)."
         data_type: string
-        
       - name: task_location_info
-        description: "Informations d'accès de la localisation de la tâche"
+        description: "Informations d'accès / localisation de la tâche."
         data_type: string
-        
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche télémétrique"
+        description: "Date et heure réelle du relevé de télémétrie. Clé de partitionnement."
         data_type: timestamp
         tests:
           - not_null
-        
+
+      # --- MESURE ---
       - name: telemetry_quantity
-        description: "Quantité télémétrique (toujours 1 par convention métier)"
+        description: "Toujours 1 (1 tâche = 1 unité de télémétrie). Sommer pour compter les relevés. Mesure additive."
         data_type: int64
-        
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification (filtre incrémental)."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -1265,87 +1265,92 @@ models:
 
   - name: int_oracle_neshu__inter_techinique_tasks
     description: >
-      Table intermédiaire des inter technique.
-      Filtrée sur les tâches de type INTER TECHNIQUE (idtask_type=131)  & filtré sur label C4 Détartrage/filtre
-      avec statut actif (code_status_record=1) et enrichie avec code produit.
-      
+      [QUOI MÉTIER]
+      Interventions de petite maintenance technique NESHU (préventif) : une ligne par intervention
+      sur un distributeur, avec son statut et sa classification (labels). Orientées petites
+      opérations ; les cas non résolus sur place sont escaladés à l'équipe technique
+      (statut_inter = TOTECH).
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 131 INTERVENTION TECHNIQUE, statuts FAIT/VALIDE/ANNULE/
+      ANOMALIE, code_status_record = '1') enrichi company/device/product, puis pivot des labels EAV
+      (label_has_task × label × label_family) en colonnes : statut_inter, dc04, mission_type,
+      objet_intervent. Filtré sur objet_intervent = 'OC04' (intervention préventive).
+
+      [GRAIN]
+      1 ligne par task_id (intervention). ~731 lignes, depuis mai 2025 (modèle récent).
+
+      [NOTES]
+      Pas de notion de flux produit (ni source/destination, ni quantité/valorisation) : c'est un
+      modèle d'évènement/statut d'intervention. Les codes de labels (statut_inter, dc04…) sont des
+      référentiels métier Oracle.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_id
-        description: "ID de la tâche"
-        data_type: int64
+        description: "Identifiant de la tâche d'intervention Oracle (EVS.TASK). PK de ce modèle."
         tests:
           - unique
           - not_null
-
       - name: device_id
-        description: "ID du device associé à la tâche"
-        data_type: int64
-        tests:
-          - not_null
-
+        description: "Distributeur (machine) concerné par l'intervention. FK → dim_neshu__device."
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
-        data_type: int64
-        tests:
-          - not_null 
-
+        description: "Client (peer company). FK → dim_neshu__company."
       - name: product_id
-        description: "ID du produit"
-        data_type: int64
+        description: "Produit / pièce liée à l'intervention (via task_has_product). FK → dim_neshu__product. Souvent NULL (ces interventions de petite maintenance n'ont en général pas de ligne produit)."
 
+      # --- CODES ---
       - name: company_code
-        description: "Code client de l'entreprise (company.code)"
-        data_type: string
-
+        description: "Code client de l'entreprise."
+      - name: device_code
+        description: "Code métier du device (numéro de série)."
       - name: product_code
-        description: "Code produit (si utilisé pour la tâche)"
-        data_type: string
-
+        description: "Code métier du produit / pièce."
       - name: task_status_code
-        description: "Code du statut de la tâche (task_status.code)"
-        data_type: string
+        description: >
+          Code du statut de la tâche. Valeurs : FAIT (réalisé, très majoritaire), ANNULE
+          (et, autorisés par le filtre, VALIDE / ANOMALIE).
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
 
+      # --- LABELS PIVOTÉS (référentiels métier) ---
       - name: statut_inter
-        description: "Statut de l'intervention technique (TERMINE ou envoyé à la technique)"
-        data_type: string
-
+        description: >
+          Statut de traitement de l'intervention (label de famille 'Statut inter'). Valeurs :
+          TERMINATED (traitée / clôturée sur place, majoritaire), TOTECH (non résolue sur place →
+          renvoyée à l'équipe technique), NULL. La famille comporte aussi UNTREATED et
+          WAITING_PIECE (absents de ce périmètre filtré).
       - name: dc04
-        description: "Label famille DC04 qui correspond au : Détail C4 -"
-        data_type: string
-      
+        description: >
+          Code de classification de l'intervention (label de famille 'DC04'). Valeurs :
+          DC0404 (majoritaire), DC0401, DC0403, DC0402, NULL.
       - name: mission_type
-        description: "Type de mission"
-        data_type: string
-
+        description: "Type de mission (label de famille 'MISSION_TYPE'). Quasi constant : INTER TECHNIQUE (ou NULL)."
       - name: objet_intervent
-        description: "Objet de l'intervention : Filtré sur C4 - Détartrage/filtre"
-        data_type: string
+        description: "Objet de l'intervention (label de famille 'Objet intervent'). Toujours OC04 ici (filtre du modèle = préventif)."
 
+      # --- DATES ---
       - name: task_start_date
-        description: "Date et heure de début réel du passage appro"
-        data_type: timestamp
+        description: "Date et heure réelle de début de l'intervention."
         tests:
           - not_null
-
       - name: task_end_date
-        description: "Date et heure de fin réel du passage appro"
-        data_type: timestamp
+        description: "Date et heure réelle de fin de l'intervention."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
-        data_type: timestamp
+        description: "Timestamp de dernière modification en source."
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
-        data_type: timestamp
+        description: "Timestamp de création en source."
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
-        data_type: timestamp
+        description: "Timestamp d'extraction depuis Oracle."
         tests:
           - not_null
 

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -485,93 +485,114 @@ models:
 
   - name: int_oracle_neshu__ecart_inventaire_tasks
     description: >
-      Table intermédiaire des tâches de d'ecart inventaire.
-      Filtrée sur les tâches de type ECART INVENTAIRE (idtask_type=163) 
-      avec statut FAIT/VALIDE/ANNULE.
-      
+      [QUOI MÉTIER]
+      Écarts d'inventaire NESHU : une ligne par produit sur une tâche d'écart d'inventaire
+      (ajustement constaté entre le stock théorique et le stock compté), par source (véhicule ou dépôt).
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 163 ECART INVENTAIRE, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      La source est résolue selon son type : product_source_type = COMPANY → code dépôt (company),
+      RESOURCES → code ressource (véhicule/roadman). Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un écart). ~133k lignes (~4 823 tâches),
+      depuis début 2023.
+
+      [NOTES]
+      Pas de destination. La majorité des tâches d'écart sont en statut ANNULE (écart non retenu) ;
+      filtrer task_status_code = 'FAIT'/'VALIDE' pour les écarts effectifs. Les lignes sans source
+      résolue (source_code NULL) sont exclues.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche d'écart d'inventaire Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-        
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit télémétrique"
+        description: "Produit concerné par l'écart. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source** du stock. Référence polymorphe : table cible nommée par
+          product_source_type — COMPANY → stg_oracle_neshu__company (dépôt),
+          RESOURCES → stg_oracle_neshu__resources (véhicule/roadman). Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : RESOURCES (stock véhicule, majoritaire), COMPANY (stock dépôt)."
         data_type: string
 
+      # --- CODES ---
       - name: source_code
-        description: "Code source du produit"
+        description: >
+          Code de l'entité source, résolu selon product_source_type : company.code si COMPANY,
+          resources.code si RESOURCES. Les lignes sans source résolue sont exclues du modèle.
         data_type: string
-        
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
-        data_type: string 
-        
+        description: >
+          Code du statut de la tâche. Valeurs : ANNULE (écart non retenu, majoritaire), FAIT (réalisé),
+          VALIDE (validé), ANOMALIE.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de la tâche d'écart."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-        
-      - name: quantity
-        description: "Quantité produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité d'écart en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive (peut être négative = manquant)."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
-        
+        description: "Valorisation de l'écart en euros = quantity × prix d'achat unitaire. Mesure additive."
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -1341,123 +1341,139 @@ models:
 
   - name: int_oracle_neshu__commande_interne_tasks
     description: >
-      Table intermédiaire des mouvements internes (commandes internes).
-      Filtrée sur les tâches de type LIVRAISON INTERNE (idtask_type = 132)
-      avec statut FAIT / VALIDE / ANNULE, et labels de la famille STATUT_LIVRAISON.
-      Contient les métriques de quantité et valorisation, avec les codes source et destination
-      (entreprise ou ressource) associés.
+      [QUOI MÉTIER]
+      Commandes / livraisons internes NESHU (type 132) : une ligne par produit d'une commande
+      interne, avec son statut de livraison. Approvisionnement interne, typiquement dépôt → véhicule.
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 132, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      Source ET destination résolues selon leur type (COMPANY → company, RESOURCES → resources).
+      Le statut de livraison vient du label de famille STATUT_LIVRAISON. Déduplication sur
+      task_product_id en priorisant le label LIVRE.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une commande interne). ~93k lignes (~8 360 tâches),
+      depuis fin 2022.
+
+      [NOTES]
+      Distinct de int_oracle_neshu__livraison_interne_tasks (idtask_type 161) : ici type 132, avec
+      suivi de statut de livraison (label_code). Flux dominant COMPANY (dépôt) → RESOURCES (véhicule).
+      Seules les lignes dont source ET destination se résolvent sont conservées.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation tâche-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "Identifiant de la tâche (référence EVS.TASK)"
+        description: "Tâche de commande interne Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "Identifiant de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
-
       - name: product_id
-        description: "Identifiant du produit concerné"
+        description: "Produit commandé. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "Identifiant du produit source (COMPANY ou RESOURCES)"
+        description: >
+          Identifiant de l'entité **source**. Référence polymorphe : table cible nommée par
+          product_source_type — COMPANY → stg_oracle_neshu__company (dépôt),
+          RESOURCES → stg_oracle_neshu__resources (véhicule). Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source (COMPANY ou RESOURCES)"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : COMPANY (dépôt, majoritaire), RESOURCES (véhicule)."
         data_type: string
-
       - name: product_destination_id
-        description: "Identifiant du produit destination (COMPANY ou RESOURCES)"
+        description: >
+          Identifiant de l'entité **destination**. Référence polymorphe : table cible nommée par
+          product_destination_type (COMPANY → company, RESOURCES → resources).
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit destination (COMPANY ou RESOURCES)"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeurs : RESOURCES (véhicule, majoritaire), COMPANY (dépôt)."
         data_type: string
 
+      # --- CODES ---
       - name: source_code
-        description: "Code de la source du mouvement (entreprise ou ressource)"
+        description: "Code de l'entité source, résolu selon product_source_type (company.code si COMPANY, resources.code si RESOURCES)."
         data_type: string
         tests:
           - not_null
-
       - name: destination_code
-        description: "Code de la destination du mouvement (entreprise ou ressource)"
+        description: "Code de l'entité destination, résolu selon product_destination_type (company.code si COMPANY, resources.code si RESOURCES)."
         data_type: string
         tests:
           - not_null
-
       - name: product_code
-        description: "Code métier du produit (référence EVS.PRODUCT)"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : FAIT (réalisé, majoritaire), VALIDE, ANNULE, ANOMALIE.
         data_type: string
-
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
       - name: label_code
-        description: "Code du label associé à la tâche (famille STATUT_LIVRAISON)"
+        description: >
+          Statut de livraison de la commande interne (label de famille STATUT_LIVRAISON). Valeurs :
+          LIVRE (livré, majoritaire), LIVRE_PARTIEL (livraison partielle), EN_ATTENTE (en attente).
+          La déduplication priorise la ligne LIVRE.
         data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [LIVRE, LIVRE_PARTIEL, EN_ATTENTE]
+              config:
+                severity: warn
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de début de la tâche"
+        description: "Date et heure réelle de la commande interne."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
       - name: unit_coeff_multi
-        description: "Coefficient multiplicateur d'unité du produit"
-        data_type: int64
-
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
       - name: unit_coeff_div
-        description: "Coefficient diviseur d'unité du produit"
-        data_type: int64
-
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité totale du produit transféré (avec coefficients unitaires)"
-        data_type: numeric
-
+        description: "Quantité commandée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation totale (quantité * prix unitaire net)"
-        data_type: numeric
+        description: "Valorisation de la commande en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière mise à jour de la tâche"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création de la tâche"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle (suivi de synchronisation)"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -372,97 +372,116 @@ models:
 
   - name: int_oracle_neshu__inventaire_tasks
     description: >
-      Table intermédiaire des tâches de d'inventaire.
-      Filtrée sur les tâches de type INVENTAIRE (idtask_type=162) 
-      avec statut FAIT/VALIDE/ANNULE.
-      
+      [QUOI MÉTIER]
+      Inventaires de stock NESHU : une ligne par produit inventorié sur une tâche d'inventaire.
+      Photographie des quantités constatées par source de stock (véhicule/roadman ou dépôt).
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 162 INVENTAIRE, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      La source est résolue selon son type : product_source_type = COMPANY → code dépôt (company),
+      RESOURCES → code ressource (véhicule/roadman). Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un inventaire). ~62k lignes (~1 398 inventaires),
+      depuis fin 2022.
+
+      [NOTES]
+      Pas de destination (un inventaire constate un stock, il ne le déplace pas). Les lignes dont
+      la source ne se résout pas (source_code NULL) sont exclues.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche d'inventaire Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-        
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit télémétrique"
+        description: "Produit inventorié. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source** du stock inventorié. Référence polymorphe : table cible
+          nommée par product_source_type — COMPANY → stg_oracle_neshu__company (dépôt),
+          RESOURCES → stg_oracle_neshu__resources (véhicule/roadman). Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : RESOURCES (stock véhicule, majoritaire), COMPANY (stock dépôt)."
         data_type: string
 
+      # --- CODES ---
       - name: source_code
-        description: "Code source du produit"
+        description: >
+          Code de l'entité source, résolu selon product_source_type : company.code si COMPANY,
+          resources.code si RESOURCES. Les lignes sans source résolue sont exclues du modèle.
         data_type: string
-        
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
-        data_type: string 
-        
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), FAIT (réalisé),
+          ANNULE, ANOMALIE.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de l'inventaire."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-        
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
+
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité inventoriée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
-        
-      - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
-        data_type: timestamp
-        tests:
-          - not_null
-          
-      - name: created_at
-        description: "Timestamp de création"
-        data_type: timestamp
-        tests:
-          - not_null
-          
-      - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
-        data_type: timestamp
-        tests:
-          - not_null
+        description: "Valorisation du stock inventorié en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp
+        tests:
+          - not_null
 
   - name: int_oracle_neshu__ecart_inventaire_tasks
     description: >

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -599,97 +599,114 @@ models:
 
   - name: int_oracle_neshu__reception_tasks
     description: >
-      Table intermédiaire des tâches de RECEPTION.
-      Filtrée sur les tâches de type RECEPTION (idtask_type=121) 
-      avec statut FAIT/VALIDE/ANNULE.
-      
+      [QUOI MÉTIER]
+      Réceptions de marchandises NESHU : une ligne par produit sur un bon de réception
+      (entrée de stock dans un dépôt). Suivi des quantités et valeurs reçues.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 121 BON RECEPTION, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
+      La destination est résolue quand product_destination_type = COMPANY → code dépôt (company).
+      Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un bon de réception). ~9 563 lignes (~1 693 bons),
+      depuis 2022.
+
+      [NOTES]
+      Symétrique de la livraison mais côté entrée : product_destination_id est polymorphe et vaut
+      toujours COMPANY ici (réception dans un dépôt). Pas de source.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de bon de réception Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-        
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit télémétrique"
+        description: "Produit reçu. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_destination_id
-        description: "ID du produit de destination"
+        description: >
+          Identifiant de l'entité **destination** (lieu de réception). Référence polymorphe : table
+          cible nommée par product_destination_type. Ici toujours COMPANY → stg_oracle_neshu__company
+          (dépôt). Pas une FK produit malgré le nom.
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit de destination"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeur : COMPANY (dépôt de réception)."
         data_type: string
 
+      # --- CODES ---
       - name: destination_code
-        description: "Code de destination du produit"
+        description: "Code du dépôt de réception (company.code), résolu via product_destination_type = COMPANY."
         data_type: string
-        
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
-        data_type: string 
-        
+        description: >
+          Code du statut de la tâche. Valeurs : VALIDE (validé, majoritaire), FAIT (réalisé),
+          ANNULE, ANOMALIE.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de la réception."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-        
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
+
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit"
-        data_type: int64
-
+        description: "Quantité reçue en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
-        
-      - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
-        data_type: timestamp
-        tests:
-          - not_null
-          
-      - name: created_at
-        description: "Timestamp de création"
-        data_type: timestamp
-        tests:
-          - not_null
-          
-      - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
-        data_type: timestamp
-        tests:
-          - not_null
+        description: "Valorisation de la réception en euros = quantity × prix d'achat unitaire. Mesure additive."
 
+      # --- MÉTADONNÉES ---
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp
+        tests:
+          - not_null
 
   - name: int_oracle_neshu__livraison_interne_tasks
     description: >

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -787,65 +787,70 @@ models:
 
   - name: int_oracle_neshu__appro_tasks
     description: >
-      Table intermédiaire des passages approvisionneurs.
-      Filtrée sur les tâches de type PASSAGE APPRO (idtask_type=32) 
-      avec statut actif (code_status_record=1) et enrichie avec ressources (roadman, véhicule).
-      
+      [QUOI MÉTIER]
+      Passages d'approvisionnement (réassort) des distributeurs NESHU : une ligne par tâche
+      de type « PASSAGE APPROVISIONNEURS ». Brique de base de la chaîne appro.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task filtré sur idtask_type = 32, statut d'enregistrement actif
+      (code_status_record = '1') et real_start_date renseignée ; jointures company (client),
+      task_status (code statut) et location (info d'accès).
+
+      [GRAIN]
+      1 ligne par task_id (PK). ~555k lignes, depuis 2022.
+
+      [NOTES]
+      Modèle de base NON enrichi : roadman, véhicule, device normalisé et statut reclassé sont
+      ajoutés en aval dans int_oracle_neshu__appro_tasks_enriched. task_status_code couvre tout
+      le cycle (PREVU → FAIT/ANNULE…), pas seulement les passages réalisés.
     columns:
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Identifiant de la tâche Oracle (EVS.TASK). PK."
         data_type: int64
         tests:
           - unique
           - not_null
 
       - name: device_id
-        description: "ID du device associé à la tâche"
+        description: "Distributeur (machine) concerné. FK → dim_neshu__device."
         data_type: int64
 
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
 
       - name: product_source_id
-        description: "ID du produit source de la tâche"
+        description: "Produit source de la tâche. FK → dim_neshu__product."
         data_type: int64
 
       - name: product_destination_id
-        description: "ID du produit destination de la tâche"
-        data_type: int64
-
-      - name: roadman_id
-        description: "ID du roadman associé à la tâche (resources type=2)"
-        data_type: int64
-
-      - name: vehicle_id
-        description: "ID du véhicule associé à la tâche (resources type=3)"
+        description: "Produit destination de la tâche. FK → dim_neshu__product."
         data_type: int64
 
       - name: company_code
-        description: "Code client de l'entreprise (company.code)"
-        data_type: string
-
-      - name: roadman_code
-        description: "Code métier du roadman (resources.code)"
-        data_type: string
-
-      - name: vehicle_code
-        description: "Code métier du véhicule (resources.code)"
-        data_type: string
-
-      - name: task_status_code
-        description: "Code du statut de la tâche (task_status.code)"
+        description: "Code client de l'entreprise (company.code)."
         data_type: string
 
       - name: product_source_type
-        description: "Type de la source produit"
+        description: "Type d'entité de la source produit. Valeurs : RESOURCES (stock véhicule/ressource), NULL."
         data_type: string
 
       - name: product_destination_type
-        description: "Type de la destination produit"
+        description: "Type d'entité de la destination produit. Valeurs : DEVICE (le distributeur), NULL."
         data_type: string
+
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche (task_status.code). Valeurs : FAIT (réalisé, majoritaire),
+          ANNULE, PREVU (planifié), ENCOURS, ANOMALIE, VALIDE, ACQUITTE, ENATTENTE.
+          Filtrer task_status_code = 'FAIT' pour les passages réellement réalisés.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, ANNULE, PREVU, ENCOURS, ANOMALIE, VALIDE, ACQUITTE, ENATTENTE]
+              config:
+                severity: warn
 
       - name: task_location_info
         description: "Informations de localisation de la tâche"

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -1513,47 +1513,78 @@ models:
 
   - name: int_oracle_neshu__pointage_tasks
     description: >
-      Table intermédiaire des tâches des pointages roadman sur les débuts et fin de journées 
-      1 ligne = 1 tâche pointage.
-      Filtrée sur les tâches de type POINTAGE et FILTRER sur label START_DAY (idtask_type=194, idlabel=2685,2686) et filtrage sur les tâches associé à des idresources
-      avec code_status_record=1
+      [QUOI MÉTIER]
+      Pointages des roadmen NESHU : une ligne par pointage de début (START_DAY) ou de fin
+      (END_DAY) de journée. Sert au suivi du temps de travail / amplitude des tournées roadman.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 194 POINTAGE, code_status_record = '1'), filtré aux
+      labels START_DAY / END_DAY (idlabel 2685 / 2686), rattaché au roadman via task_has_resources
+      × resources (type 2 = PERSON). Conservé uniquement si un roadman est rattaché.
+
+      [GRAIN]
+      1 ligne par task_id (un pointage). ~43k lignes, 91 roadmen, depuis 2022. Une journée de
+      roadman = typiquement 2 pointages (un START_DAY + un END_DAY).
+
+      [NOTES]
+      Pas de notion de produit ni de flux. Pour reconstruire une amplitude de journée, apparier
+      START_DAY et END_DAY d'un même roadman sur date_pointage_jour.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_id
-        description: >
-          Identifiant unique de la tâche de pointage.
+        description: "Identifiant de la tâche de pointage Oracle (EVS.TASK). PK de ce modèle."
         tests:
+          - unique
           - not_null
-
       - name: company_id
-        description: >
-          Identifiant de l'entreprise (idcompany_peer de la tâche).
+        description: "Client (peer company) rattaché à la tâche. FK → dim_neshu__company."
+      - name: resources_roadman_id
+        description: "Roadman ayant pointé. FK → stg_oracle_neshu__resources (idresources, type 2 = PERSON). Toujours renseigné (filtre du modèle)."
         tests:
           - not_null
-
-      - name: resources_roadman_id
-        description: >
-          Identifiant de la ressource roadman (idresources_type=2) associée à la tâche.
-
       - name: roadman_code
-        description: >
-          Code métier du roadman associé à la tâche.
+        description: "Code métier du roadman."
 
+      # --- STATUT / TYPE ---
       - name: status_code
         description: >
-          Code statut de la tâche (depuis task_status).
-
+          Code du statut de la tâche de pointage (task_status.code). En pratique toujours VALIDE
+          (le modèle ne filtre pas le statut, mais seuls des pointages validés existent).
+        tests:
+          - accepted_values:
+              arguments:
+                values: [VALIDE, FAIT, ANNULE, ANOMALIE, PREVU, ENCOURS, ACQUITTE, ENATTENTE]
+              config:
+                severity: warn
       - name: label_code
         description: >
-          Code du label de la tâche. Filtré sur START_DAY (idlabel=2685).
-
-      - name: date_pointage_jour
-        description: >
-          Date du jour du pointage (sans l'heure), extraite de real_start_date.
+          Type de pointage. Valeurs : START_DAY (début de journée), END_DAY (fin de journée).
         tests:
-          - not_null
+          - accepted_values:
+              arguments:
+                values: [START_DAY, END_DAY]
+              config:
+                severity: warn
 
+      # --- DATES ---
       - name: date_pointage
-        description: >
-          Timestamp du pointage
+        description: "Date et heure réelle du pointage (real_start_date)."
         tests:
           - not_null
+      - name: date_pointage_jour
+        description: "Jour du pointage (date_pointage tronqué au jour) — clé d'appariement START_DAY/END_DAY par roadman."
+
+      # --- MÉTADONNÉES ---
+      - name: created_at
+        description: "Timestamp de création en source."
+        tests:
+          - not_null
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        tests:
+          - not_null
+

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -90,105 +90,162 @@ models:
 
   - name: int_oracle_neshu__chargement_tasks
     description: >
-      Table intermédiaire des tâches de chargement machine.
-      Filtrée sur les tâches de type CHARGEMENT (idtask_type=13) 
-      avec statut FAIT/VALIDE/ANNULE et label du chargement (LOADING / REMOVING).
-      
+      [QUOI MÉTIER]
+      Chargements (et retraits) de produits dans les distributeurs NESHU : une ligne par
+      produit chargé lors d'une tâche de chargement machine. Brique de base de l'analyse
+      consommation / réassort.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 13 CHARGEMENT MACHINE, statuts FAIT/VALIDE/ANNULE/
+      ANOMALIE, code_status_record = '1') croisé avec task_has_product (grain ligne produit),
+      enrichi company/device/product/location, label de chargement (LOADING/REMOVING), roadman
+      (resources type 2) et véhicule (resources type 3). Quantité ramenée en unités de base via
+      les coefficients de conditionnement ; valorisation = quantité × prix d'achat.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une tâche). ~1,14M lignes (~333k tâches),
+      depuis 2022. Incrémental (merge sur task_product_id).
+
+      [NOTES]
+      load_type_code distingue chargement (LOADING, ~99,7%) et retrait (REMOVING). Les colonnes
+      product_source_id / product_destination_id sont des références polymorphes (cf. leur _type).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de chargement Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-        
+      - name: device_id
+        description: "Distributeur (machine) chargé. FK → dim_neshu__device."
+        data_type: int64
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company). FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit"
+        description: "Produit chargé/retiré. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
-      - name: roadman_id
-        description: "ID du roadman associé à la tâche, lien avec la table RESOURCES"
-        data_type: int64
-
-      - name: vehicle_id
-        description: "ID du véhicule associé à la tâche, lien avec la table RESOURCES"
-        data_type: int64
-
       - name: location_id
-        description: "ID de la localisation de la tâche"
+        description: "Localisation de la tâche. FK → stg_oracle_neshu__location."
         data_type: int64
-        
-      - name: device_code
-        description: "Code métier du device (numéro de série)"
-        data_type: string
-        
-      - name: product_code
-        description: "Code métier du produit"
-        data_type: string
-        
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité source. Référence polymorphe : la table cible est nommée par
+          product_source_type (RESOURCES → resources, DEVICE → device, COMPANY → company). Pour le
+          chargement, type = RESOURCES (stock véhicule/roadman). Pas une FK produit malgré le nom.
+        data_type: int64
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité destination. Référence polymorphe : table cible nommée par
+          product_destination_type. Pour le chargement, type = DEVICE → le distributeur rempli.
+        data_type: int64
+      - name: roadman_id
+        description: "Roadman ayant effectué le chargement. FK → stg_oracle_neshu__resources (idresources, type 2 = PERSON)."
+        data_type: int64
+      - name: vehicle_id
+        description: "Véhicule utilisé. FK → stg_oracle_neshu__resources (idresources, type 3 = VEHICLE)."
+        data_type: int64
+
+      # --- CODES / LIBELLÉS ---
       - name: company_code
-        description: "Code client de l'entreprise"
+        description: "Code client de l'entreprise."
         data_type: string
-        
+      - name: device_code
+        description: "Code métier du device (numéro de série)."
+        data_type: string
+      - name: product_code
+        description: "Code métier du produit."
+        data_type: string
+      - name: roadman_code
+        description: "Code métier du roadman."
+        data_type: string
+      - name: vehicle_code
+        description: "Code métier du véhicule."
+        data_type: string
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche (périmètre filtré aux statuts pertinents). Valeurs :
+          FAIT (réalisé, majoritaire), ANNULE, VALIDE, ANOMALIE.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, ANNULE, VALIDE, ANOMALIE]
+              config:
+                severity: warn
+      - name: load_type_code
+        description: >
+          Type d'opération (label de la tâche). Valeurs : LOADING (chargement, ~99,7%),
+          REMOVING (retrait de produit).
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [LOADING, REMOVING]
+              config:
+                severity: warn
+      - name: product_source_type
+        description: "Type de l'entité source = table cible de product_source_id. Chargement : RESOURCES (stock véhicule), ou NULL/DEVICE (rare)."
+        data_type: string
+      - name: product_destination_type
+        description: "Type de l'entité destination = table cible de product_destination_id. Chargement : DEVICE (le distributeur), ou NULL/RESOURCES (rare)."
+        data_type: string
+      - name: task_location_info
+        description: "Informations d'accès / localisation de la tâche."
+        data_type: string
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle du chargement. Clé de partitionnement."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
       - name: unit_coeff_multi
-        description: "Coefficient multiplicateur d'unité du produit"
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
         data_type: int64
-
       - name: unit_coeff_div
-        description: "Coefficient diviseur d'unité du produit"
+        description: "Coefficient diviseur de conditionnement."
         data_type: int64
-
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
         data_type: int64
-
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-        
-      - name: load_quantity
-        description: "Quantité produit chargée ou retirée"
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
         data_type: int64
 
-      - name: load_valuation
-        description: "Valorisation du chargement (quantité * prix unitaire)"
+      # --- MESURES ---
+      - name: load_quantity
+        description: "Quantité chargée (ou retirée) en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
         data_type: int64
-        
+      - name: load_valuation
+        description: "Valorisation du chargement en euros = load_quantity × prix d'achat unitaire. Mesure additive."
+        data_type: int64
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification (filtre incrémental)."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -1495,21 +1495,52 @@ models:
 
   - name: int_oracle_neshu__valorisation_parc_machines
     description: >
-      Table intermédiaire de valorisation du parc machines NESHU par device_name et device_group en filtrant sur les clients actifs NESHU
-      et calculant la valorisation à partir des références de capacité et des prix d'achat des produits lié à chaque machine/groupe de machines.
+      [QUOI MÉTIER]
+      Valorisation théorique du parc machines NESHU : pour chaque modèle de machine (device_name)
+      et son groupe, le nombre de machines actives et la valeur totale du stock théorique
+      qu'elles devraient contenir (capacité × prix d'achat des produits).
+
+      [COMMENT CONSTRUITE]
+      Part des clients actifs NESHU (dim_neshu__company : is_active, company_type CLIENTNESHU,
+      code 'CN' + 4 chiffres) et de leurs machines actives (dim_neshu__device). Chaque machine est
+      rattachée à un device_group (ref_oracle_neshu__groupement_machine), valorisée via les capacités
+      de référence (ref_oracle_neshu__valo_machine_capacite) et les prix d'achat produit
+      (dim_neshu__product), puis agrégée par (device_name, device_group).
+
+      [GRAIN]
+      1 ligne par (device_name, device_group). ~27 lignes (9 groupes), couvrant ~970 machines
+      actives pour ~101 k€ de stock théorique total.
+
+      [NOTES]
+      Modèle agrégé (pas de grain machine ni de FK device/company en sortie) : c'est une vue
+      de référence du parc, reconstruite à chaque run (cf. dbt_updated_at / dbt_invocation_id).
+      Valorisation = stock *théorique* (capacité de référence), pas le stock réel constaté.
     columns:
+      # --- GRAIN ---
       - name: device_name
-        description: "Nom de la machine"
+        description: "Modèle / désignation de la machine. Composante du grain."
         tests:
           - not_null
       - name: device_group
-        description: "Groupe de la machine (mapping avec référence)"
+        description: "Groupe de machines (mapping ref_oracle_neshu__groupement_machine). Composante du grain."
         tests:
           - not_null
+
+      # --- MESURES ---
       - name: nombre_machines
-        description: "Nombre de machines"
+        description: "Nombre de machines actives de ce modèle/groupe (clients NESHU actifs). Mesure additive."
       - name: valorisation_totale_machine
-        description: "Valorisation totale du parc machines"
+        description: "Valeur totale du stock théorique (€) pour ce modèle/groupe = somme sur les machines de (capacité de référence × prix d'achat produit). Mesure additive."
+
+      # --- MÉTADONNÉES D'EXÉCUTION ---
+      - name: dbt_updated_at
+        description: "Timestamp de calcul du modèle (current_timestamp au moment du run dbt). Le modèle est entièrement recalculé à chaque run."
+      - name: dbt_invocation_id
+        description: "Identifiant d'invocation dbt du run ayant produit la ligne (traçabilité)."
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [device_name, device_group]
 
   - name: int_oracle_neshu__pointage_tasks
     description: >

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -252,81 +252,120 @@ models:
 
   - name: int_oracle_neshu__livraison_tasks
     description: >
-      Table intermédiaire des tâches de bon de livraison.
-      Filtrée sur les tâches de type BON LIVRAISON (idtask_type=101) 
-      avec statut FAIT/VALIDE/ANNULE.
-      
+      [QUOI MÉTIER]
+      Lignes de bons de livraison NESHU : une ligne par produit livré sur une tâche de type
+      BON LIVRAISON. Suivi des livraisons de produits (distinct du chargement machine).
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 101 BON LIVRAISON, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi company
+      et product. Quantité ramenée en unités de base via les coefficients de conditionnement ;
+      valorisation = quantité × prix d'achat.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un bon de livraison). ~3 962 lignes (~718 bons),
+      depuis fin 2022.
+
+      [NOTES]
+      Petit volume ; en pratique surtout des bons VALIDE. product_source_id / product_destination_id
+      sont des références polymorphes (cf. leur _type) ; pour la livraison, source et destination
+      valent COMPANY (ou la valeur littérale 'NONE' quand il n'y a pas d'entité).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de bon de livraison Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-        
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company). FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit"
+        description: "Produit livré. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-        
-      - name: product_code
-        description: "Code métier du produit"
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité source. Référence polymorphe : table cible nommée par
+          product_source_type (COMPANY → company, RESOURCES → resources, DEVICE → device).
+          Pour la livraison, type = COMPANY. Pas une FK produit malgré le nom.
+        data_type: int64
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité destination. Référence polymorphe : table cible nommée par
+          product_destination_type. Pour la livraison, type = COMPANY.
+        data_type: int64
+      - name: product_source_type
+        description: "Type de l'entité source = table cible de product_source_id. Livraison : COMPANY (ou 'NONE' si aucune)."
         data_type: string
-        
+      - name: product_destination_type
+        description: "Type de l'entité destination = table cible de product_destination_id. Livraison : COMPANY (ou 'NONE')."
+        data_type: string
+
+      # --- CODES ---
       - name: company_code
-        description: "Code client de l'entreprise"
+        description: "Code client de l'entreprise."
         data_type: string
-        
+      - name: product_code
+        description: "Code métier du produit."
+        data_type: string
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche (périmètre filtré). Valeurs autorisées : FAIT, VALIDE,
+          ANNULE, ANOMALIE ; en pratique surtout VALIDE (livraison validée) et quelques ANNULE.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle de la livraison."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-        
-      - name: quantity
-        description: "Quantité produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité livrée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
-        
+        description: "Valorisation de la livraison en euros = quantity × prix d'achat unitaire. Mesure additive."
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -833,125 +833,130 @@ models:
 
   - name: int_oracle_neshu__invendus_tasks
     description: >
-      Table intermédiaire des tâches d'invendus.
-      Filtrée sur les tâches de type INVENDUS (idtask_type=11)
-      avec statut FAIT/VALIDE/ANNULE et une destination non nulle (COMPANY ou RESOURCES).
-      Enrichie avec le véhicule associé à la tâche (resources_type=3 uniquement,
-      pas de roadman) via task_has_resources.
+      [QUOI MÉTIER]
+      Invendus NESHU : une ligne par produit retiré d'un distributeur car invendu / périmé, et
+      retourné au dépôt. Suivi des quantités et valeurs d'invendus (pertes / retours).
 
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 11 INVENDUS, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
+      code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product,
+      company et véhicule collecteur (resources type 3). La destination est résolue (destination_code).
+      Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un retrait d'invendus). ~5 344 lignes (~3 852 tâches),
+      depuis 2022.
+
+      [NOTES]
+      Flux : source = DEVICE (le distributeur) → destination = COMPANY (dépôt de retour).
+      Seules les lignes dont la destination se résout (destination_code non NULL) sont conservées.
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche d'invendus Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
-
       - name: product_id
-        description: "ID du produit"
+        description: "Produit invendu. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
       - name: resources_id
-        description: "ID du véhicule associé à la tâche (resources type=3, jointure via task_has_resources)"
+        description: "Véhicule ayant collecté les invendus. FK → stg_oracle_neshu__resources (idresources, type 3 = VEHICLE)."
         data_type: int64
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source** (d'où sont retirés les invendus). Référence polymorphe :
+          table cible nommée par product_source_type. Ici DEVICE → stg_oracle_neshu__device (le
+          distributeur). Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source (COMPANY ou RESOURCES)"
+        description: "Type de l'entité source = table cible de product_source_id. Valeur : DEVICE (le distributeur)."
         data_type: string
-
       - name: product_destination_id
-        description: "ID du produit de destination"
+        description: >
+          Identifiant de l'entité **destination** (où sont retournés les invendus). Référence
+          polymorphe : table cible nommée par product_destination_type. Ici COMPANY → company (dépôt).
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit de destination (COMPANY ou RESOURCES)"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeur : COMPANY (dépôt de retour)."
         data_type: string
 
+      # --- CODES ---
       - name: destination_code
-        description: "Code de destination du mouvement (entreprise ou ressource)"
+        description: "Code du dépôt de retour (company.code), résolu via product_destination_type = COMPANY. Toujours renseigné (filtre du modèle)."
         data_type: string
         tests:
           - not_null
-
       - name: company_code
-        description: "Code client de l'entreprise (company.code)"
+        description: "Code client de l'entreprise."
         data_type: string
-
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: vehicle_code
-        description: "Code métier du véhicule associé à la tâche (resources.code, type=3)"
+        description: "Code métier du véhicule collecteur."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
+        description: >
+          Code du statut de la tâche. Valeurs : FAIT (réalisé, très majoritaire), ANNULE,
+          ANOMALIE, VALIDE.
         data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
 
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle du retrait d'invendus."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
       - name: unit_coeff_multi
-        description: "Coefficient multiplicateur d'unité du produit"
-        data_type: int64
-
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
       - name: unit_coeff_div
-        description: "Coefficient diviseur d'unité du produit"
-        data_type: int64
-
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
       - name: quantity
-        description: "Quantité produit (avec coefficients unitaires)"
-        data_type: numeric
-
+        description: "Quantité d'invendus en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: numeric
+        description: "Valorisation des invendus en euros = quantity × prix d'achat unitaire. Mesure additive (pertes)."
 
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -710,105 +710,123 @@ models:
 
   - name: int_oracle_neshu__livraison_interne_tasks
     description: >
-      Table intermédiaire des tâches de Livraison interne.
-      Filtrée sur les tâches de type LIVRAISON INTERNE (idtask_type=161) 
-      avec statut FAIT/VALIDE/ANNULE.
-      
+      [QUOI MÉTIER]
+      Livraisons internes NESHU : une ligne par produit déplacé lors d'un mouvement de stock
+      interne (typiquement dépôt → véhicule pour approvisionner les roadmen). Suivi des quantités
+      et valeurs transférées entre entités internes.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 161 LIVRAISONS INTERNE, statuts FAIT/VALIDE/ANNULE/
+      ANOMALIE, code_status_record = '1') croisé avec task_has_product (grain ligne produit),
+      enrichi product. Source ET destination résolues selon leur type (COMPANY → company,
+      RESOURCES → resources). Quantité ramenée en unités de base.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'un mouvement interne). ~94k lignes (~9 048 tâches),
+      depuis début 2023.
+
+      [NOTES]
+      Seules les lignes dont la source ET la destination se résolvent sont conservées. En pratique
+      le flux dominant est COMPANY (dépôt) → RESOURCES (véhicule/roadman).
     columns:
+      # --- IDENTIFIANTS ---
       - name: task_product_id
-        description: "Clé primaire de task_has_product - Identifiant unique de la relation task-produit"
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
         data_type: int64
         tests:
           - unique
           - not_null
-          
       - name: task_id
-        description: "ID de la tâche (référence vers EVS.TASK)"
+        description: "Tâche de livraison interne Oracle (EVS.TASK)."
         data_type: int64
         tests:
           - not_null
-        
       - name: company_id
-        description: "ID de l'entreprise cliente (peer company)"
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
         data_type: int64
-          
       - name: product_id
-        description: "ID du produit télémétrique"
+        description: "Produit déplacé. FK → dim_neshu__product."
         data_type: int64
         tests:
           - not_null
-
       - name: product_source_id
-        description: "ID du produit source"
+        description: >
+          Identifiant de l'entité **source** (d'où part le produit). Référence polymorphe : table
+          cible nommée par product_source_type — COMPANY → stg_oracle_neshu__company (dépôt),
+          RESOURCES → stg_oracle_neshu__resources (véhicule). Pas une FK produit.
         data_type: int64
-
       - name: product_source_type
-        description: "Type du produit source"
+        description: "Type de l'entité source = table cible de product_source_id. Valeurs : COMPANY (dépôt, majoritaire), RESOURCES (véhicule)."
         data_type: string
-
       - name: product_destination_id
-        description: "ID du produit de destination"
+        description: >
+          Identifiant de l'entité **destination** (où va le produit). Référence polymorphe : table
+          cible nommée par product_destination_type (COMPANY → company, RESOURCES → resources).
         data_type: int64
-
       - name: product_destination_type
-        description: "Type du produit de destination"
+        description: "Type de l'entité destination = table cible de product_destination_id. Valeurs : RESOURCES (véhicule, majoritaire), COMPANY (dépôt)."
         data_type: string
 
-      - name: destination_code
-        description: "Code de destination du produit"
-        data_type: string
-
+      # --- CODES ---
       - name: source_code
-        description: "Code source du produit"
+        description: "Code de l'entité source, résolu selon product_source_type (company.code si COMPANY, resources.code si RESOURCES)."
         data_type: string
-        
+      - name: destination_code
+        description: "Code de l'entité destination, résolu selon product_destination_type (company.code si COMPANY, resources.code si RESOURCES)."
+        data_type: string
       - name: product_code
-        description: "Code métier du produit"
+        description: "Code métier du produit."
         data_type: string
-
       - name: task_status_code
-        description: "Code statut de la tâche (FAIT, VALIDE, ANNULE)"
-        data_type: string 
-        
+        description: >
+          Code du statut de la tâche. Valeurs : FAIT (réalisé, majoritaire), VALIDE (validé),
+          ANNULE, ANOMALIE.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
       - name: task_start_date
-        description: "Date et heure réelle de la tâche"
+        description: "Date et heure réelle du mouvement interne."
         data_type: timestamp
         tests:
           - not_null
 
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
       - name: base_unit_quantity
-        description: "Quantité unitaire (sans conditionnement)"
-        data_type: int64
-
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
       - name: product_unit_price_task
-        description: "Prix unitaire hors tax du produit au moment de la tâche"
-
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
       - name: product_unit_price_latest
-        description: "Dernier Prix d'achat unitaire hors tax du produit"
-        data_type: int64
-        
-      - name: quantity
-        description: "Quantité produit"
-        data_type: int64
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
 
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité déplacée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
-        description: "Valorisation du produit (quantité * prix unitaire)"
-        data_type: int64
-        
+        description: "Valorisation du mouvement en euros = quantity × prix d'achat unitaire. Mesure additive."
+
+      # --- MÉTADONNÉES ---
       - name: updated_at
-        description: "Timestamp de dernière modification (pour incrément)"
+        description: "Timestamp de dernière modification en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: created_at
-        description: "Timestamp de création"
+        description: "Timestamp de création en source."
         data_type: timestamp
         tests:
           - not_null
-          
       - name: extracted_at
-        description: "Timestamp d'extraction depuis Oracle"
+        description: "Timestamp d'extraction depuis Oracle."
         data_type: timestamp
         tests:
           - not_null

--- a/models/intermediate/yuman/_yuman__intermediate_models.yml
+++ b/models/intermediate/yuman/_yuman__intermediate_models.yml
@@ -271,15 +271,15 @@ models:
 
       # --- DIMENSIONS RATTACHEES (FK) ---
       - name: material_id
-        description: Identifiant du matériel concerné.
+        description: "Matériel concerné. FK → stg_yuman__materials / dim_technique__material."
       - name: site_id
-        description: Identifiant du site client.
+        description: "Site client concerné. FK → stg_yuman__sites / dim_technique__site."
       - name: client_id
-        description: Identifiant du client.
+        description: "Client concerné. FK → stg_yuman__clients / dim_technique__client."
       - name: technician_id
-        description: Identifiant du technicien affecté au bon de travail.
+        description: "Technicien affecté au bon de travail. FK → stg_yuman__users / dim_technique__technician."
       - name: manager_id
-        description: Identifiant du manager associé.
+        description: "Manager associé. FK → stg_yuman__users."
 
       # --- ETAT METIER ---
       - name: intervention_state
@@ -314,9 +314,13 @@ models:
               config:
                 severity: warn
       - name: workorder_status
-        description: Statut brut du bon de travail Yuman (Closed, In progress, Scheduled, …).
+        description: >
+          Statut brut du bon de travail Yuman. Valeurs : Closed (clôturé), Scheduled (planifié),
+          In progress (en cours). NULL si la demande n'a pas de bon de travail.
       - name: demand_status
-        description: Statut brut de la demande d'intervention Yuman (Closed, Accepted, Open, Rejected).
+        description: >
+          Statut brut de la demande Yuman. Valeurs : Closed (clôturée), Rejected (rejetée),
+          Accepted (acceptée), Open (ouverte).
       - name: is_realized
         description: >
           True si l'intervention a réellement été réalisée (= intervention_state 'REALISEE' :

--- a/models/intermediate/yuman/_yuman__intermediate_models.yml
+++ b/models/intermediate/yuman/_yuman__intermediate_models.yml
@@ -242,20 +242,29 @@ models:
 
   - name: int_yuman__interventions
     description: >
-      Modèle intermédiaire consolidé des interventions Yuman, source de vérité unique pour
-      la qualification métier, la tarification automatique et le délai de traitement.
-      Construit sur int_yuman__demands_workorders_enriched, il fusionne ici la logique qui
-      était auparavant éclatée en deux faits chaînés (fct_technique__workorder_pricing puis
-      fct_neshu__workorder_delai), supprimant ainsi les dépendances fait→fait.
-      Couvre : (1) normalisation type/machine/métropole + extraction du code postal,
-      (2) tarification automatique (récurrence → palier de remise → montant via table de
-      référence), (3) délai en jours ouvrés et son type (J+0,5 … J++),
-      (4) qualification métier via intervention_state.
-      Périmètre : exclut les bons de travail "secs" (sans demande rattachée, demand_id NULL),
-      dépourvus de référentiel client/partenaire fiable (partner_name, client_id… NULL) qui
-      fausserait la clé d'intervention aval et la tarification (~44 lignes en prod).
-      Grain : 1 ligne par couple (demand_id, workorder_id). Inclut les demandes sans bon de
-      travail (workorder_id NULL → DEMANDE_OUVERTE / DEMANDE_REJETEE) ; exclut l'inverse.
+      [QUOI MÉTIER]
+      Modèle consolidé des interventions Yuman : source de vérité unique pour la qualification
+      métier (état), la tarification automatique et le délai de traitement. C'est la table
+      pivot des interventions techniques, consommée par les marts technique/neshu.
+
+      [COMMENT CONSTRUITE]
+      Construit sur int_yuman__demands_workorders_enriched ; fusionne la logique auparavant
+      éclatée en deux faits chaînés (fct_technique__workorder_pricing puis
+      fct_neshu__workorder_delai), supprimant les dépendances fait→fait. Couvre :
+      (1) normalisation type/machine/métropole + extraction du code postal,
+      (2) tarification automatique (récurrence → palier de remise → montant via table de réf),
+      (3) délai en jours ouvrés et son type (J+0,5 … J++),
+      (4) qualification métier via intervention_state (repris en passthrough de l'enriched).
+
+      [GRAIN]
+      1 ligne par couple (demand_id, workorder_id). ~18,9k lignes (18 872). Inclut les demandes
+      sans bon de travail (workorder_id NULL → DEMANDE_OUVERTE / DEMANDE_REJETEE) ; dédupliqué
+      via qualify (le fan-out de l'enriched est tranché ici).
+
+      [NOTES]
+      Périmètre : exclut les bons de travail "secs" (orphelins, demand_id NULL, ~44 lignes),
+      dépourvus de référentiel client/partenaire fiable qui fausserait la clé d'intervention
+      et la tarification. À l'inverse de l'enriched (qui les conserve via is_orphan_workorder).
     columns:
       # --- CLES / GRAIN ---
       - name: demand_id

--- a/models/intermediate/yuman/_yuman__intermediate_models.yml
+++ b/models/intermediate/yuman/_yuman__intermediate_models.yml
@@ -3,69 +3,98 @@ version: 2
 models:
   - name: int_yuman__demands_workorders_enriched
     description: >
-      Vue intermédiaire unifiée regroupant les demandes d'intervention (workorder_demands)
-      et les interventions (workorders). 
-      Ce modèle combine également les informations associées aux clients, sites, matériels, 
-      catégories et utilisateurs. 
-      Il sert de base de données centrale pour les analyses et modèles marts relatifs aux 
-      opérations de maintenance et d'intervention.
+      [QUOI MÉTIER]
+      Vue unifiée des demandes d'intervention et des bons de travail Yuman, enrichie des
+      entités liées (client, site, matériel, catégories, contact, utilisateur/technicien).
+      Base centrale de toute la chaîne intervention/maintenance (technique + suivi partenaire).
 
+      [COMMENT CONSTRUITE]
+      Full join demandes (workorder_demands) ↔ bons de travail (workorders), puis lookups
+      sur les 9 entités Yuman (clients, sites, materials, categories, users, contacts…).
+      Définit ici l'état métier canonique intervention_state, source de vérité unique reprise
+      en passthrough par int_yuman__interventions et dérivée par fct_technique__suivi_partenaire.
+
+      [GRAIN]
+      1 ligne par couple (demand_id, workorder_id). ~18,9k lignes. Inclut 65 bons de travail
+      orphelins (demand_id NULL, issus du full join) et 559 demandes sans bon de travail
+      (workorder_id NULL). Léger fan-out (~64 lignes en double sur le couple) non dédupliqué
+      ici — int_yuman__interventions tranche via qualify.
+
+      [NOTES]
+      Aucun filtre de périmètre à ce stade : les bons de travail orphelins sont conservés
+      (flag is_orphan_workorder) ; c'est l'aval qui filtre. Les colonnes préfixées
+      (client_*, site_*, material_*) viennent du staging Yuman (noms génériques co-joints).
     columns:
       # --- DEMANDES D'INTERVENTION ---
       - name: demand_id
-        description: Identifiant unique de la demande d'intervention.
+        description: Identifiant de la demande d'intervention Yuman (clé métier de la demande). NULL pour un bon de travail orphelin (65 lignes).
       - name: workorder_id
-        description: Identifiant du bon de travail associé à la demande (si existant).
+        description: Identifiant du bon de travail rattaché. NULL si la demande n'a pas (encore) de bon de travail (559 lignes).
       - name: material_id
-        description: Identifiant du matériel concerné par la demande.
+        description: "Matériel concerné par la demande. FK → stg_yuman__materials / dim_technique__material."
       - name: site_id
-        description: Identifiant du site client concerné.
+        description: "Site client concerné. FK → stg_yuman__sites / dim_technique__site."
       - name: client_id
-        description: Identifiant du client concerné.
+        description: "Client concerné. FK → stg_yuman__clients / dim_technique__client."
       - name: user_id
-        description: Identifiant de l'utilisateur ayant créé la demande.
+        description: "Utilisateur Yuman ayant créé la demande. FK → stg_yuman__users."
       - name: demand_description
-        description: Description textuelle de la demande d'intervention.
+        description: >
+          Texte libre de la demande (saisi par le créateur). Sert notamment au repli
+          d'extraction du code postal en aval quand le site n'en a pas.
       - name: demand_status
-        description: Statut actuel de la demande d'intervention.
+        description: >
+          Statut brut de la demande Yuman. Valeurs : Closed (clôturée, ~18,1k),
+          Rejected (rejetée), Accepted (acceptée, en attente de bon de travail),
+          Open (ouverte). NULL pour les bons de travail orphelins.
       - name: demand_reject_comment
-        description: Commentaire éventuel de rejet de la demande.
+        description: Commentaire de rejet de la demande (renseigné quand demand_status = 'Rejected').
       - name: demand_created_at
-        description: Date et heure de création de la demande d'intervention.
+        description: Timestamp de création de la demande.
       - name: demand_updated_at
-        description: Date et heure de la dernière mise à jour de la demande.
+        description: Timestamp de dernière mise à jour de la demande.
 
       # --- CATEGORIE DEMANDE ---
       - name: demand_category_name
-        description: Nom de la catégorie associée à la demande d'intervention.
+        description: >
+          Catégorie de la demande, libellé composite suivant le motif
+          `<TYPE> <DÉLAI/PROG> - <PARTENAIRE>` (ex. 'CURATIVE J+2 - NESHU',
+          'PREVENTIVE PROG - BRITA', 'INSTALLATION PROG - NESHU'). ~40 combinaisons.
 
       # --- INTERVENTIONS / WORKORDERS ---
       - name: technician_id
-        description: Identifiant du technicien affecté à l'intervention.
+        description: "Technicien affecté au bon de travail. FK → stg_yuman__users."
       - name: workorder_number
-        description: Numéro unique du bon de travail.
+        description: Numéro lisible du bon de travail dans Yuman.
       - name: workorder_category
-        description: Catégorie de l'intervention (préventive, curative, etc.).
+        description: >
+          Catégorie brute du bon de travail, même motif que demand_category_name
+          (`<TYPE> <DÉLAI/PROG> - <PARTENAIRE>`, ex. 'CURATIVE J+2 - NESHU'). NULL si pas de
+          bon de travail (~800 lignes).
       - name: workorder_status
-        description: Statut actuel du bon de travail.
+        description: >
+          Statut brut du bon de travail Yuman. Valeurs : Closed (clôturé, ~18,1k),
+          Scheduled (planifié), In progress (en cours). NULL si la demande n'a pas de bon de travail.
       - name: workorder_title
-        description: Titre ou résumé de l'intervention.
+        description: Titre ou résumé du bon de travail.
       - name: workorder_description
         description: Description détaillée du bon de travail.
       - name: workorder_report
-        description: Compte-rendu ou rapport de l'intervention réalisée.
+        description: Compte-rendu d'intervention saisi par le technicien.
       - name: workorder_technician_name
-        description: Nom du technicien affecté.
+        description: Nom du technicien affecté au bon de travail.
       - name: workorder_date_creation
         description: Date de création du bon de travail.
       - name: workorder_motif_non_intervention
-        description: Motif de non-intervention, si applicable.
+        description: >
+          Motif de non-intervention. Renseigné ⇒ l'intervention n'a pas eu lieu (alimente
+          is_workorder_not_done et l'état NON_REALISEE). Ex. 'Erreur de saisie', 'Résolue client'.
       - name: workorder_detail_non_intervention
-        description: Détails supplémentaires sur la non-intervention.
+        description: Détail complémentaire du motif de non-intervention, si applicable.
       - name: workorder_raison_mise_en_pause
-        description: Raison de mise en pause du bon de travail.
+        description: Raison de mise en pause du bon de travail (renseigné ⇒ pause active ou historique).
       - name: workorder_explication_mise_en_pause
-        description: Explications détaillées concernant la mise en pause.
+        description: Explication détaillée de la mise en pause.
       - name: is_workorder_paused
         description: >
           True si l'intervention est en pause (au moins un des champs
@@ -98,6 +127,7 @@ models:
           DEMANDE_OUVERTE (pas de workorder, demande Open) ;
           DEMANDE_REJETEE (pas de workorder, demande Rejected) ;
           AUTRE (filet de sécurité, capte tout statut Yuman futur non prévu).
+          Filtrer intervention_state = 'REALISEE' pour les interventions réellement réalisées.
         tests:
           - accepted_values:
               arguments:
@@ -125,45 +155,51 @@ models:
           référentiel partenaire/client/site (tous NULL). Définition unique : reprise par
           int_yuman__interventions (qui les exclut) et fct_technique__suivi_partenaire (flag).
       - name: workorder_necessite_intervenir
-        description: Indique si une intervention est nécessaire.
+        description: Champ Yuman du compte-rendu — indique si une intervention sur site est nécessaire.
       - name: workorder_si_non_pourquoi
-        description: Justification en cas de non-intervention.
+        description: Justification saisie dans le compte-rendu quand aucune intervention n'est nécessaire.
       - name: date_planned
         description: Date planifiée de l'intervention.
       - name: date_started
         description: Date de début réel de l'intervention.
       - name: date_done
-        description: Date de fin ou de clôture de l'intervention.
+        description: Date de fin / clôture de l'intervention.
 
       # --- CLIENTS ---
       - name: partner_name
-        description: Nom du partenaire associé au client.
+        description: >
+          Partenaire (donneur d'ordre) du client. Valeurs : NESHU, AUUM, BRITA, TWYD,
+          FONTAINCO, NU, EXPRESSO, DAAN. Détermine les paliers de remise tarifaire.
       - name: client_code
-        description: Code unique du client.
+        description: Code unique du client (Yuman).
       - name: client_name
         description: Nom du client.
       - name: client_category
-        description: Catégorie ou segment du client.
+        description: >
+          Segment commercial du client. Valeurs : PREMIUM, VIP, OR, ARGENT, BRONZE.
+          **Renseigné uniquement pour les clients du partenaire NESHU** — NULL attendu
+          pour les autres partenaires (ce n'est pas une donnée manquante). Quelques
+          valeurs sales résiduelles côté NESHU (chaîne vide, littéral 'nan') = non renseigné.
       - name: client_is_active
-        description: Indicateur précisant si le client est actif.
+        description: True si le client est actif dans Yuman.
 
       # --- SITES ---
       - name: site_code
-        description: Code unique du site client.
+        description: Code unique du site client (Yuman).
       - name: site_name
         description: Nom du site.
       - name: site_address
         description: Adresse complète du site.
       - name: site_postal_code
-        description: Code postal du site.
+        description: Code postal du site (tel que saisi dans Yuman ; peut être NULL ou '00000', corrigé en aval).
 
       # --- CONTACT DU SITE ---
       - name: contact_id
-        description: Identifiant du contact le plus récemment créé rattaché au site.
+        description: "Contact le plus récemment créé rattaché au site. FK → stg_yuman__contacts."
       - name: contact_name
         description: Nom du contact.
       - name: contact_title
-        description: Civilité du contact (mr, mrs, etc.).
+        description: "Civilité du contact. Valeurs : mr, ms (souvent NULL)."
       - name: contact_phone
         description: Numéro de téléphone fixe du contact.
       - name: contact_mobile
@@ -185,21 +221,24 @@ models:
 
       # --- CATEGORIE MATERIEL ---
       - name: material_category
-        description: Catégorie fonctionnelle du matériel.
+        description: >
+          Désignation / modèle du matériel (haute cardinalité, ce n'est pas une énumération
+          fermée) — ex. 'MGZ', 'MINITOWER MOMENTO', 'MILANO GRAIN FTS60E + MODULO'. Sert de
+          base à la normalisation machine en aval (machine_clean / famille_neshu).
 
       # --- UTILISATEURS ---
       - name: manager_id
-        description: Identifiant du manager associé à l'utilisateur.
+        description: "Manager associé à l'utilisateur. FK → stg_yuman__users."
       - name: user_name
-        description: Nom de l'utilisateur ou du créateur de la demande.
+        description: Nom de l'utilisateur / créateur de la demande.
       - name: user_type
-        description: Type d'utilisateur (technicien, manager, client, etc.).
+        description: "Rôle Yuman de l'utilisateur. Valeurs : guest (~17,4k), manager (souvent NULL)."
       - name: is_manager_as_technician
-        description: Indique si un manager agit en tant que technicien.
+        description: True si un manager agit comme technicien sur le bon de travail.
 
       # --- AGENCE TECHNICIEN (MAPPING) ---
       - name: technician_agency_stock
-        description: Agence de rattachement du technicien selon le mapping fourni de Vincent.
+        description: Agence de rattachement du technicien (mapping fourni par Vincent).
 
   - name: int_yuman__interventions
     description: >

--- a/models/intermediate/zoho_desk/_zoho_desk__intermediate_models.yml
+++ b/models/intermediate/zoho_desk/_zoho_desk__intermediate_models.yml
@@ -211,167 +211,187 @@ models:
         description: "Temps de réponse total cumulé (minutes)."
   - name: int_zoho_desk__ticket_status_events
     description: >
-      Une ligne par changement de statut — vue brute mais normalisée.
-      Source : stg_zoho_desk__ticket_history × stg_zoho_desk__ticket_history_event_info,
-      filtré sur property_name = 'Status'.
-      Inclut les événements de création : Zoho les enregistre avec
-      previous_value / updated_value à NULL et la valeur initiale dans
-      property_value. On lit ce dernier via COALESCE et on flagge la ligne
-      avec is_creation_event = true.
-      Les statuts bruts (français + anciens libellés anglais hérités) sont
-      enrichis via le seed ref_zoho_desk__status_mapping pour exposer
-      status_type / is_on_hold / is_closed.
-      Aucune sémantique métier n'est appliquée ici (closed/reopened/etc.) :
-      ces règles sont laissées aux marts pour rester flexible.
-      event_date_paris est calculé en Europe/Paris pour aligner avec les
-      rapports métier.
+      [QUOI MÉTIER]
+      Une ligne par changement de statut d'un ticket (incluant la création). Brique d'analyse du
+      cycle de vie : ouvertures, mises en attente, fermetures, réouvertures.
+
+      [COMMENT CONSTRUITE]
+      stg_zoho_desk__ticket_history × ticket_history_event_info, filtré property_name = 'Status'.
+      Les événements de création (prev/new à NULL, valeur initiale dans property_value) sont lus via
+      COALESCE et flaggés is_creation_event. Les statuts bruts (FR + anciens libellés EN hérités)
+      sont normalisés via le seed ref_zoho_desk__status_mapping (status_type / is_on_hold / is_closed).
+
+      [GRAIN]
+      1 ligne par événement de changement de statut. ~66,4k événements, ~22,2k tickets (dont ~23,2k
+      créations), depuis février 2024.
+
+      [NOTES]
+      Aucune sémantique métier (closed/reopened) appliquée ici — laissée aux marts. event_date_paris
+      en Europe/Paris. Filtrer event_name != 'TicketMergedMaster' pour exclure le bruit des fusions.
     columns:
       - name: ticket_id
-        description: "FK vers le ticket concerné"
+        description: "Ticket concerné. FK → stg_zoho_desk__tickets / int_zoho_desk__ticket_enriched."
         tests:
           - not_null
           - relationships:
-              arguments:
-                to: ref('stg_zoho_desk__tickets')
-                field: ticket_id
-              config:
-                severity: warn
+              arguments: {to: "ref('stg_zoho_desk__tickets')", field: ticket_id}
+              config: {severity: warn}
       - name: event_at
-        description: "Date/heure exacte de l'événement (TIMESTAMP UTC)"
+        description: "Date/heure exacte de l'événement (TIMESTAMP UTC)."
         tests:
           - not_null
       - name: event_date_paris
-        description: "Date de l'événement (Europe/Paris) — colonne de partition"
+        description: "Date de l'événement en Europe/Paris (colonne de partition)."
       - name: event_name
         description: >
-          Nom de l'action Zoho ayant déclenché le changement (méta-événement parent).
-          Valeurs : TicketUpdated (modification utilisateur classique),
-          TicketCreated (création), TicketMergedMaster (effet de bord d'une fusion
-          de tickets — Zoho ré-estampille les propriétés sans changement réel).
-          Permet aux marts de filtrer le bruit des fusions.
+          Action Zoho parente ayant déclenché le changement. Valeurs : TicketUpdated (modif
+          classique), TicketCreated (création), TicketMergedMaster (effet de bord d'une fusion de
+          tickets — Zoho ré-estampille sans changement réel ; à filtrer pour exclure le bruit).
+        tests:
+          - accepted_values:
+              arguments: {values: [TicketUpdated, TicketCreated, TicketMergedMaster]}
+              config: {severity: warn}
       - name: actor_id
-        description: "ID Zoho de l'acteur (agent / contact / système)"
+        description: "ID Zoho de l'acteur (agent / contact / système)."
       - name: actor_name
-        description: "Nom lisible de l'acteur"
+        description: "Nom lisible de l'acteur."
       - name: actor_type
-        description: "Type d'acteur : AGENT, CONTACT, SYSTEM"
+        description: "Type d'acteur. Valeurs : Agent, Contact, Workflow (automatisation), ou NULL."
+        tests:
+          - accepted_values:
+              arguments: {values: [Agent, Contact, Workflow]}
+              config: {severity: warn}
       - name: prev_status
-        description: "Libellé brut du statut avant la transition. NULL pour les événements de création."
+        description: "Libellé brut du statut avant la transition. NULL pour les créations."
       - name: new_status
-        description: >
-          Libellé brut du statut après la transition. Pour les événements de
-          création, contient le statut initial du ticket (lu depuis property_value).
+        description: "Libellé brut du statut après (pour les créations : statut initial, lu depuis property_value)."
       - name: is_creation_event
-        description: >
-          BOOLEAN — true si la ligne représente la création initiale du ticket
-          (prev_status IS NULL, new_status = statut initial). Permet de
-          distinguer creation vs changement de statut classique.
+        description: "True si la ligne représente la création du ticket (prev NULL, new = statut initial)."
       - name: prev_status_type
-        description: "Catégorie normalisée du statut avant : Open / On Hold / Closed (depuis le seed)"
+        description: "Catégorie normalisée du statut avant : Open / On Hold / Closed (seed status_mapping)."
       - name: prev_is_on_hold
-        description: "BOOLEAN — le statut avant était une attente (depuis le seed)"
+        description: "True si le statut avant était une attente (seed)."
       - name: prev_is_closed
-        description: "BOOLEAN — le statut avant était fermé (depuis le seed)"
+        description: "True si le statut avant était fermé (seed)."
       - name: new_status_type
-        description: "Catégorie normalisée du statut après : Open / On Hold / Closed (depuis le seed)"
+        description: "Catégorie normalisée du statut après : Open / On Hold / Closed (seed status_mapping)."
       - name: new_is_on_hold
-        description: "BOOLEAN — le statut après est une attente (depuis le seed)"
+        description: "True si le statut après est une attente (seed)."
       - name: new_is_closed
-        description: "BOOLEAN — le statut après est fermé (depuis le seed)"
+        description: "True si le statut après est fermé (seed)."
 
   - name: int_zoho_desk__ticket_priority_events
     description: >
-      Une ligne par changement de priorité du ticket
-      (filtré sur property_name = 'Priority').
-      Source : stg_zoho_desk__ticket_history × stg_zoho_desk__ticket_history_event_info.
-      Même pattern que ticket_status_events : la priorité est une valeur scalaire,
-      donc on lit prev/new dans property_value__previous_value / __updated_value,
-      avec un fallback sur property_value pour l'attribution initiale.
-      Permet d'analyser les escalades (ex : Low → High en cours de traitement).
+      [QUOI MÉTIER]
+      Une ligne par changement de priorité d'un ticket. Permet d'analyser les escalades
+      (ex. Low → High en cours de traitement).
+
+      [COMMENT CONSTRUITE]
+      stg_zoho_desk__ticket_history × ticket_history_event_info, filtré property_name = 'Priority'.
+      Valeur scalaire : prev/new lus dans property_value__previous_value / __updated_value, fallback
+      property_value pour l'attribution initiale.
+
+      [GRAIN]
+      1 ligne par événement de changement de priorité (≥ 0 par ticket). Depuis février 2024.
+
+      [NOTES]
+      Beaucoup de tickets n'ont aucun changement de priorité (priorité souvent jamais renseignée,
+      cf. ticket_enriched.priority ~35% NULL).
     columns:
       - name: ticket_id
-        description: "FK vers le ticket concerné"
+        description: "Ticket concerné. FK → stg_zoho_desk__tickets / int_zoho_desk__ticket_enriched."
         tests:
           - not_null
           - relationships:
-              arguments:
-                to: ref('stg_zoho_desk__tickets')
-                field: ticket_id
-              config:
-                severity: warn
+              arguments: {to: "ref('stg_zoho_desk__tickets')", field: ticket_id}
+              config: {severity: warn}
       - name: event_at
-        description: "Date/heure exacte (TIMESTAMP UTC)"
+        description: "Date/heure exacte (TIMESTAMP UTC)."
         tests:
           - not_null
       - name: event_date_paris
-        description: "Date Europe/Paris — colonne de partition"
+        description: "Date Europe/Paris (colonne de partition)."
       - name: event_name
-        description: >
-          Nom de l'action Zoho ayant déclenché le changement (méta-événement parent).
-          TicketUpdated / TicketCreated / TicketMergedMaster. Voir
-          int_zoho_desk__ticket_status_events pour le détail.
+        description: "Action Zoho parente (TicketUpdated / TicketCreated / TicketMergedMaster — cf. ticket_status_events)."
+        tests:
+          - accepted_values:
+              arguments: {values: [TicketUpdated, TicketCreated, TicketMergedMaster]}
+              config: {severity: warn}
       - name: actor_id
-        description: "ID Zoho de l'acteur"
+        description: "ID Zoho de l'acteur."
       - name: actor_name
-        description: "Nom lisible de l'acteur"
+        description: "Nom lisible de l'acteur."
       - name: actor_type
-        description: "Type d'acteur : AGENT, CONTACT, SYSTEM"
+        description: "Type d'acteur. Valeurs : Agent, Contact, Workflow, ou NULL."
+        tests:
+          - accepted_values:
+              arguments: {values: [Agent, Contact, Workflow]}
+              config: {severity: warn}
       - name: prev_priority
         description: "Priorité avant (Low / Medium / High / Urgent). NULL pour l'attribution initiale."
       - name: new_priority
-        description: "Priorité après (lue depuis updated_value, ou property_value pour l'attribution initiale)."
+        description: "Priorité après (updated_value, ou property_value pour l'attribution initiale)."
       - name: is_initial_assignment
-        description: "BOOLEAN — true si c'est la première attribution de priorité (prev=NULL, new=valeur initiale)."
+        description: "True si première attribution de priorité (prev NULL, new = valeur initiale)."
 
   - name: int_zoho_desk__ticket_assignee_events
     description: >
-      Une ligne par changement de propriétaire du ticket (l'agent assigné),
-      filtré sur property_name = 'Case Owner' (nomenclature Zoho héritée
-      de Salesforce, équivalent à "Propriétaire du Ticket" dans l'UI).
-      Source : stg_zoho_desk__ticket_history × stg_zoho_desk__ticket_history_event_info.
-      Différence avec priority/status : la valeur est un objet (agent_id + agent_name),
-      donc on lit dans les champs __id / __name (et non les scalaires).
-      Permet d'analyser la charge agent dans le temps et le taux de réassignation.
+      [QUOI MÉTIER]
+      Une ligne par changement de propriétaire (agent assigné) d'un ticket. Permet d'analyser la
+      charge agent dans le temps et le taux de réassignation.
+
+      [COMMENT CONSTRUITE]
+      stg_zoho_desk__ticket_history × ticket_history_event_info, filtré property_name = 'Case Owner'
+      (nomenclature Zoho héritée de Salesforce = « Propriétaire du ticket » dans l'UI). La valeur est
+      un objet (agent id + name) : lecture dans les champs __id / __name, fallback property_value__*
+      pour l'attribution initiale.
+
+      [GRAIN]
+      1 ligne par événement de (ré)assignation. Depuis février 2024.
+
+      [NOTES]
+      « Case Owner » = l'agent assigné (assignee dans ticket_enriched), pas l'auteur du changement
+      (qui est actor_*).
     columns:
       - name: ticket_id
-        description: "FK vers le ticket concerné"
+        description: "Ticket concerné. FK → stg_zoho_desk__tickets / int_zoho_desk__ticket_enriched."
         tests:
           - not_null
           - relationships:
-              arguments:
-                to: ref('stg_zoho_desk__tickets')
-                field: ticket_id
-              config:
-                severity: warn
+              arguments: {to: "ref('stg_zoho_desk__tickets')", field: ticket_id}
+              config: {severity: warn}
       - name: event_at
-        description: "Date/heure exacte (TIMESTAMP UTC)"
+        description: "Date/heure exacte (TIMESTAMP UTC)."
         tests:
           - not_null
       - name: event_date_paris
-        description: "Date Europe/Paris — colonne de partition"
+        description: "Date Europe/Paris (colonne de partition)."
       - name: event_name
-        description: >
-          Nom de l'action Zoho ayant déclenché le changement (méta-événement parent).
-          TicketUpdated / TicketCreated / TicketMergedMaster. Voir
-          int_zoho_desk__ticket_status_events pour le détail.
+        description: "Action Zoho parente (TicketUpdated / TicketCreated / TicketMergedMaster — cf. ticket_status_events)."
+        tests:
+          - accepted_values:
+              arguments: {values: [TicketUpdated, TicketCreated, TicketMergedMaster]}
+              config: {severity: warn}
       - name: actor_id
-        description: "ID Zoho de l'acteur ayant déclenché le changement"
+        description: "ID Zoho de l'acteur ayant déclenché le changement."
       - name: actor_name
-        description: "Nom de l'acteur"
+        description: "Nom de l'acteur."
       - name: actor_type
-        description: "Type d'acteur : AGENT, CONTACT, SYSTEM"
+        description: "Type d'acteur. Valeurs : Agent, Contact, Workflow, ou NULL."
+        tests:
+          - accepted_values:
+              arguments: {values: [Agent, Contact, Workflow]}
+              config: {severity: warn}
       - name: prev_assignee_id
-        description: "ID de l'agent assigné avant. NULL si non assigné ou attribution initiale."
+        description: "Agent assigné avant. FK → stg_zoho_desk__agents. NULL si non assigné / attribution initiale."
       - name: prev_assignee_name
-        description: "Nom de l'agent assigné avant"
+        description: "Nom de l'agent assigné avant."
       - name: new_assignee_id
-        description: >
-          ID de l'agent assigné après (depuis updated_value__id, fallback property_value__id
-          pour l'attribution initiale).
+        description: "Agent assigné après. FK → stg_zoho_desk__agents (updated_value__id, fallback property_value__id)."
       - name: new_assignee_name
-        description: "Nom de l'agent assigné après"
+        description: "Nom de l'agent assigné après."
       - name: is_initial_assignment
-        description: "BOOLEAN — true si c'est la première attribution d'un propriétaire au ticket."
+        description: "True si première attribution d'un propriétaire au ticket."
 
   - name: int_zoho_desk__ticket_lifecycle_segments
     description: >

--- a/models/intermediate/zoho_desk/_zoho_desk__intermediate_models.yml
+++ b/models/intermediate/zoho_desk/_zoho_desk__intermediate_models.yml
@@ -395,106 +395,127 @@ models:
 
   - name: int_zoho_desk__ticket_lifecycle_segments
     description: >
-      Une ligne par période (segment) pendant laquelle le ticket reste dans un
-      même statut. Construit en appliquant LEAD() sur ticket_status_events :
-      le segment N commence à event_at[N] et se termine à event_at[N+1].
-      Le dernier segment (statut final) a segment_end_at = NULL et duration = NULL.
-      Les événements de fusion (TicketMergedMaster) sont exclus.
-      Sert de base pour calculer les temps passés en On Hold / Open / Closed.
+      [QUOI MÉTIER]
+      Une ligne par période (segment) pendant laquelle un ticket reste dans un même statut, avec
+      sa durée calendaire et sa durée en heures ouvrées. Brique de calcul des temps passés en
+      Open / On Hold / Closed (utilisée par int_zoho_desk__ticket_sla).
+
+      [COMMENT CONSTRUITE]
+      LEAD() sur int_zoho_desk__ticket_status_events (événements TicketCreated/TicketUpdated, fusions
+      exclues) : le segment N va de event_at[N] à event_at[N+1]. Durée ouvrée = minutes dans la
+      plage 9h00-17h30, jours ouvrés, hors fériés FR (ref_general__feries_metropole).
+
+      [GRAIN]
+      1 ligne par (ticket_id, segment_idx). ~65,3k segments. Le dernier segment (statut courant)
+      a segment_end_at et les durées à NULL.
+
+      [NOTES]
+      Heures ouvrées = 09:00–17:30, lun-ven, hors jours fériés métropole.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments: {combination_of_columns: [ticket_id, segment_idx]}
     columns:
       - name: ticket_id
-        description: "FK vers le ticket"
+        description: "Ticket concerné. FK → int_zoho_desk__ticket_enriched / stg_zoho_desk__tickets."
         tests:
           - not_null
       - name: segment_idx
-        description: "Numéro chronologique du segment (1, 2, 3...) par ticket"
+        description: "Numéro chronologique du segment (1, 2, 3…) au sein du ticket. Composante du grain."
         tests:
           - not_null
       - name: segment_start_at
-        description: "Début du segment (TIMESTAMP UTC)"
+        description: "Début du segment (TIMESTAMP UTC) = moment du changement de statut."
         tests:
           - not_null
       - name: segment_start_date_paris
-        description: "Date Europe/Paris du début — colonne de partition"
+        description: "Date Europe/Paris du début (colonne de partition)."
       - name: segment_end_at
-        description: "Fin = début du segment suivant. NULL pour le dernier segment."
+        description: "Fin du segment = début du segment suivant. NULL pour le dernier segment (statut courant)."
       - name: status
-        description: "Libellé brut du statut pendant ce segment"
+        description: "Libellé brut du statut pendant ce segment."
       - name: status_type
-        description: "Catégorie normalisée : Open / On Hold / Closed (depuis le seed)"
+        description: "Catégorie normalisée du statut : Open / On Hold / Closed (seed status_mapping)."
+        tests:
+          - accepted_values:
+              arguments: {values: [Open, "On Hold", Closed]}
+              config: {severity: warn}
       - name: is_on_hold
-        description: "BOOLEAN — segment en attente"
+        description: "True si le segment est en attente."
       - name: is_closed
-        description: "BOOLEAN — segment clôturé"
+        description: "True si le segment est clôturé."
       - name: duration_minutes_calendar
-        description: "Durée du segment en minutes calendaires. NULL si dernier segment."
+        description: "Durée du segment en minutes calendaires (24/7). NULL si dernier segment."
       - name: duration_minutes_business
-        description: >
-          Durée en heures ouvrées (9h-17h30, jours ouvrés FR, hors fériés)
-          via la macro business_minutes_between. NULL si dernier segment.
+        description: "Durée du segment en minutes ouvrées (9h-17h30, jours ouvrés, hors fériés FR). NULL si dernier segment."
 
   - name: int_zoho_desk__ticket_sla
     description: >
-      Métriques SLA par ticket — 1 ligne par ticket.
-      Agrège trois sources : ticket_threads (first_agent_response_at),
-      ticket_status_events (first_close_at / last_close_at, nb_reopens),
-      ticket_lifecycle_segments (temps passés en Open / On Hold).
-      Toutes les durées existent en deux variantes :
-        - _calendar : minutes calendaires (24/7)
-        - _business : minutes ouvrées (9h-17h30 FR, hors weekends et fériés)
-      Trois définitions de "resolution time" :
-        - first_close      : créé → PREMIER close (ignore ré-ouvertures)
-        - last_close       : créé → DERNIER close (inclut tous les cycles)
-        - excluding_hold   : somme des segments Open uniquement (exclut attente client)
-      Règles internes en attente de la confirmation Zoho support sur leur
-      dashboard officiel.
+      [QUOI MÉTIER]
+      Métriques de SLA par ticket, **recalculées par EVS** : délai de première réponse, délais de
+      résolution, temps passé en attente / actif, réouvertures. 1 ligne par ticket. Synonymes :
+      SLA, délais de traitement, temps de réponse / résolution support.
+
+      [COMMENT CONSTRUITE]
+      Agrège : ticket_threads (1re réponse agent), ticket_status_events (1re/dernière clôture,
+      réouvertures), ticket_lifecycle_segments (temps en Open / On Hold). Chaque durée existe en
+      deux variantes : `_calendar` (24/7) et `_business` (heures ouvrées 9h-17h30 FR, hors WE/fériés).
+
+      [GRAIN]
+      1 ligne par ticket_id (PK). ~22,2k tickets. 1re réponse moyenne ~944 min ouvrées ; ~3,3k
+      tickets rouverts au moins une fois (max 161 réouvertures).
+
+      [NOTES]
+      ⚠️ Ce sont des métriques **maison** (heures ouvrées EVS), DISTINCTES de celles fournies par
+      Zoho et exposées dans int_zoho_desk__ticket_enriched (first_response_time_minutes,
+      resolution_time_minutes…). Utiliser CE modèle pour le SLA « heures ouvrées » EVS ; l'enriched
+      pour les chiffres bruts Zoho. Trois définitions de résolution : first_close (créé→1re clôture,
+      ignore réouvertures), last_close (créé→dernière clôture, tous cycles), excluding_hold (somme des
+      segments Open, hors attente client). Règles en attente de confirmation vs dashboard Zoho officiel.
     columns:
       - name: ticket_id
-        description: "PK — FK vers le ticket"
+        description: "Ticket. PK. FK → int_zoho_desk__ticket_enriched."
         tests:
           - unique
           - not_null
       - name: created_time
-        description: "Date/heure de création (TIMESTAMP UTC)"
+        description: "Date/heure de création du ticket (TIMESTAMP UTC) — point de départ des délais."
       - name: first_agent_response_at
         description: >
-          Première réponse agent. Source : threads avec direction='out',
-          author__type='AGENT', NOT is_description_thread.
-          NULL si aucun agent n'a répondu.
+          Horodatage de la 1re réponse agent (thread direction='out', author='AGENT', hors thread de
+          description). NULL si aucun agent n'a répondu.
       - name: first_inbound_at
-        description: "Premier thread entrant (direction='in')"
+        description: "Horodatage du 1er thread entrant (direction='in')."
       - name: first_response_minutes_calendar
-        description: "Délai première réponse, minutes calendaires. NULL si pas de réponse."
+        description: "Délai de 1re réponse en minutes calendaires. Synonymes : temps de prise en charge, délai de réponse. NULL si pas de réponse."
       - name: first_response_minutes_business
-        description: "Idem en minutes ouvrées"
+        description: "Délai de 1re réponse en minutes **ouvrées** (la mesure SLA de référence côté EVS)."
       - name: first_close_at
-        description: "Première fois que le ticket atteint Clôturée. NULL si jamais clôturé."
+        description: "1re fois que le ticket atteint un statut clôturé. NULL si jamais clôturé."
       - name: last_close_at
-        description: "Dernière clôture. NULL si jamais clôturé."
+        description: "Dernière clôture (après d'éventuelles réouvertures)."
       - name: nb_closes
-        description: "Nombre total de clôtures"
+        description: "Nombre total de clôtures du ticket. Mesure."
       - name: nb_reopens
-        description: "Nombre total de ré-ouvertures"
+        description: "Nombre total de réouvertures. Synonyme : relances / réouvertures. Mesure."
       - name: resolution_minutes_first_close_calendar
-        description: "Création → premier close, minutes calendaires"
+        description: "Délai de résolution (création → 1re clôture), minutes calendaires. Ignore les réouvertures."
       - name: resolution_minutes_first_close_business
-        description: "Idem en minutes ouvrées"
+        description: "Idem en minutes ouvrées. Synonyme : délai de résolution (1re clôture)."
       - name: resolution_minutes_last_close_calendar
-        description: "Création → dernier close, minutes calendaires (inclut tous les cycles)"
+        description: "Délai de résolution (création → dernière clôture), minutes calendaires. Inclut tous les cycles de réouverture."
       - name: resolution_minutes_last_close_business
-        description: "Idem en minutes ouvrées"
+        description: "Idem en minutes ouvrées. Synonyme : délai de résolution définitif."
       - name: time_in_open_minutes_calendar
-        description: "Temps total en Open (Nouveau / En cours), minutes calendaires"
+        description: "Temps total passé en statut Open (Nouveau / En cours), minutes calendaires."
       - name: time_in_on_hold_minutes_calendar
-        description: "Temps total en attente, minutes calendaires"
+        description: "Temps total passé en attente (On Hold), minutes calendaires. Synonyme : temps d'attente client."
       - name: time_in_open_minutes_business
-        description: "Temps en Open, minutes ouvrées"
+        description: "Temps en Open, minutes ouvrées."
       - name: time_in_on_hold_minutes_business
-        description: "Temps en On Hold, minutes ouvrées"
+        description: "Temps en On Hold, minutes ouvrées."
       - name: resolution_excluding_hold_minutes_calendar
         description: >
-          Temps de résolution excluant les périodes d'attente
-          (= time_in_open_minutes_calendar). Représente le temps "actif"
-          passé sur le ticket, hors attente client.
+          Temps de résolution **hors attente** (= time_in_open) : temps « actif » passé sur le ticket,
+          minutes calendaires. Synonyme : temps de traitement actif.
       - name: resolution_excluding_hold_minutes_business
-        description: "Idem en minutes ouvrées"
+        description: "Idem en minutes ouvrées."

--- a/models/intermediate/zoho_desk/_zoho_desk__intermediate_models.yml
+++ b/models/intermediate/zoho_desk/_zoho_desk__intermediate_models.yml
@@ -23,150 +23,192 @@ models:
 
   - name: int_zoho_desk__ticket_enriched
     description: >
-      Vue enrichie 1:1 par ticket — fondation des marts ticket (dim).
-      Joint tickets + ticket_details (custom fields) + ticket_metrics (SLA,
-      compteurs) + accounts (avec fallback via le contact quand t.account_id
-      est NULL) + contacts + departments + agents.
-      Chaque ligne contient tout ce dont le métier a besoin pour analyser un
-      ticket : compte client, contact, agent assigné, département, catégories,
-      nature, threads, réponses agent, durées SLA.
+      [QUOI MÉTIER]
+      Vue enrichie 1 ligne par ticket de support Zoho Desk — fondation de la dim ticket.
+      Tout le contexte d'un ticket : compte client, contact, agent assigné, département,
+      catégorisation métier, flags SLA, compteurs de conversation et durées SLA.
+      Synonymes métier : « ticket » = demande / réclamation / dossier support.
+
+      [COMMENT CONSTRUITE]
+      Jointure tickets + ticket_details (champs custom cf_*) + ticket_metrics (SLA, compteurs) +
+      accounts (avec fallback via le contact quand t.account_id est NULL) + contacts + departments
+      + agents. Les durées SLA viennent directement de ticket_metrics (Zoho), pas recalculées ici.
+
+      [GRAIN]
+      1 ligne par ticket_id (PK). ~22,2k tickets, depuis février 2024.
+
+      [NOTES]
+      ⚠️ Les champs Zoho standard `category` / `sub_category` sont **toujours NULL** : la
+      catégorisation métier se fait via `nature_des_demandes` (1er niveau) et les colonnes `cf_*`
+      (catégories / sous-catégories custom). En quasi-totalité des tickets sont Clôturés.
+      `resolution` est presque toujours vide. Pour l'analyse temporelle (réouvertures, fermetures
+      par jour) utiliser int_zoho_desk__ticket_status_events ; pour le SLA détaillé int_zoho_desk__ticket_sla.
     columns:
+      # --- IDENTITÉ TICKET ---
       - name: ticket_id
-        description: "PK — identifiant unique du ticket"
+        description: "Identifiant unique du ticket Zoho Desk. PK."
         tests:
           - unique
           - not_null
       - name: ticket_number
-        description: "Numéro de ticket lisible dans Zoho (ex : 21952)"
+        description: "Numéro de ticket lisible dans Zoho (ex. 21952). Synonyme : numéro de demande."
       - name: subject
-        description: "Objet du ticket"
+        description: "Objet / sujet du ticket (texte libre)."
       - name: web_url
-        description: "URL de la fiche ticket dans Zoho Desk"
+        description: "URL de la fiche ticket dans Zoho Desk."
+
+      # --- STATUT & CLASSIFICATION ---
       - name: status
-        description: "Statut courant"
-      - name: status_type
-        description: "Catégorie du statut : open, closed, on_hold"
-      - name: priority
-        description: "Priorité : Low, Medium, High, Urgent"
-      - name: channel
-        description: "Canal d'entrée : Email, Phone, Chat, Web, etc."
-      - name: category
-        description: "Catégorie métier (premier niveau)"
-      - name: sub_category
-        description: "Sous-catégorie métier (deuxième niveau)"
-      - name: is_archived
-        description: "BOOLEAN — ticket archivé"
-      - name: is_spam
-        description: "BOOLEAN — ticket marqué comme spam"
-      - name: created_time
-        description: "Date/heure de création (TIMESTAMP UTC)"
-      - name: closed_time
         description: >
-          Date/heure de la dernière fermeture (TIMESTAMP UTC, NULL si jamais fermé).
-          Pour l'analyse temporelle (réouvertures, fermetures par jour),
-          utiliser int_zoho_desk__ticket_status_events.
+          Statut courant (libellé brut Zoho, en français, parfois incohérent). Valeurs : Clôturée
+          (très majoritaire), Nouveau, En attente infos complémentaires, En attente interne,
+          En cours de traitement, Closed/Clôturé (doublons). Préférer status_type pour regrouper.
+      - name: status_type
+        description: >
+          Catégorie de statut (regroupement propre). Valeurs : Closed (clôturé, ~99,8%), Open
+          (ouvert), On Hold (en attente). Synonyme : état du ticket. À utiliser plutôt que `status`.
+        tests:
+          - accepted_values:
+              arguments: {values: [Closed, Open, "On Hold"]}
+              config: {severity: warn}
+      - name: priority
+        description: >
+          Priorité du ticket. Valeurs : Medium, Low, High (pas d'Urgent observé). ~35% NULL
+          (priorité non renseignée). Synonyme : criticité.
+        tests:
+          - accepted_values:
+              arguments: {values: [Low, Medium, High, Urgent]}
+              config: {severity: warn}
+      - name: channel
+        description: >
+          Canal d'entrée du ticket. Valeurs : Email (~99%), Phone, Zoho Opportunity, Zoho Form,
+          Web. Synonyme : canal / source de la demande.
+      - name: category
+        description: "⚠️ Champ Zoho standard NON utilisé (toujours NULL). La catégorisation passe par nature_des_demandes + cf_*."
+      - name: sub_category
+        description: "⚠️ Champ Zoho standard NON utilisé (toujours NULL). Voir les cf_s_* pour les sous-catégories."
+      - name: is_archived
+        description: "True si le ticket est archivé."
+      - name: is_spam
+        description: "True si le ticket est marqué comme spam."
+
+      # --- DATES ---
+      - name: created_time
+        description: "Date/heure de création du ticket (TIMESTAMP UTC). Axe temporel principal."
+        tests:
+          - not_null
+      - name: closed_time
+        description: "Date/heure de la dernière fermeture (NULL si jamais fermé). Pour les cycles de réouverture, voir ticket_status_events."
       - name: due_date
-        description: "Échéance SLA de résolution"
+        description: "Échéance SLA de résolution (Zoho)."
       - name: response_due_date
-        description: "Échéance SLA de première réponse"
+        description: "Échéance SLA de première réponse (Zoho)."
+
+      # --- COMPTE / CONTACT / AGENT / DÉPARTEMENT (FK) ---
       - name: account_id
         description: >
-          ID du compte client (entreprise). COALESCE de t.account_id puis
-          c.account_id (compte du contact). NULL si ni le ticket ni le contact
-          n'est lié à un compte dans Zoho.
+          Compte client (entreprise) du ticket. FK → stg_zoho_desk__accounts. COALESCE de
+          t.account_id puis du compte du contact. NULL si aucun rattachement. Synonyme : client / société.
       - name: account_name
-        description: >
-          Nom du compte client. NULL quand account_id est NULL ou que le compte
-          n'a pas de nom. ~92% de couverture sur l'historique.
+        description: "Nom du compte client (~92% de couverture). NULL si account_id NULL."
       - name: contact_id
-        description: "FK contact ayant ouvert le ticket"
+        description: "Contact (personne) ayant ouvert le ticket. FK → stg_zoho_desk__contacts."
       - name: contact_first_name
-        description: "Prénom du contact"
+        description: "Prénom du contact."
       - name: contact_last_name
-        description: "Nom du contact"
+        description: "Nom du contact."
       - name: contact_email
-        description: "Email du contact"
+        description: "Email du contact."
       - name: assignee_id
-        description: "FK agent actuellement assigné"
+        description: "Agent support actuellement assigné. FK → stg_zoho_desk__agents."
       - name: assignee_name
-        description: "Nom complet de l'agent assigné"
+        description: "Nom complet de l'agent assigné. Synonyme : technicien support / conseiller."
       - name: department_id
-        description: "FK département"
+        description: "Département traitant. FK → stg_zoho_desk__departments."
       - name: department_name
-        description: "Nom du département (ex : Service Client, Facturation)"
-      - name: nature_des_demandes
-        description: "Nature de la demande (custom field cf_nature_des_demandes)"
-      - name: cf_contrat_avenant
-        description: "Catégorie principale : contrat / avenant"
-      - name: cf_creation_d_un_site
-        description: "Catégorie principale : création d'un site"
-      - name: cf_demande_intervention
-        description: "Catégorie principale : demande d'intervention"
-      - name: cf_inscription
-        description: "Catégorie principale : inscription"
-      - name: cf_machines
-        description: "Catégorie principale : machines"
-      - name: cf_modification
-        description: "Catégorie principale : modification"
-      - name: cf_modification_d_un_site
-        description: "Catégorie principale : modification d'un site"
-      - name: cf_modifications
-        description: "Catégorie principale : modifications"
-      - name: cf_rupture
-        description: "Catégorie principale : rupture de stock"
-      - name: cf_suivi_intervention
-        description: "Catégorie principale : suivi d'intervention"
-      - name: cf_s_systeme_de_paiement
-        description: "Catégorie principale : système de paiement"
-      - name: cf_technique
-        description: "Catégorie principale : technique"
-      - name: cf_s_equipements
-        description: "Sous-catégorie : équipements"
-      - name: cf_s_commande_directes
-        description: "Sous-catégorie : commandes directes"
-      - name: cf_s_commercial
-        description: "Sous-catégorie : commercial"
-      - name: cf_s_facturation
-        description: "Sous-catégorie : facturation"
-      - name: cf_s_gestion_des_cartes_privatives
-        description: "Sous-catégorie : gestion cartes privatives"
-      - name: cf_s_gestion_des_planogrammes
-        description: "Sous-catégorie : gestion planogrammes"
-      - name: cf_s_recyclage
-        description: "Sous-catégorie : recyclage"
-      - name: cf_s_remboursement
-        description: "Sous-catégorie : remboursement"
-      - name: cf_s_remontees_personnel_neshu
-        description: "Sous-catégorie : remontées personnel NESHU"
-      - name: cf_s_reappro
-        description: "Sous-catégorie : réapprovisionnement"
-      - name: is_over_due
-        description: "BOOLEAN — SLA résolution dépassé"
-      - name: is_response_overdue
-        description: "BOOLEAN — SLA première réponse dépassé"
-      - name: is_escalated
-        description: "BOOLEAN — ticket escaladé"
-      - name: resolution
-        description: "Texte de résolution saisi par l'agent à la fermeture"
-      - name: thread_count
-        description: "Nombre total de threads (client + agent)"
-      - name: agent_response_count
-        description: >
-          Nombre de réponses agent (= outgoing_count des metrics).
-          Vérifié contre threads où direction='out' AND author__type='AGENT'.
-      - name: response_count
-        description: "Nombre total de réponses (compteur Zoho — peut différer légèrement de outgoing_count)"
-      - name: reopen_count
-        description: "Nombre de réouvertures historiques du ticket"
-      - name: reassign_count
-        description: "Nombre de réassignations historiques"
-      - name: first_response_time_minutes
-        description: "Délai première réponse (minutes)"
-      - name: resolution_time_minutes
-        description: "Durée totale de résolution (minutes)"
-      - name: total_response_time_minutes
-        description: "Temps de réponse total cumulé (minutes)"
+        description: "Nom du département (ex. Service Client, Facturation)."
 
+      # --- CATÉGORISATION MÉTIER (custom fields) ---
+      - name: nature_des_demandes
+        description: >
+          **Nature / motif de la demande** — principal champ de catégorisation métier (cf_nature_des_demandes).
+          Valeurs fréquentes : Gestion des cartes privatives/Badges, Equipements, Remboursements,
+          Facturation, Commerce/CSM, Commandes directes/Négoce, Réappro, Recyclage… (~50% NULL).
+          Synonymes : type de demande / motif / sujet métier.
+      - name: cf_contrat_avenant
+        description: "Catégorie custom : contrat / avenant."
+      - name: cf_creation_d_un_site
+        description: "Catégorie custom : création d'un site."
+      - name: cf_demande_intervention
+        description: "Catégorie custom : demande d'intervention."
+      - name: cf_inscription
+        description: "Catégorie custom : inscription."
+      - name: cf_machines
+        description: "Catégorie custom : machines."
+      - name: cf_modification
+        description: "Catégorie custom : modification."
+      - name: cf_modification_d_un_site
+        description: "Catégorie custom : modification d'un site."
+      - name: cf_modifications
+        description: "Catégorie custom : modifications."
+      - name: cf_rupture
+        description: "Catégorie custom : rupture de stock."
+      - name: cf_suivi_intervention
+        description: "Catégorie custom : suivi d'intervention."
+      - name: cf_s_systeme_de_paiement
+        description: "Catégorie custom : système de paiement."
+      - name: cf_technique
+        description: "Catégorie custom : technique."
+      - name: cf_s_equipements
+        description: "Sous-catégorie custom : équipements."
+      - name: cf_s_commande_directes
+        description: "Sous-catégorie custom : commandes directes."
+      - name: cf_s_commercial
+        description: "Sous-catégorie custom : commercial."
+      - name: cf_s_facturation
+        description: "Sous-catégorie custom : facturation."
+      - name: cf_s_gestion_des_cartes_privatives
+        description: "Sous-catégorie custom : gestion cartes privatives."
+      - name: cf_s_gestion_des_planogrammes
+        description: "Sous-catégorie custom : gestion planogrammes."
+      - name: cf_s_recyclage
+        description: "Sous-catégorie custom : recyclage."
+      - name: cf_s_remboursement
+        description: "Sous-catégorie custom : remboursement."
+      - name: cf_s_remontees_personnel_neshu
+        description: "Sous-catégorie custom : remontées personnel NESHU."
+      - name: cf_s_reappro
+        description: "Sous-catégorie custom : réapprovisionnement."
+
+      # --- FLAGS SLA ---
+      - name: is_over_due
+        description: "True si le SLA de résolution est dépassé (Zoho)."
+      - name: is_response_overdue
+        description: "True si le SLA de première réponse est dépassé (Zoho)."
+      - name: is_escalated
+        description: "True si le ticket a été escaladé."
+      - name: resolution
+        description: "Texte de résolution saisi à la fermeture. Quasi toujours vide (~0,6% rempli)."
+
+      # --- COMPTEURS DE CONVERSATION ---
+      - name: thread_count
+        description: "Nombre total de threads (messages client + agent). Mesure."
+      - name: agent_response_count
+        description: "Nombre de réponses agent (= outgoing_count des metrics)."
+      - name: response_count
+        description: "Nombre total de réponses (compteur Zoho ; peut différer légèrement de agent_response_count)."
+      - name: reopen_count
+        description: "Nombre de réouvertures du ticket. Synonyme : nombre de relances."
+      - name: reassign_count
+        description: "Nombre de réassignations de l'agent."
+
+      # --- DURÉES SLA (minutes, source ticket_metrics) ---
+      - name: first_response_time_minutes
+        description: "Délai de première réponse (minutes). Synonymes : temps de 1re réponse, délai de prise en charge."
+      - name: resolution_time_minutes
+        description: "Durée totale de résolution (minutes), cumulée sur tous les cycles. Synonyme : délai de résolution."
+      - name: total_response_time_minutes
+        description: "Temps de réponse total cumulé (minutes)."
   - name: int_zoho_desk__ticket_status_events
     description: >
       Une ligne par changement de statut — vue brute mais normalisée.


### PR DESCRIPTION
## Pourquoi

Documenter les YAML de la couche **intermediate** comme **grounding pour l'agent NL→SQL** (projet EVS-IA DATA pole : l'agent lit les descriptions du manifest dbt pour traduire les questions métier en SQL). La qualité des descriptions = qualité des réponses.

## Ce qui change

### Documentation des 7 sources intermediate (~43 modèles)
Chaque modèle passe à un standard « agent-ready » :
- **Description en 4 blocs** : `[QUOI MÉTIER]` / `[COMMENT CONSTRUITE]` / `[GRAIN]` (obligatoire) / `[NOTES]`.
- **Énumérations échantillonnées dans BigQuery** (valeurs réelles + sens), pas devinées.
- **Cibles FK** explicites (`→ dim_x` / `stg_x`), **synonymes métier** (CA, conso, délai de résolution…).
- **Tests-contrat** : `accepted_values` (énums), `relationships` (FK), `unique`/`not_null` (grain) — ils maintiennent le grounding vrai dans le temps.

Sources : `yuman`, `mssql_sage`, `nesp_tech`, `nesp_co`, `oracle_neshu` (15), `zoho_desk` (6), `oracle_lcdp` (12).

Convention écrite dans `docs/conventions/intermediate.md` §6.

### Corrections / faits métier capturés (validés avec le métier)
- **Polymorphisme** des `product_source_id` / `product_destination_id` Oracle : la table cible dépend du `*_type` (COMPANY/RESOURCES/DEVICE) — PAS une FK produit.
- **Télémétrie** = origine NAYAX → ERP Distrilog. lcdp porte en plus la **valorisation des ventes** (CA Nayax).
- `inter_technique` : `TOTECH` = renvoyé à la technique (non résolu sur place).
- Corrections de bugs de doc (colonnes fantômes appro_tasks, `category`/`sub_category` Zoho toujours NULL, `type`→`intervention_type` nesp_tech…).

### Changement de logique : CHECK_LUNCH dans le comptage LCDP
`int_oracle_lcdp__comptage_tasks` : les **titres-restaurant** (`CHECK_LUNCH`) sont désormais inclus dans le CA encaissé (nouvelle colonne `ca_titres_resto_eur` + intégrés à `ca_cash_eur`). `JETON` reste exclu (0 €). Rétablit la cohérence `ca_cash_eur = ca_cash_ht + ca_cash_tva`. `on_schema_change='append_new_columns'` ajouté.

## ⚠️ Action requise APRÈS merge

`int_oracle_lcdp__comptage_tasks` est **incrémental** : le CI (`state:modified+`) ne fera qu'un merge incrémental → la nouvelle colonne et le `ca_cash_eur` corrigé ne s'appliqueront qu'aux lignes récentes. **Lancer un full-refresh une fois** (table ~9k lignes, trivial) :
```bash
dbt build -s int_oracle_lcdp__comptage_tasks --full-refresh --target prod
```

## Notes
- **Aucun modèle SQL modifié** sauf `comptage_tasks` (ajout CHECK_LUNCH + on_schema_change). Le reste = YAML uniquement.
- `_oracle_lcdp__intermediate_models.yml` est en **CRLF** (les autres en LF) — préservé tel quel pour des diffs propres ; normalisation LF possible dans un commit séparé si souhaité.
- `dbt parse` OK et `sqlfluff lint` OK sur le SQL modifié.

🤖 Generated with [Claude Code](https://claude.com/claude-code)