### PR TITLE
feat(selectors): isolate passage_appro fast-lane per BU

### DIFF
--- a/docs/pipeline-schedule.md
+++ b/docs/pipeline-schedule.md
@@ -33,8 +33,8 @@ marts aval). Le transform n'a plus d'horaire propre : il suit la fin de l'EL de 
 07:30  EL+T  nesp_tech (lundi seulement)                              → + marts technique, commerce
 08:00  EL+T  sftp_evs/gac, nesp_co                                    → + marts services_generaux, commerce
 09:00  SN    transform-snapshots-daily (tous snapshots)
-08,11,15h  EL+T  passages-appro-neshu (fast-lane: tap appro + selector passage_appro_fastlane) → fct_neshu__passage_appro
-08,11,15,18h  EL+T  passages-appro-lcdp (fast-lane: tap appro + selector passage_appro_fastlane) → fct_lcdp__passage_appro
+08,11,15h  EL+T  passages-appro-neshu (fast-lane: tap appro + selector passage_appro_fastlane_neshu) → fct_neshu__passage_appro
+08,11,15,18h  EL+T  passages-appro-lcdp (fast-lane: tap appro + selector passage_appro_fastlane_lcdp) → fct_lcdp__passage_appro
 23:00  EL+T  oracle_stock_theorique                                  → + marts supply_chain
 23:15  EL+T  oracle_lcdp_stock_theorique                             → + marts supply_chain (lcdp)
 ─────────────────────────────────────────────────────────────────────────────────
@@ -57,9 +57,9 @@ homonyme dans `workflows/*.yaml`.
 |---|---|---|---|---|
 | pipeline-oracle-neshu | `0 1 * * *` | tous | pipeline-oracle-neshu.yaml | oracle_neshu |
 | pipeline-oracle-neshu-full-refresh | `0 4 * * 0` | dim | pipeline-oracle-neshu-full-refresh.yaml | oracle_neshu (full) |
-| pipeline-passages-appro-neshu | `0 8,11,15 * * 1-5` | lun-ven | pipeline-passages-appro-neshu.yaml | oracle_neshu (fast-lane appro: EL `tap-oracle-appro-fastlane` + dbt selector `passage_appro_fastlane` + refresh PBI) |
+| pipeline-passages-appro-neshu | `0 8,11,15 * * 1-5` | lun-ven | pipeline-passages-appro-neshu.yaml | oracle_neshu (fast-lane appro: EL `tap-oracle-appro-fastlane` + dbt selector `passage_appro_fastlane_neshu` + refresh PBI) |
 | pipeline-oracle-lcdp | `0 1 * * *` | tous | pipeline-oracle-lcdp.yaml | oracle_lcdp |
-| pipeline-passages-appro-lcdp | `5 8,11,15,18 * * 1-5` | lun-ven | pipeline-passages-appro-lcdp.yaml | oracle_lcdp (fast-lane appro: EL `tap-oracle-lcdp-appro-fastlane` + dbt selector `passage_appro_fastlane` + refresh PBI) |
+| pipeline-passages-appro-lcdp | `0 8,11,15,18 * * 1-5` | lun-ven | pipeline-passages-appro-lcdp.yaml | oracle_lcdp (fast-lane appro: EL `tap-oracle-lcdp-appro-fastlane` + dbt selector `passage_appro_fastlane_lcdp` + refresh PBI) |
 | pipeline-mssql-sage | `0 1 * * 1-5` | lun-ven | pipeline-mssql-sage.yaml | mssql_sage |
 | pipeline-yuman | `0 1 * * 1-5` | lun-ven | pipeline-yuman.yaml | yuman |
 | pipeline-zoho-desk | `0 3 * * 1-5` | lun-ven | pipeline-zoho-desk.yaml | zoho_desk |

--- a/selectors.yml
+++ b/selectors.yml
@@ -2,23 +2,42 @@ selectors:
   # ============================================================
   # FAST-LANE — Passages appro (refresh intra-day)
   # ============================================================
