### PR TITLE
fix(dbt-runner): copy selectors.yml into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN pip install --no-cache-dir -r requirements-lock.txt
 
 WORKDIR /app
 
-COPY dbt_project.yml packages.yml profiles.yml ./
+COPY dbt_project.yml packages.yml profiles.yml selectors.yml ./
 COPY models/ models/
 COPY snapshots/ snapshots/
 COPY data/ data/


### PR DESCRIPTION
Le job `dbt-runner` échoue sur `dbt build --selector passage_appro_fastlane` :
`Could not find selector named passage_appro_fastlane, expected one of []`.

Cause : le Dockerfile fait des `COPY` explicites (pas `COPY . .`) et
`selectors.yml` n'était pas copié → dbt ne charge aucun selector au runtime.

Fix : ajout de `selectors.yml` à la ligne `COPY` des fichiers de config.
`Dockerfile` est dans les paths déclencheurs de la CI → le merge rebuild+push l'image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)