### PR TITLE
fix(neshu): cohérence des marts appro chargement (doc, tests, star schema, filtre statut)

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -482,10 +482,19 @@ models:
 
   - name: fct_neshu__chargement_consommation
     description: |
-      [QUOI MÉTIER] Quantités chargées vs consommées par machine et par passage APPRO (taux d'écoulement).
+      [QUOI MÉTIER] Quantités chargées vs consommées par machine et par jour de passage APPRO (taux d'écoulement).
       [COMMENT CONSTRUITE] Pour chaque passage APPRO d'une machine, calcul via LAG du passage précédent pour borner la période d'écoulement ; q_consommee = somme des télémétries entre les deux passages ; q_chargee = somme des chargements lors du passage actuel. Sources : int_oracle_neshu__chargement_tasks, int_oracle_neshu__telemetry_tasks, jointes par device_id et period bounds.
-      [GRAIN] 1 ligne par (device_id, date_debut_passage_appro, product_id).
-      [NOTES] roadman_code = nom du roadman associé au véhicule source (attribut d'affichage). product_source_id / product_source_type = identifiant et type Oracle de la source du chargement (exposés pour diagnostic, pas de test FK car mart combinant plusieurs intermediates). product_type aplati pour filtre BI. product_code conservé en attribut d'affichage.
+      [GRAIN] 1 ligne par (device_id, date_debut_passage_appro, product_id). Grain JOURNALIER, pas par passage : les jours à plusieurs passages (~1,7 % des device-jours) sont fusionnés en une seule ligne.
+      [NOTES]
+      ⚠️ q_consommee = somme BRUTE des télémétries, SANS arbitrage télémétrie/chargement ni multiplicateur de conditionnement. Ce N'EST PAS la métrique officielle de consommation : le volume de consommation arbitré (consommation_volume du semantic layer) est porté par fct_neshu__consommation. Ne pas confondre les deux.
+      Ce mart re-dérive sa propre notion de passage (int_oracle_neshu__appro_tasks filtré task_status_code='FAIT', depuis 2025-01-01) et n'est PAS aligné sur fct_neshu__passage_appro (source de vérité passages, périmètre PREVU/FAIT/ANOMALIE) — ré-ancrage à prévoir.
+      q_chargee utilise un MAX (et non un SUM) : sur un jour à plusieurs passages, la jointure chargement par DATE duplique le total journalier sur chaque passage, le MAX dédoublonne ce total. task_start_date_min = MIN des horodatages des passages du jour (pas un horodatage unique).
+      roadman_code = nom du roadman associé au véhicule source (attribut d'affichage). product_source_id / product_source_type = identifiant et type Oracle de la source du chargement (exposés pour diagnostic, pas de test FK car mart combinant plusieurs intermediates). product_type aplati pour filtre BI. product_code conservé en attribut d'affichage.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [device_id, date_debut_passage_appro, product_id]
 
     columns:
       - name: device_id
@@ -503,7 +512,7 @@ models:
           - not_null
 
       - name: task_start_date_min
-        description: "Horodatage exact du passage APPRO."
+        description: "Horodatage du premier passage APPRO du jour (MIN sur les passages fusionnés dans la ligne)."
 
       - name: date_passage_precedent
         description: "Date du passage APPRO précédent pour ce device."
@@ -547,10 +556,16 @@ models:
           - not_null
 
       - name: q_consommee
-        description: "Quantité consommée entre le passage précédent et le passage actuel."
+        description: "Somme BRUTE des télémétries écoulées entre le passage précédent et le passage actuel (sans arbitrage ni conditionnement). Ne correspond PAS à la métrique officielle consommation_volume (cf. fct_neshu__consommation)."
 
       - name: q_chargee
-        description: "Quantité chargée lors du passage APPRO."
+        description: "Quantité chargée lors du passage APPRO (MAX du total journalier, cf. NOTES)."
+
+      - name: dbt_updated_at
+        description: "Horodatage de la dernière exécution dbt ayant matérialisé la ligne."
+
+      - name: dbt_invocation_id
+        description: "Identifiant d'invocation dbt ayant produit la ligne (traçabilité du run)."
 
 
   - name: fct_neshu__chargement_quinzaine
@@ -587,10 +602,10 @@ models:
 
   - name: dim_neshu__resource
     description: |
-      [QUOI MÉTIER] Dimension ressource Oracle Neshu : roadmen (PERSON) + véhicules (VEHICULE) avec hiérarchie.
+      [QUOI MÉTIER] Dimension ressource Oracle Neshu : roadmen (PERSON) + véhicules (VEHICLE) avec hiérarchie.
       [COMMENT CONSTRUITE] Issu de stg_oracle_neshu__resources, pivot des labels via stg_oracle_neshu__label_has_resources : ISACTIVE, Fonction. Enrichi du code GEA depuis ref_oracle_neshu__roadman_gea (seed) sur les PERSON uniquement (jointure resources_code).
       [GRAIN] 1 ligne par resources_id.
-      [NOTES] Hiérarchie : resources_idresources d'un VEHICULE pointe vers l'ID du roadman PERSON associé ; NULL pour les roadmen. code_status_record conservé (1=actif) sans filtre — filtrage à la volée côté BI. is_active converti en booléen.
+      [NOTES] Hiérarchie : resources_idresources d'un VEHICLE pointe vers l'ID du roadman PERSON associé ; NULL pour les roadmen. code_status_record conservé (1=actif) sans filtre — filtrage à la volée côté BI. is_active converti en booléen.
     columns:
       - name: resources_id
         description: "Identifiant unique de la ressource dans Oracle"
@@ -603,7 +618,7 @@ models:
 
       - name: resources_idresources
         description: >
-          Lien vers la ressource associée. Pour un véhicule (VEHICULE) : pointe vers l'ID du roadman (PERSON) associé.
+          Lien vers la ressource associée. Pour un véhicule (VEHICLE) : pointe vers l'ID du roadman (PERSON) associé.
           Pour un roadman (PERSON) : NULL.
 
       - name: company_id
@@ -634,7 +649,7 @@ models:
         description: "Nom de la ressource"
 
       - name: resources_type
-        description: "Type de ressource : PERSON (roadman) ou VEHICULE"
+        description: "Type de ressource : PERSON (roadman) ou VEHICLE (véhicule)"
         tests:
           - not_null
 

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -488,7 +488,7 @@ models:
       [NOTES]
       ⚠️ q_consommee = somme BRUTE des télémétries, SANS arbitrage télémétrie/chargement ni multiplicateur de conditionnement. Ce N'EST PAS la métrique officielle de consommation : le volume de consommation arbitré (consommation_volume du semantic layer) est porté par fct_neshu__consommation. Ne pas confondre les deux.
       Ce mart re-dérive sa propre notion de passage (int_oracle_neshu__appro_tasks filtré task_status_code='FAIT', depuis 2025-01-01) et n'est PAS aligné sur fct_neshu__passage_appro (source de vérité passages, périmètre PREVU/FAIT/ANOMALIE) — ré-ancrage à prévoir.
-      q_chargee utilise un MAX (et non un SUM) : sur un jour à plusieurs passages, la jointure chargement par DATE duplique le total journalier sur chaque passage, le MAX dédoublonne ce total. task_start_date_min = MIN des horodatages des passages du jour (pas un horodatage unique).
+      q_chargee : chargement filtré sur task_status_code in ('FAIT', 'VALIDE') (ANNULE/ANOMALIE exclus, aligné sur fct_neshu__consommation). Utilise un MAX (et non un SUM) : sur un jour à plusieurs passages, la jointure chargement par DATE duplique le total journalier sur chaque passage, le MAX dédoublonne ce total. task_start_date_min = MIN des horodatages des passages du jour (pas un horodatage unique).
       roadman_code = nom du roadman associé au véhicule source (attribut d'affichage). product_source_id / product_source_type = identifiant et type Oracle de la source du chargement (exposés pour diagnostic, pas de test FK car mart combinant plusieurs intermediates). product_type aplati pour filtre BI. product_code conservé en attribut d'affichage.
 
     tests:
@@ -577,7 +577,7 @@ models:
       ⚠️ Périmètre restreint aux machines GRATUITES (device_economic_model = 'Gratuit') — non comparable au chargement total.
       ⚠️ Fenêtre glissante : seuls les 730 derniers jours (interval 730 day) sont inclus.
       quantite_chargee = somme de load_quantity (déjà déconditionnée par les coefficients Oracle unit_coeff_multi/div dans l'intermediate), MAIS sans le multiplicateur de conditionnement seed (units_per_pack) que fct_neshu__consommation applique en plus — d'où un écart avec le chargement de fct_neshu__consommation.
-      Aucun filtre de statut : inclut FAIT/VALIDE mais aussi ANNULE/ANOMALIE (volume négligeable, ~0,005 %).
+      Chargement filtré sur task_status_code in ('FAIT', 'VALIDE') (ANNULE/ANOMALIE exclus), aligné sur fct_neshu__consommation.
       quinzaine_chgt ∈ [1, 27].
 
     tests:

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -570,21 +570,34 @@ models:
 
   - name: fct_neshu__chargement_quinzaine
     description: |
-      [QUOI MÉTIER] Quantités chargées par client, type de produit, année et quinzaine.
-      [COMMENT CONSTRUITE] Issu de int_oracle_neshu__chargement_tasks joint à dim_neshu__product (product_type) et dim_neshu__device (company_code). Regroupement BOISSONS FRAICHES + SNACKING → SODA + SNACKS pour le reporting BI. Quinzaine calculée depuis le lundi de référence de l'année (FLOOR(jours / 14) + 1).
+      [QUOI MÉTIER] Quantités chargées sur les machines GRATUITES uniquement, par client, type de produit, année et quinzaine.
+      [COMMENT CONSTRUITE] Issu de int_oracle_neshu__chargement_tasks : company_code provient directement de chargement_tasks, product_type de dim_neshu__product, company_name de stg_oracle_neshu__company ; le join dim_neshu__device sert UNIQUEMENT à filtrer device_economic_model = 'Gratuit' (machines gratuites). Regroupement BOISSONS FRAICHES + SNACKING → SODA + SNACKS pour le reporting BI. Quinzaine = floor(jours écoulés depuis le lundi de la semaine du 1er janvier / 14) + 1.
       [GRAIN] 1 ligne par (product_type, company_code, annee_chgt, quinzaine_chgt).
-      [NOTES] quinzaine_chgt ∈ [1, 27].
+      [NOTES]
+      ⚠️ Périmètre restreint aux machines GRATUITES (device_economic_model = 'Gratuit') — non comparable au chargement total.
+      ⚠️ Fenêtre glissante : seuls les 730 derniers jours (interval 730 day) sont inclus.
+      quantite_chargee = somme BRUTE de load_quantity, SANS multiplicateur de conditionnement — diffère du chargement arbitré de fct_neshu__consommation.
+      Aucun filtre de statut : inclut FAIT/VALIDE mais aussi ANNULE/ANOMALIE (volume négligeable, ~0,005 %).
+      quinzaine_chgt ∈ [1, 27].
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: [product_type, company_code, annee_chgt, quinzaine_chgt]
 
     columns:
       - name: product_type
-        description: Type de produit issu de la dimension produit
+        description: Type de produit issu de la dimension produit (BOISSONS FRAICHES + SNACKING regroupés en SODA + SNACKS)
         tests:
           - not_null
 
       - name: company_code
-        description: Code de la société
+        description: Code de la société (issu de int_oracle_neshu__chargement_tasks)
         tests:
           - not_null
+
+      - name: company_name
+        description: Nom de la société (issu de stg_oracle_neshu__company)
 
       - name: annee_chgt
         description: Année de la date de démarrage de la tâche
@@ -597,7 +610,13 @@ models:
           - not_null
 
       - name: quantite_chargee
-        description: Quantité totale chargée sur la période
+        description: Quantité brute totale chargée sur la période (sans conditionnement)
+
+      - name: dbt_updated_at
+        description: "Horodatage de la dernière exécution dbt ayant matérialisé la ligne."
+
+      - name: dbt_invocation_id
+        description: "Identifiant d'invocation dbt ayant produit la ligne (traçabilité du run)."
 
 
   - name: dim_neshu__resource

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -571,12 +571,12 @@ models:
   - name: fct_neshu__chargement_quinzaine
     description: |
       [QUOI MÉTIER] Quantités chargées sur les machines GRATUITES uniquement, par client, type de produit, année et quinzaine.
-      [COMMENT CONSTRUITE] Issu de int_oracle_neshu__chargement_tasks : company_code provient directement de chargement_tasks, product_type de dim_neshu__product, company_name de stg_oracle_neshu__company ; le join dim_neshu__device sert UNIQUEMENT à filtrer device_economic_model = 'Gratuit' (machines gratuites). Regroupement BOISSONS FRAICHES + SNACKING → SODA + SNACKS pour le reporting BI. Quinzaine = floor(jours écoulés depuis le lundi de la semaine du 1er janvier / 14) + 1.
+      [COMMENT CONSTRUITE] Issu de int_oracle_neshu__chargement_tasks : company_code provient directement de chargement_tasks, product_type de dim_neshu__product, company_name de dim_neshu__company ; le join dim_neshu__device sert UNIQUEMENT à filtrer device_economic_model = 'Gratuit' (machines gratuites). Regroupement BOISSONS FRAICHES + SNACKING → SODA + SNACKS pour le reporting BI. Quinzaine = floor(jours écoulés depuis le lundi de la semaine du 1er janvier / 14) + 1.
       [GRAIN] 1 ligne par (product_type, company_code, annee_chgt, quinzaine_chgt).
       [NOTES]
       ⚠️ Périmètre restreint aux machines GRATUITES (device_economic_model = 'Gratuit') — non comparable au chargement total.
       ⚠️ Fenêtre glissante : seuls les 730 derniers jours (interval 730 day) sont inclus.
-      quantite_chargee = somme BRUTE de load_quantity, SANS multiplicateur de conditionnement — diffère du chargement arbitré de fct_neshu__consommation.
+      quantite_chargee = somme de load_quantity (déjà déconditionnée par les coefficients Oracle unit_coeff_multi/div dans l'intermediate), MAIS sans le multiplicateur de conditionnement seed (units_per_pack) que fct_neshu__consommation applique en plus — d'où un écart avec le chargement de fct_neshu__consommation.
       Aucun filtre de statut : inclut FAIT/VALIDE mais aussi ANNULE/ANOMALIE (volume négligeable, ~0,005 %).
       quinzaine_chgt ∈ [1, 27].
 
@@ -597,7 +597,7 @@ models:
           - not_null
 
       - name: company_name
-        description: Nom de la société (issu de stg_oracle_neshu__company)
+        description: Nom de la société (issu de dim_neshu__company)
 
       - name: annee_chgt
         description: Année de la date de démarrage de la tâche

--- a/models/marts/neshu/fct_neshu__chargement_consommation.sql
+++ b/models/marts/neshu/fct_neshu__chargement_consommation.sql
@@ -43,7 +43,6 @@ telemetry_agg as (
     select
         pa.device_id,
         pa.task_start_date,
-        p.product_type as product_type_2,
         (case
             when p.product_type in ('BOISSONS FRAICHES', 'SNACKING') then 'SODA + SNACKS'
             else p.product_type
@@ -59,8 +58,8 @@ telemetry_agg as (
             between coalesce(pa.date_passage_precedent, timestamp('2024-12-30 00:00:00')) and pa.task_start_date
     left join {{ ref('dim_neshu__product') }} as p
         on t.product_id = p.product_id
-    group by 1, 2, 3, 4, 5, 6
-    having p.product_type is not null or sum(t.telemetry_quantity) > 0
+    group by 1, 2, 3, 4, 5
+    having product_type is not null or sum(t.telemetry_quantity) > 0
 ),
 
 -- -----------------------------------------------------------------------------------
@@ -71,7 +70,6 @@ chargement_agg as (
     select
         pa.device_id,
         pa.task_start_date,
-        p.product_type as product_type_2,
         (case
             when p.product_type in ('BOISSONS FRAICHES', 'SNACKING') then 'SODA + SNACKS'
             else p.product_type
@@ -86,7 +84,7 @@ chargement_agg as (
             and date(pa.task_start_date) = date(cm.task_start_date)
     left join {{ ref('dim_neshu__product') }} as p
         on cm.product_id = p.product_id
-    group by 1, 2, 3, 4, 5, 6
+    group by 1, 2, 3, 4, 5
     having product_type is not null or sum(cm.load_quantity) > 0
 ),
 

--- a/models/marts/neshu/fct_neshu__chargement_consommation.sql
+++ b/models/marts/neshu/fct_neshu__chargement_consommation.sql
@@ -82,6 +82,7 @@ chargement_agg as (
         on
             pa.device_id = cm.device_id
             and date(pa.task_start_date) = date(cm.task_start_date)
+            and cm.task_status_code in ('FAIT', 'VALIDE')
     left join {{ ref('dim_neshu__product') }} as p
         on cm.product_id = p.product_id
     group by 1, 2, 3, 4, 5

--- a/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
+++ b/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
@@ -1,4 +1,3 @@
--- models/fct_chargement_quinzaine.sql
 {{ config(materialized='table') }}
 
 with base as (
@@ -9,12 +8,12 @@ with base as (
         end) as product_type,
         cm.company_code,
         comp.name as company_name,
-        EXTRACT(year from cm.task_start_date) as annee_chgt,
-        FLOOR(
-            DATE_DIFF(
-                DATE(cm.task_start_date),
-                DATE_TRUNC(
-                    DATE_TRUNC(DATE(cm.task_start_date), year),
+        extract(year from cm.task_start_date) as annee_chgt,
+        floor(
+            date_diff(
+                date(cm.task_start_date),
+                date_trunc(
+                    date_trunc(date(cm.task_start_date), year),
                     week (monday)
                 ),
                 day
@@ -30,7 +29,7 @@ with base as (
             and d.device_economic_model = 'Gratuit'
     left join {{ ref('stg_oracle_neshu__company') }} as comp
         on cm.company_id = comp.idcompany
-    where cm.task_start_date >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), interval 730 day)
+    where cm.task_start_date >= timestamp_sub(current_timestamp(), interval 730 day)
 )
 
 select
@@ -39,9 +38,10 @@ select
     company_name,
     annee_chgt,
     quinzaine_chgt,
-    SUM(load_quantity) as quantite_chargee,
+    sum(load_quantity) as quantite_chargee,
+
     -- Métadonnées dbt
-    CURRENT_TIMESTAMP() as dbt_updated_at,
+    current_timestamp() as dbt_updated_at,
     '{{ invocation_id }}' as dbt_invocation_id  -- noqa: TMP
 from base
 group by

--- a/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
+++ b/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
@@ -29,7 +29,9 @@ with base as (
             and d.device_economic_model = 'Gratuit'
     left join {{ ref('dim_neshu__company') }} as comp
         on cm.company_id = comp.company_id
-    where cm.task_start_date >= timestamp_sub(current_timestamp(), interval 730 day)
+    where
+        cm.task_start_date >= timestamp_sub(current_timestamp(), interval 730 day)
+        and cm.task_status_code in ('FAIT', 'VALIDE')
 )
 
 select

--- a/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
+++ b/models/marts/neshu/fct_neshu__chargement_quinzaine.sql
@@ -7,7 +7,7 @@ with base as (
             else p.product_type
         end) as product_type,
         cm.company_code,
-        comp.name as company_name,
+        comp.company_name,
         extract(year from cm.task_start_date) as annee_chgt,
         floor(
             date_diff(
@@ -27,8 +27,8 @@ with base as (
         on
             cm.device_id = d.device_id
             and d.device_economic_model = 'Gratuit'
-    left join {{ ref('stg_oracle_neshu__company') }} as comp
-        on cm.company_id = comp.idcompany
+    left join {{ ref('dim_neshu__company') }} as comp
+        on cm.company_id = comp.company_id
     where cm.task_start_date >= timestamp_sub(current_timestamp(), interval 730 day)
 )
 


### PR DESCRIPTION
## Contexte

Audit de cohérence des marts appro NESHU `fct_neshu__chargement_consommation` (legacy, ancien collab) et `fct_neshu__chargement_quinzaine`, post-refonte by-BU. Objectif : aligner doc, tests et logique de comptage sur les sources de vérité posées par la refonte (`fct_neshu__consommation`, `fct_neshu__passage_appro`) — **sans changer un calcul sauf décision explicite** (le filtre de statut, validé en revue).

Toutes les modifs ont été buildées + testées en `dev`, avec contrôle de parité vs `prod` à chaque étape.

## Changements

### 1. `fct_neshu__chargement_consommation` — doc & tests (`2ff1f9ca`)
- ➕ test `unique_combination_of_columns` sur la grain `(device_id, date_debut_passage_appro, product_id)` (vérifiée unique : 1 493 087 = 1 493 087).
- 📝 Doc corrigée : grain **JOURNALIER** (pas par passage — ~1,7 % des device-jours fusionnés), ⚠️ `q_consommee` = télémétrie **brute** ≠ métrique officielle `consommation_volume` (`fct_neshu__consommation`), note sur le `MAX(q_chargee)` (dédup du total journalier) et le désalignement avec `fct_neshu__passage_appro`.
- 🧹 Drop de la colonne morte `product_type_2`.
- 🐛 Doc `dim_neshu__resource` : `VEHICULE` → `VEHICLE` (valeur réelle en base — la doc mentait, le join du modèle était correct).

### 2. `fct_neshu__chargement_quinzaine` — doc, tests, lint (`8157da92`)
- ➕ test `unique_combination_of_columns` sur la grain (9 263 = 9 263).
- 📝 Doc : périmètre **machines GRATUITES** (`device_economic_model = 'Gratuit'`, 574/~6000 devices) — totalement absent avant ; fenêtre **glissante 730 j** ; précision conditionnement.
- 🐛 Correction du `[COMMENT CONSTRUITE]` faux : `company_code` vient de `chargement_tasks` (pas de `dim_neshu__device`, qui ne sert qu'au filtre Gratuit).
- 🎨 SQL : fonctions en minuscules (lint), suppression d'un commentaire de chemin obsolète.

### 3. `fct_neshu__chargement_quinzaine` — star schema (`bf24ec45`)
- ♻️ Remplace la ref staging `stg_oracle_neshu__company` par `dim_neshu__company` (pas de ref staging dans un mart).
- ✅ Parité vérifiée : 90 `company_id` en scope, 0 manquant dans la dim, 0 `company_name` null.

### 4. Filtre de statut chargement `FAIT`/`VALIDE` — les 2 marts (`aea7ebd0`)
- 🐛 Un chargement `ANNULE`/`ANOMALIE` n'a pas eu lieu et ne doit pas être compté. Aligne sur `fct_neshu__consommation`.
- Appliqué **au niveau mart** (l'intermediate `int_oracle_neshu__chargement_tasks` garde volontairement les 4 statuts pour un futur usage d'analyse d'anomalies).
- `chargement_consommation` : filtre dans le `ON` du LEFT join (préserve les passages sans chargement) → q_chargee **−9 368**.
- `chargement_quinzaine` : filtre dans le `WHERE` → quantite_chargee **−271** (= les ANNULE du scope Gratuit).

## Validation
- `sqlfluff lint` clean sur les 2 modèles.
- `dbt build --target dev` OK sur les 2 marts + tous les tests (15/15 PASS au dernier build, dont les 2 nouveaux tests de grain).
- Parité dev/prod contrôlée à chaque commit ; seuls écarts = dérive upstream + fenêtre glissante 730 j + retrait volontaire des ANNULE/ANOMALIE.

## Restes ouverts (hors scope, décision métier)
- [ ] **Multiplicateur seed `units_per_pack`** : faut-il l'appliquer dans ces 2 marts pour aligner les volumes de chargement sur `fct_neshu__consommation` ? (changerait les chiffres affichés)
- [ ] **Taux d'écoulement** (`chargement_consommation`) : le décalage N/N-1 (q_chargee à N vs q_consommee sur [N-1, N]) est-il le comportement voulu ?
- [ ] **Ré-ancrage** éventuel de `chargement_consommation` sur `fct_neshu__passage_appro` (option B de l'audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
