### PR TITLE
feat(lcdp): add fct_lcdp__passage_appro mart

### DIFF
--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1360,3 +1360,48 @@ models:
         data_type: timestamp
         tests:
           - not_null
+
+  - name: int_oracle_lcdp__appro_tasks_enriched
+    description: >
+      [QUOI MÉTIER]
+      Passages appro LCDP enrichis : roadman affecté (nom + code), référentiels client/machine
+      aplatis, statut normalisé et indicateurs. Brique directe du mart fct_lcdp__passage_appro.
+
+      [COMMENT CONSTRUITE]
+      int_oracle_lcdp__appro_tasks + roadman (task_has_resources × resources type=2) +
+      company (nom) + device (code/nom). Statut ENCOURS reclassé FAIT. Filtré sur les tâches
+      ayant un roadman associé.
+
+      [GRAIN]
+      1 ligne par task_id (PK), uniquement les passages avec roadman.
+
+      [NOTES]
+      is_planned = PREVU/FAIT/ENCOURS/ANOMALIE ; is_done = FAIT/ENCOURS ; is_anomaly = ANOMALIE.
+      passage_duration_min calculée seulement pour les passages FAIT.
+    columns:
+      - name: task_id
+        description: "Identifiant de la tâche appro (PK)."
+        data_type: int64
+        tests:
+          - unique
+          - not_null
+      - name: resources_roadman_id
+        description: "Roadman affecté (resources type=2). FK → dim_lcdp__resource."
+        data_type: int64
+        tests:
+          - not_null
+      - name: roadman_name
+        description: "Nom du roadman affecté au passage."
+        data_type: string
+      - name: is_done
+        description: "Indicateur binaire : 1 si réalisé (statut brut FAIT ou ENCOURS), sinon 0."
+        data_type: int64
+      - name: is_planned
+        description: "Indicateur binaire : 1 si statut brut PREVU, FAIT, ENCOURS ou ANOMALIE, sinon 0."
+        data_type: int64
+      - name: is_anomaly
+        description: "Indicateur binaire : 1 si statut brut ANOMALIE, sinon 0."
+        data_type: int64
+      - name: passage_duration_min
+        description: "Durée du passage en minutes (fin - début), uniquement pour les passages FAIT."
+        data_type: float64

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__appro_tasks_enriched.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__appro_tasks_enriched.sql
@@ -1,0 +1,93 @@
+{{ config(materialized='table') }}
+
+-- ============================================================
+-- CTE 1 : Roadman associé à chaque tâche appro
+-- Jointure stg_oracle_lcdp__task_has_resources × resources (type=2 = roadman)
+-- ============================================================
+with resources_roadman as (
+    select
+        thr.idtask,
+        min(r.idresources) as resources_roadman_id,
+        min(r.code) as roadman_code,
+        min(r.name) as roadman_name
+    from {{ ref('stg_oracle_lcdp__task_has_resources') }} as thr
+    inner join {{ ref('stg_oracle_lcdp__resources') }} as r
+        on
+            thr.idresources = r.idresources
+            and r.idresources_type = 2
+    group by thr.idtask
+),
+
+-- ============================================================
+-- CTE 2 : Enrichissement tâche appro
+-- Joint le référentiel company, device. Normalise le statut
+-- (ENCOURS reclassé en FAIT après validation métier). Calcule
+-- la durée du passage et les indicateurs binaires.
+-- ============================================================
+enriched as (
+    select
+        -- IDs
+        pa.task_id,
+        pa.device_id,
+        pa.company_id,
+        pa.product_source_id,
+        r.resources_roadman_id,
+        pa.product_destination_id,
+        pa.product_source_type,
+        pa.product_destination_type,
+
+        -- Codes et libellés aplatis
+        pa.company_code,
+        c.name as company_name,
+        c.name || ' - ' || pa.company_code as company_info,
+        d.code as device_code,
+        d.name as device_name,
+        d.name || ' - ' || d.code as device_info,
+        r.roadman_code,
+        r.roadman_name,
+        pa.task_location_info,
+
+        -- Statut normalisé (ENCOURS → FAIT)
+        case
+            when pa.task_status_code in ('FAIT', 'ENCOURS') then 'FAIT'
+            else pa.task_status_code
+        end as task_status_code,
+        case when pa.task_status_code in ('FAIT', 'ENCOURS') then 1 else 0 end as is_done,
+        case
+            when pa.task_status_code in ('PREVU', 'FAIT', 'ENCOURS', 'ANOMALIE') then 1 else 0
+        end as is_planned,
+        case when pa.task_status_code = 'ANOMALIE' then 1 else 0 end as is_anomaly,
+
+        -- Dates
+        date(pa.task_start_date) as start_date_day,
+        pa.task_start_date,
+        pa.task_end_date,
+
+        -- Durée du passage (minutes), uniquement si réalisé
+        case
+            when
+                pa.task_start_date is not null
+                and pa.task_end_date is not null
+                and pa.task_status_code = 'FAIT'
+                then timestamp_diff(pa.task_end_date, pa.task_start_date, second) / 60.0
+        end as passage_duration_min,
+
+        -- Métadonnées
+        pa.created_at,
+        pa.updated_at
+
+    from {{ ref('int_oracle_lcdp__appro_tasks') }} as pa
+
+    left join resources_roadman as r
+        on pa.task_id = r.idtask
+
+    left join {{ ref('stg_oracle_lcdp__company') }} as c
+        on pa.company_id = c.idcompany
+
+    left join {{ ref('stg_oracle_lcdp__device') }} as d
+        on pa.device_id = d.iddevice
+
+    where r.resources_roadman_id is not null
+)
+
+select * from enriched

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -459,3 +459,161 @@ models:
           arguments:
             expression: "ca_total_ttc_eur >= 0"
 
