### PR TITLE
fix(neshu): past_* vide sur fct_neshu__machine_appro_intervention (demand_status)

### DIFF
--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -75,7 +75,7 @@ with appro_context as (
 --     en pause = pause historique, déjà reprise et clôturée).
 --
 -- Logique des buckets (statut-d'abord, mutuellement exclusifs) :
---   - past    : workorder_status = 'Closed'      + demand Accepted + date_done dans [J-15 ; aujourd'hui]
+--   - past    : workorder_status = 'Closed'      + demand Closed   + date_done dans [J-15 ; aujourd'hui]
 --   - current : workorder_status = 'In progress' + demand Accepted (toute date)
 --   - future  : workorder_status = 'Scheduled'   + demand Accepted (toute date, y compris planifié en retard)
 -- Chaque WO réel a un statut unique → tombe dans au plus un bucket
@@ -118,7 +118,9 @@ yuman_workorders as (
         case
             when
                 any_value(workorder_status) = 'Closed'
-                and any_value(demand_status) = 'Accepted'
+                -- une demande dont le WO est clôturé bascule en 'Closed'
+                -- (et non 'Accepted', contrairement aux buckets current/future)
+                and any_value(demand_status) = 'Closed'
                 and max(date_done) is not null
                 and date(max(date_done))
                 between date_sub(current_date(), interval 15 day)


### PR DESCRIPTION
## Contexte

Signalé par la Data Analyst : sur le **dashboard de pilotage des passages d'approvisionnement et interventions machines**, le filtre **« CLÔTURÉ J-15 »** n'affiche aucune donnée, la page reste vide.

Vérification dans `prod_marts.fct_neshu__machine_appro_intervention` (1 846 lignes) : **toutes les colonnes `past_*` sont vides** (0 valeur renseignée sur `past_intervention_id`, `past_intervention_number`, `past_technician_id`, `past_date_started`, `past_date_planned`, `past_date_done`), alors que les colonnes `future_*` sont bien alimentées (11 interventions futures).

## Cause racine

Le bucket `past` (flag `is_past_intervention_15d`) exigeait **simultanément** :
- `workorder_status = 'Closed'`
- `demand_status = 'Accepted'`

Or dans l'amont `int_yuman__demands_workorders_enriched`, **aucun** workorder NESHU curatif clôturé n'a `demand_status = 'Accepted'` : quand un workorder passe à `Closed`, sa demande Yuman bascule elle aussi en `Closed`.

Répartition des WO NESHU curatifs (hors « non faites ») :

| workorder_status | demand_status | nb | done 15j | done 90j | max date_done |
|---|---|---|---|---|---|
| **Closed** | **Closed** | 5 451 | **103** | 594 | 2026-06-19 |
| Scheduled | Accepted | 13 | — | — | — |
| In progress | Accepted | 7 | — | — | — |
| (null) | Rejected | 41 | — | — | — |

Le bucket `past` cherchait `Closed` + `Accepted` → **0 ligne possible**. Les buckets `current` (`In progress` + `Accepted`) et `future` (`Scheduled` + `Accepted`) n'étaient pas touchés car ces WO non clôturés conservent une demande `Accepted`. C'est une incohérence de logique (la même condition `demand = 'Accepted'` copiée sur les 3 buckets, valable seulement pour current/future).

## Correctif

Bucket `past` : `demand_status = 'Closed'` (au lieu de `'Accepted'`), + commentaires de logique des buckets mis à jour pour documenter la distinction.

```diff
 when
     any_value(workorder_status) = 'Closed'
-    and any_value(demand_status) = 'Accepted'
+    -- une demande dont le WO est clôturé bascule en 'Closed'
+    -- (et non 'Accepted', contrairement aux buckets current/future)
+    and any_value(demand_status) = 'Closed'
     and max(date_done) is not null
```

## Validation

Logique corrigée testée contre `prod_intermediate` (read-only, pas de build prod) :
- **103 workorders** clôturés sur les 15 derniers jours (594 sur 90j, dernier au 2026-06-19)
- rattachés à **88 machines en appro** (sur 1 846) qui auront désormais leurs `past_*` renseignés — au lieu de 0 aujourd'hui

`sqlfluff lint` : OK. Build prod effectif au merge (CI).

## À savoir (hors périmètre de ce fix)

- **Période figée dans le SQL** : la fenêtre `[J-15 ; aujourd'hui]` du bucket `past` est en dur dans le modèle. Si le besoin est une période glissante pilotée côté Power BI, il faudra élargir/retirer ce filtre côté dbt — sinon le mart borne à 15j quoi qu'il arrive.
- **Jointure cross-source fragile** : `device_code` Neshu = serial Yuman normalisé (`UPPER` + `TRIM` + strip `NESH_`). Ici 88/92 machines matchent ; 4 serials Yuman restent sans correspondance appro. À remplacer par une table de mapping device dans un PR ultérieur (déjà noté en commentaire dans le modèle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
