### PR TITLE
feat(appro): scope passage_appro (PREVU/FAIT/ANOMALIE) + sortir ANOMALIE du taux LCDP

### DIFF
--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1376,7 +1376,7 @@ models:
       1 ligne par task_id (PK), uniquement les passages avec roadman.
 
       [NOTES]
-      is_planned = PREVU/FAIT/ENCOURS/ANOMALIE ; is_done = FAIT/ENCOURS ; is_anomaly = ANOMALIE.
+      is_planned = PREVU/FAIT/ENCOURS (ANOMALIE exclu de la base du taux) ; is_done = FAIT/ENCOURS ; is_anomaly = ANOMALIE.
       passage_duration_min calculée seulement pour les passages FAIT.
     columns:
       - name: task_id
@@ -1397,7 +1397,7 @@ models:
         description: "Indicateur binaire : 1 si réalisé (statut brut FAIT ou ENCOURS), sinon 0."
         data_type: int64
       - name: is_planned
-        description: "Indicateur binaire : 1 si statut brut PREVU, FAIT, ENCOURS ou ANOMALIE, sinon 0."
+        description: "Indicateur binaire : 1 si statut brut PREVU, FAIT ou ENCOURS, sinon 0. ANOMALIE volontairement exclu de la base du taux (règle métier non figée)."
         data_type: int64
       - name: is_anomaly
         description: "Indicateur binaire : 1 si statut brut ANOMALIE, sinon 0."

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__appro_tasks_enriched.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__appro_tasks_enriched.sql
@@ -53,8 +53,10 @@ enriched as (
             else pa.task_status_code
         end as task_status_code,
         case when pa.task_status_code in ('FAIT', 'ENCOURS') then 1 else 0 end as is_done,
+        -- ANOMALIE volontairement exclu de la base du taux (règle métier non figée) :
+        -- les anomalies restent visibles via is_anomaly mais ne pèsent pas au dénominateur.
         case
-            when pa.task_status_code in ('PREVU', 'FAIT', 'ENCOURS', 'ANOMALIE') then 1 else 0
+            when pa.task_status_code in ('PREVU', 'FAIT', 'ENCOURS') then 1 else 0
         end as is_planned,
         case when pa.task_status_code = 'ANOMALIE' then 1 else 0 end as is_anomaly,
 

--- a/models/marts/lcdp/_lcdp__marts_models.yml
+++ b/models/marts/lcdp/_lcdp__marts_models.yml
@@ -464,7 +464,7 @@ models:
       [QUOI MÉTIER] Passages APPRO des roadmen chez les clients LCDP, enrichis du pointage début/fin de journée du roadman.
       [COMMENT CONSTRUITE] Issu de int_oracle_lcdp__appro_tasks_enriched (tâches appro idtask_type=32 + roadman type 2 + référentiels company/device, statut ENCOURS reclassé FAIT) joint au pointage journalier dérivé de int_oracle_lcdp__pointage_tasks : date_pointage_debut = premier START_DAY ≥ 03:00 par roadman/jour, date_pointage_fin = dernier END_DAY postérieur au début le même jour.
       [GRAIN] 1 ligne par task_id (1 tâche APPRO).
-      [NOTES] is_planned (PREVU/FAIT/ENCOURS/ANOMALIE) / is_done (FAIT/ENCOURS) / is_anomaly (ANOMALIE) : indicateurs binaires. pointage_missing_flag=1 si aucun début de journée trouvé pour le roadman ce jour. passage_duration_min calculée uniquement pour les passages FAIT.
+      [NOTES] Périmètre restreint aux statuts PREVU / FAIT / ANOMALIE (ENCOURS déjà replié en FAIT en intermédiaire) ; ANNULE et VALIDE sont exclus au niveau de ce mart (l'intermédiaire conserve le périmètre complet). is_planned (PREVU/FAIT/ENCOURS) / is_done (FAIT/ENCOURS) / is_anomaly (ANOMALIE) : indicateurs binaires. ANOMALIE est exclu de is_planned (donc du dénominateur du taux, règle métier non figée) mais les lignes anomalie restent présentes et identifiables via is_anomaly. Taux de réalisation = sum(is_done)/sum(is_planned). pointage_missing_flag=1 si aucun début de journée trouvé pour le roadman ce jour. passage_duration_min calculée uniquement pour les passages FAIT.
 
     columns:
       - name: task_id
@@ -571,7 +571,9 @@ models:
         description: Durée du passage en minutes (fin - début). NULL si passage non terminé.
 
       - name: is_planned
-        description: Indicateur binaire — tâche planifiée (1) si statut PREVU / FAIT / ENCOURS / ANOMALIE, sinon 0
+        description: >
+          Indicateur binaire — tâche planifiée (1) si statut PREVU / FAIT / ENCOURS, sinon 0.
+          ANOMALIE volontairement exclu : base du dénominateur du taux de réalisation (règle métier non figée).
         tests:
           - accepted_values:
               arguments:

--- a/models/marts/lcdp/fct_lcdp__passage_appro.sql
+++ b/models/marts/lcdp/fct_lcdp__passage_appro.sql
@@ -119,3 +119,6 @@ select
     '{{ invocation_id }}' as dbt_invocation_id  -- noqa: TMP
 
 from passage_appro
+-- Périmètre du rapport : PREVU / FAIT (ENCOURS déjà replié en FAIT) + ANOMALIE en flag.
+-- ANNULE / VALIDE exclus. ANOMALIE reste hors du taux via is_planned (défini en intermédiaire).
+where task_status_code in ('PREVU', 'FAIT', 'ANOMALIE')

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -678,7 +678,7 @@ models:
       [QUOI MÉTIER] Passages APPRO des roadmen enrichis des métriques journalières de temps de travail.
       [COMMENT CONSTRUITE] Issu de int_oracle_neshu__appro_tasks joint à int_oracle_neshu__pointage_tasks (START_DAY) pour le pointage journalier du roadman. Calculs window function par roadman et jour : rang du passage, nombre quotidien de passages, durée moyenne, durée nette du temps de travail (dernière fin - début effectif, nettoyée des valeurs aberrantes <0 ou >12h). Statut ENCOURS reclassé en FAIT après validation métier.
       [GRAIN] 1 ligne par task_id (1 tâche APPRO).
-      [NOTES] effective_work_start = pointage si disponible, sinon première tâche du jour. is_planned (PREVU/FAIT/ENCOURS/ANOMALIE) / is_done (FAIT/ENCOURS) / is_anomaly (ANOMALIE) : indicateurs binaires. Source de vérité unique des passages appro (KPIs journaliers + attributs détaillés), consommée par le monitoring et le reporting appro.
+      [NOTES] Périmètre restreint aux statuts PREVU / FAIT / ANOMALIE (filtré dans la CTE passage_appro, avant les window functions, pour que les métriques journalières ne portent que sur ce périmètre) ; ANNULE / VALIDE / ACQUITTE / ENATTENTE exclus. NESHU compte les anomalies : ANOMALIE est inclus dans is_planned (donc dans le taux). effective_work_start = pointage si disponible, sinon première tâche du jour. is_planned (PREVU/FAIT/ENCOURS/ANOMALIE) / is_done (FAIT/ENCOURS) / is_anomaly (ANOMALIE) : indicateurs binaires. Source de vérité unique des passages appro (KPIs journaliers + attributs détaillés), consommée par le monitoring et le reporting appro.
 
     columns:
 

--- a/models/marts/neshu/fct_neshu__passage_appro.sql
+++ b/models/marts/neshu/fct_neshu__passage_appro.sql
@@ -79,6 +79,10 @@ passage_appro as (
         on
             e.start_date_day = p.date_pointage_jour
             and e.resources_roadman_id = p.resources_roadman_id
+    -- Périmètre du rapport : PREVU / FAIT + ANOMALIE (NESHU compte les anomalies, is_planned les inclut).
+    -- ANNULE / VALIDE / ACQUITTE / ENATTENTE exclus. Filtré ici pour que les métriques
+    -- journalières (window functions) ne portent que sur ce périmètre.
+    where e.task_status_code in ('PREVU', 'FAIT', 'ANOMALIE')
 ),
 
 -- ============================================================


### PR DESCRIPTION
## Contexte

Les marts `passage_appro` (LCDP & NESHU) gardaient **tous** les statuts de tâches, y compris les annulés (`ANNULE`, `VALIDE`, `ACQUITTE`, `ENATTENTE`) qui polluaient les comptages bruts. Par ailleurs, la **règle de traitement des anomalies n'est pas figée** côté LCDP : on ne veut pas qu'elles pèsent sur le taux de réalisation pour l'instant, tout en les gardant visibles. NESHU, lui, **compte** les anomalies dans le taux.

Cette PR scope les deux marts au périmètre métier utile et applique le traitement différencié des anomalies par BU.

## Changements

### LCDP — anomalies **hors** du taux (flag uniquement)

| Fichier | Changement |
|---|---|
| `int_oracle_lcdp__appro_tasks_enriched.sql` | `is_planned` exclut désormais `ANOMALIE` → `PREVU/FAIT/ENCOURS`. Périmètre complet conservé (tous statuts restent dans l'intermédiaire, réutilisable). `is_anomaly` inchangé. |
| `fct_lcdp__passage_appro.sql` | `where task_status_code in ('PREVU','FAIT','ANOMALIE')` au `select` final. Exclut `ANNULE` (1 274), `VALIDE` (2). |

→ Anomalies présentes comme indication (`is_anomaly=1`) mais `is_planned=0` → **hors du dénominateur du taux**.

### NESHU — anomalies **comptées** dans le taux (inchangé)

| Fichier | Changement |
|---|---|
| `fct_neshu__passage_appro.sql` | `where task_status_code in ('PREVU','FAIT','ANOMALIE')` dans la **CTE `passage_appro`** (avant les window functions), pour que les métriques journalières (`daily_task_count`, `passage_rank_of_day`, `avg_passage_duration_day`, `taux_realisation_*`) ne portent que sur le périmètre. Exclut `ANNULE` (77 165), `VALIDE`, `ACQUITTE`, `ENATTENTE`. |

→ Intermédiaire NESHU **non modifié** : `is_planned` inclut toujours `ANOMALIE` (65 lignes) → comptées dans le taux.

### Pourquoi un placement différent du `WHERE` ?

- **LCDP** : pas de window function en amont → filtre au `select` final, suffisant.
- **NESHU** : métriques journalières calculées par window functions sur tout le périmètre → filtre placé **avant** les fenêtres, sinon les 77k `ANNULE` (≈13 % des lignes) gonflent `daily_task_count` / `passage_rank_of_day`.

### Doc
Descriptions YAML mises à jour (intermédiaire LCDP `is_planned` + `[NOTES]` des 2 marts) pour tracer le périmètre et la règle anomalies par BU.

## Récap de la règle par BU

| Mart | Périmètre | ANOMALIE dans le taux ? |
|---|---|---|
| `fct_lcdp__passage_appro` | PREVU / FAIT / ANOMALIE | **Non** (flag seul) |
| `fct_neshu__passage_appro` | PREVU / FAIT / ANOMALIE | **Oui** (comptée) |

## Validation (dev)

- Lint `sqlfluff` : OK sur les 3 modèles SQL.
- `dbt build` LCDP (intermédiaire + mart) : **17 PASS / 0 fail**.
- `dbt build` NESHU (mart) : **10 PASS / 0 fail**.
- Répartition statuts post-filtre vérifiée en `dev_marts` :
  - LCDP : FAIT 47 773 (taux), PREVU 1 406 (taux), ANOMALIE 920 (flag, `is_planned=0`). Taux ≈ 97,1 %.
  - NESHU : FAIT 473 983, PREVU 4 444, ANOMALIE 65 (`is_planned=1`, comptée). ANNULE/VALIDE/ACQUITTE/ENATTENTE absents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