+  - name: fct_lcdp__passage_appro
+    description: |
+      [QUOI MÉTIER] Passages APPRO des roadmen chez les clients LCDP, enrichis du pointage début/fin de journée du roadman.
+      [COMMENT CONSTRUITE] Issu de int_oracle_lcdp__appro_tasks_enriched (tâches appro idtask_type=32 + roadman type 2 + référentiels company/device, statut ENCOURS reclassé FAIT) joint au pointage journalier dérivé de int_oracle_lcdp__pointage_tasks : date_pointage_debut = premier START_DAY ≥ 03:00 par roadman/jour, date_pointage_fin = dernier END_DAY postérieur au début le même jour.
+      [GRAIN] 1 ligne par task_id (1 tâche APPRO).
+      [NOTES] is_planned (PREVU/FAIT/ENCOURS/ANOMALIE) / is_done (FAIT/ENCOURS) / is_anomaly (ANOMALIE) : indicateurs binaires. pointage_missing_flag=1 si aucun début de journée trouvé pour le roadman ce jour. passage_duration_min calculée uniquement pour les passages FAIT.
+
+    columns:
+      - name: task_id
+        description: Identifiant unique de la tâche de passage
+        tests:
+          - not_null
+          - unique
+
+      - name: device_id
+        description: Identifiant de la machine concernée (FK vers dim_lcdp__device)
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__device')
+                field: device_id
+
+      - name: company_id
+        description: Identifiant du client (FK vers dim_lcdp__company)
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__company')
+                field: company_id
+
+      - name: resources_roadman_id
+        description: Identifiant du roadman ayant effectué le passage (FK vers dim_lcdp__resource)
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_lcdp__resource')
+                field: resources_id
+
+      - name: product_source_id
+        description: Identifiant du produit source (chargé). Polymorphe selon product_source_type ; pas de FK dim garantie.
+
+      - name: product_destination_id
+        description: Identifiant du produit destination (déchargé). Polymorphe selon product_destination_type ; pas de FK dim garantie.
+
+      - name: company_code
+        description: Code métier du client
+
+      - name: company_name
+        description: Nom du client
+
+      - name: company_info
+        description: Nom et code du client (format "Nom - Code")
+
+      - name: device_code
+        description: Code métier de la machine
+
+      - name: device_name
+        description: Nom de la machine
+
+      - name: device_info
+        description: Nom et code de la machine (format "Nom - Code")
+
+      - name: roadman_code
+        description: Code métier du roadman
+
+      - name: roadman_name
+        description: Nom du roadman
+
+      - name: product_source_type
+        description: Type du produit source (qualifie product_source_id)
+
+      - name: product_destination_type
+        description: Type du produit destination (qualifie product_destination_id)
+
+      - name: task_location_info
+        description: Informations de localisation de la tâche (access_info de la LOCATION Oracle)
+
+      - name: task_status_code
+        description: >
+          Statut métier de la tâche. Les statuts ENCOURS sont reclassés FAIT après validation métier.
+
+      - name: date_pointage_debut
+        description: Début de journée du roadman (premier pointage START_DAY ≥ 03:00). NULL si absent.
+
+      - name: date_pointage_fin
+        description: Fin de journée du roadman (dernier pointage END_DAY postérieur au début, même jour). NULL si absent.
+
+      - name: date_pointage_jour
+        description: Jour de pointage du roadman (date sans heure)
+
+      - name: start_date_day
+        description: Date de début du passage sans l'heure. Clé de rattachement au pointage journalier.
+
+      - name: task_start_date
+        description: Date et heure de début réel du passage
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "<= task_end_date"
+                config:
+                  severity: warn
+
+      - name: task_end_date
+        description: Date et heure de fin réelle du passage. NULL si passage en cours.
+
+      - name: passage_duration_min
+        description: Durée du passage en minutes (fin - début). NULL si passage non terminé.
+
+      - name: is_planned
+        description: Indicateur binaire — tâche planifiée (1) si statut PREVU / FAIT / ENCOURS / ANOMALIE, sinon 0
+        tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1]
+                quote: false
+              config:
+                severity: warn
+
+      - name: is_done
+        description: Indicateur binaire indiquant si la tâche est réalisée (1, statut FAIT/ENCOURS) ou non (0)
+
+      - name: is_anomaly
+        description: Indicateur binaire indiquant si la tâche est en anomalie (1, statut ANOMALIE) ou non (0)
+        tests:
+          - accepted_values:
+              arguments:
+                values: [0, 1]
+                quote: false
+              config:
+                severity: warn
+
+      - name: pointage_missing_flag
+        description: 1 = aucun début de journée (pointage) trouvé pour ce roadman ce jour-là
+
+      - name: created_at
+        description: Date de création de la tâche dans le système source
+
+      - name: updated_at
+        description: Date de dernière mise à jour de la tâche dans le système source
+
+      - name: dbt_updated_at
+        description: Horodatage de la dernière exécution du modèle dbt (trace le dernier refresh)
+
+      - name: dbt_invocation_id
+        description: Identifiant unique de l'exécution dbt
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - task_id
+              - roadman_code
+            config:
+              severity: error
+