-  # Sous-graphe minimal alimentant les marts de passages appro.
-  # Construit UNIQUEMENT les ancêtres de fct_{neshu,lcdp}__appro
-  # (staging.task incremental + intermediate.appro_tasks incremental
-  # + dims neshu/lcdp), PAS tout le DAG des sources Oracle.
+  # Sous-graphe minimal alimentant un mart de passages appro : ancêtres
+  # de fct_<bu>__passage_appro (staging.task + intermediate.appro_tasks
+  # incrémentaux + enriched + pointage + dims), PAS tout le DAG Oracle.
   #
-  # Usage : voie rapide orchestrée plusieurs fois/jour, en parallèle
-  # du build nocturne `source:oracle_neshu+` / `source:oracle_lcdp+`.
-  #   dbt build --selector passage_appro_fastlane
+  # Production : chaque workflow EL appelle SON selector par BU (isolé),
+  # pour ne rebuild que sa propre BU :
+  #   pipeline-passages-appro-neshu  → passage_appro_fastlane_neshu
+  #   pipeline-passages-appro-lcdp   → passage_appro_fastlane_lcdp
   #
-  # Remplace les pipelines Python externes
-  # ingest-oracle-{neshu,lcdp}-passages-appro (cf. consolidation
-  # passages_appro : une seule définition métier, dans dbt).
+  # Le selector combiné `passage_appro_fastlane` reste disponible pour un
+  # full refresh manuel des deux BUs (`dbt build --selector passage_appro_fastlane`).
   # ============================================================
+
+  - name: passage_appro_fastlane_neshu
+    description: >
+      Sous-graphe ancêtre de fct_neshu__passage_appro (refresh intra-day neshu).
+    default: false
+    definition:
+      method: fqn
+      value: fct_neshu__passage_appro
+      parents: true
+
+  - name: passage_appro_fastlane_lcdp
+    description: >
+      Sous-graphe ancêtre de fct_lcdp__passage_appro (refresh intra-day lcdp).
+    default: false
+    definition:
+      method: fqn
+      value: fct_lcdp__passage_appro
+      parents: true
+
+  # Combiné : neshu + lcdp d'un coup. Pour full refresh manuel uniquement,
+  # PAS utilisé par les workflows (qui sont isolés par BU ci-dessus).
   - name: passage_appro_fastlane
     description: >
-      Sous-graphe ancêtre des marts passages appro (neshu + lcdp),
-      pour refresh intra-day sans rebuild des sources Oracle complètes.
+      Full refresh manuel des deux marts passages appro (neshu + lcdp).
     default: false
     definition:
       union:


### PR DESCRIPTION
Isole les voies rapides passages appro par BU pour ne plus rebuild les deux marts à chaque run.

## Pourquoi
Les 2 workflows (neshu, lcdp) utilisaient le même selector combiné `passage_appro_fastlane` (union neshu+lcdp) → chaque run reconstruisait les **deux** marts (26 modèles), alors qu'un run ne rafraîchit qu'une BU. Compute redondant + besoin d'un décalage de cron pour éviter 2 `dbt build` concurrents sur les mêmes tables.

## Changements (`selectors.yml`)
- **`passage_appro_fastlane_neshu`** → `+fct_neshu__passage_appro` (13 modèles)
- **`passage_appro_fastlane_lcdp`** → `+fct_lcdp__passage_appro` (13 modèles)
- **`passage_appro_fastlane`** (combiné) conservé pour **full refresh manuel** uniquement (plus utilisé par les workflows)

## Suite (hors PR, à déployer ensemble)
- workflows : `DBT_SELECTOR_NAME` → selector par BU (direct master)
- infra : cron lcdp `5 8,11,15,18` → `0 8,11,15,18` (décalage minute 5 devenu inutile)
- Transition sans fenêtre de casse : le combiné reste dispo le temps que les workflows basculent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)