--- a/models/marts/lcdp/fct_lcdp__passage_appro.sql
+++ b/models/marts/lcdp/fct_lcdp__passage_appro.sql
@@ -1,0 +1,122 @@
+{{ config(
+    materialized='table',
+    partition_by={
+        'field': 'task_start_date',
+        'data_type': 'timestamp',
+        'granularity': 'day'
+    },
+    cluster_by=['company_id', 'device_id', 'roadman_code']
+) }}
+
+-- ============================================================
+-- CTE 1 : Début de journée par roadman/jour
+-- Premier pointage START_DAY à partir de 03:00:00
+-- ============================================================
+with pointage_debut as (
+    select
+        resources_roadman_id,
+        roadman_code,
+        date_pointage_jour,
+        min(case
+            when
+                label_code = 'START_DAY'
+                and format_timestamp('%H:%M:%S', date_pointage) >= '03:00:00'
+                then date_pointage
+        end) as date_pointage_debut
+    from {{ ref('int_oracle_lcdp__pointage_tasks') }}
+    group by resources_roadman_id, roadman_code, date_pointage_jour
+),
+
+-- ============================================================
+-- CTE 2 : Fin de journée = dernier END_DAY postérieur au début
+-- (évite une fin antérieure au début le même jour)
+-- ============================================================
+pointage_final as (
+    select
+        d.resources_roadman_id,
+        d.roadman_code,
+        d.date_pointage_jour,
+        d.date_pointage_debut,
+        max(case
+            when
+                pf.label_code = 'END_DAY'
+                and pf.date_pointage >= d.date_pointage_debut
+                then pf.date_pointage
+        end) as date_pointage_fin
+    from pointage_debut as d
+    left join {{ ref('int_oracle_lcdp__pointage_tasks') }} as pf
+        on
+            d.resources_roadman_id = pf.resources_roadman_id
+            and d.date_pointage_jour = pf.date_pointage_jour
+    group by
+        d.resources_roadman_id,
+        d.roadman_code,
+        d.date_pointage_jour,
+        d.date_pointage_debut
+),
+
+-- ============================================================
+-- CTE 3 : Tâches appro enrichies + pointage début/fin joint
+-- ============================================================
+passage_appro as (
+    select
+        e.*,
+        p.date_pointage_debut,
+        p.date_pointage_fin,
+        p.date_pointage_jour,
+        case when p.date_pointage_debut is null then 1 else 0 end as pointage_missing_flag
+    from {{ ref('int_oracle_lcdp__appro_tasks_enriched') }} as e
+    left join pointage_final as p
+        on
+            e.start_date_day = p.date_pointage_jour
+            and e.resources_roadman_id = p.resources_roadman_id
+)
+
+-- ============================================================
+-- Sélection finale (grain : 1 ligne par task_id)
+-- ============================================================
+select
+    -- 1️⃣ IDs
+    task_id,
+    device_id,
+    company_id,
+    resources_roadman_id,
+    product_source_id,
+    product_destination_id,
+
+    -- 2️⃣ Attributs
+    company_code,
+    company_name,
+    company_info,
+    device_code,
+    device_name,
+    device_info,
+    roadman_code,
+    roadman_name,
+    product_source_type,
+    product_destination_type,
+    task_location_info,
+    task_status_code,
+
+    -- 3️⃣ Dates / Temps
+    date_pointage_debut,
+    date_pointage_fin,
+    date_pointage_jour,
+    start_date_day,
+    task_start_date,
+    task_end_date,
+
+    -- 4️⃣ Mesures / Flags
+    passage_duration_min,
+    is_planned,
+    is_done,
+    is_anomaly,
+    pointage_missing_flag,
+
+    -- 5️⃣ Métadonnées
+    created_at,
+    updated_at,
+    current_timestamp() as dbt_updated_at,
+    '{{ invocation_id }}' as dbt_invocation_id  -- noqa: TMP
+
+from passage_appro

--- a/selectors.yml
+++ b/selectors.yml
@@ -25,6 +25,6 @@ selectors:
         - method: fqn
           value: fct_neshu__passage_appro
           parents: true
-        # TODO(lcdp): ajouter `fct_lcdp__appro` ici une fois le mart créé.
-        # Le monitoring LCDP n'existe aujourd'hui qu'en pipeline Python ;
-        # le mart dbt reste à porter (cf. consolidation passages_appro).
+        - method: fqn
+          value: fct_lcdp__passage_appro
+          parents: true


### PR DESCRIPTION
Porte les passages appro LCDP dans dbt au niveau des marts (même démarche que neshu), 1ʳᵉ étape avant la fast-lane LCDP.

## Nouveaux modèles
- **`int_oracle_lcdp__appro_tasks_enriched`** : roadman (type 2, + roadman_name) + noms company/device, statut normalisé (ENCOURS→FAIT), flags `is_done`/`is_planned`/`is_anomaly`, `passage_duration_min`.
- **`fct_lcdp__passage_appro`** : + pointage **début/fin** par roadman/jour dérivé de `int_oracle_lcdp__pointage_tasks` (début = 1er START_DAY ≥ 03:00, fin = dernier END_DAY ≥ début). Grain 1 ligne/task_id, partition `task_start_date`.

## Décisions de design (validées)
- Pointage **début + fin** (plus riche que le `date_pointage` unique déployé)
- KPIs **lean** (parité monitoring, pas de window KPIs)
- **ANOMALIE** incluse dans `is_planned` + flag `is_anomaly` (cohérent avec neshu)
- `roadman_name` ajouté ; **pas de colonne INTERVAL** (sûr pour le connecteur PBI)

## Validation
- dev : **110/110 tests** verts (PK, 3 FK vers dim_lcdp__company/device/resource, flags, clé composite).
- Parité vs `prod_marts.fct_lcdp__monitoring_passage_appro` : `date_pointage_debut` == `date_pointage` déployé (0 diff), `company_code`/`device_code` 0 diff. Écarts `is_planned` (884) = **100% ANOMALIE** (changement voulu) ; 211 clés manquantes = dates aujourd'hui+futur (lag EL, `prod_raw` en retard sur l'Oracle lu en direct par le Python).

## Suite (étape séparée, comme neshu)
Fast-lane LCDP : tap `tap-oracle-appro-fastlane` côté `elt_oracle_lcdp` + réécriture du workflow `pipeline-passages-appro-lcdp` (EL+dbt selector) + cutover PBI + retrait Python.

🤖 Generated with [Claude Code](https://claude.com/claude-code)