### PR TITLE
feat(selectors): include stg contact in the passage_appro fast-lane

### DIFF
--- a/docs/architecture/passages-appro-fast-lane.md
+++ b/docs/architecture/passages-appro-fast-lane.md
@@ -25,7 +25,7 @@ Cloud Scheduler (jours ouvrés)            workflow pipeline-passages-appro-<bu>
   lcdp  : 0 8,11,15,18      ──────────────► │ 1) EL en PARALLÈLE :                     │
                                             │    • tap transactionnel (incr.)         │  TASK, TASK_HAS_RESOURCES,
                                             │      tap-oracle-<bu>-appro-fastlane      │  LABEL_HAS_TASK  → prod_raw
-                                            │    • tap référentiels (full table)      │  COMPANY, DEVICE, LOCATION,
+                                            │    • tap référentiels (full table)      │  COMPANY, DEVICE, LOCATION, CONTACT,
                                             │      tap-oracle-<bu>-appro-refs          │  TASK_STATUS, RESOURCES, LABEL
                                             │ 2) dbt build                            │
                                             │    --selector passage_appro_fastlane_<bu>│  → fct_<bu>__passage_appro
@@ -50,6 +50,12 @@ sous-graphe reconstruit (`COMPANY, DEVICE, LOCATION, TASK_STATUS, RESOURCES, LAB
 Résultat : dims fraîches dès l'intra-day, tests `relationships` qui restent **stricts
 (`error`)** sans flapping, et un nouveau client/machine/site visible le jour même.
 
+> **Ajouter une réf au tap ne suffit pas si la chaîne appro ne la joint pas.** Le test
+> `relationships` compare deux modèles *staging* ; il faut donc aussi que le `stg_*` de la
+> réf soit **reconstruit** par la voie rapide. Ex. `contact` : il n'est joint par aucun
+> modèle appro, donc on l'a ajouté **à la fois** au tap réf (`CONTACT`) **et** au selector
+> (`stg_oracle_<bu>__contact`) pour que `stg_task.idcontact → contact` reste strict.
+
 ## Isolation par BU
 
 Chaque workflow utilise **son** selector (`passage_appro_fastlane_neshu` /
@@ -60,10 +66,11 @@ existe encore mais **uniquement pour un full refresh manuel des deux** :
 ## Limite connue (eventual consistency)
 
 Quelques FK pointent vers des références **hors** du sous-graphe appro (ex.
-`task → task_type`, `task → contact`, `company → company_type`). Leur modèle staging
-n'est pas reconstruit par la voie rapide, donc leur test `relationships` peut rarement
-flapper sur un enregistrement créé le jour même. Ces réfs changent très rarement → laissé
-en `error`, à traiter au cas par cas (cf. § Dépannage).
+`task → task_type`, `company → company_type`). Leur modèle staging n'est pas reconstruit
+par la voie rapide, donc leur test `relationships` peut rarement flapper sur un
+enregistrement créé le jour même. Ces réfs changent très rarement → laissé en `error`, à
+traiter au cas par cas (cf. § Dépannage). Si l'une se met à flapper régulièrement, la
+traiter comme `contact` : l'ajouter au tap réf **et** au selector (cf. encart ci-dessus).
 
 ## Opérer
 

--- a/selectors.yml
+++ b/selectors.yml
@@ -15,23 +15,33 @@ selectors:
   # full refresh manuel des deux BUs (`dbt build --selector passage_appro_fastlane`).
   # ============================================================
 
+  # NB : stg_<bu>__contact est ajouté bien qu'il ne soit PAS joint par la chaîne
+  # appro — stg_task porte un test relationships idcontact→contact. Le reconstruire
+  # ici (depuis le prod_raw.contact rafraîchi par le tap réf) garde ce test strict
+  # en intra-day au lieu de comparer un stg_contact stale.
   - name: passage_appro_fastlane_neshu
     description: >
-      Sous-graphe ancêtre de fct_neshu__passage_appro (refresh intra-day neshu).
+      Sous-graphe ancêtre de fct_neshu__passage_appro + stg contact (refresh intra-day neshu).
     default: false
     definition:
-      method: fqn
-      value: fct_neshu__passage_appro
-      parents: true
+      union:
+        - method: fqn
+          value: fct_neshu__passage_appro
+          parents: true
+        - method: fqn
+          value: stg_oracle_neshu__contact
 
   - name: passage_appro_fastlane_lcdp
     description: >
-      Sous-graphe ancêtre de fct_lcdp__passage_appro (refresh intra-day lcdp).
+      Sous-graphe ancêtre de fct_lcdp__passage_appro + stg contact (refresh intra-day lcdp).
     default: false
     definition:
-      method: fqn
-      value: fct_lcdp__passage_appro
-      parents: true
+      union:
+        - method: fqn
+          value: fct_lcdp__passage_appro
+          parents: true
+        - method: fqn
+          value: stg_oracle_lcdp__contact
 
   # Combiné : neshu + lcdp d'un coup. Pour full refresh manuel uniquement,
   # PAS utilisé par les workflows (qui sont isolés par BU ci-dessus).
@@ -47,3 +57,7 @@ selectors:
         - method: fqn
           value: fct_lcdp__passage_appro
           parents: true
+        - method: fqn
+          value: stg_oracle_neshu__contact
+        - method: fqn
+          value: stg_oracle_lcdp__contact


### PR DESCRIPTION
Pendant dbt de l'ajout de `CONTACT` au tap réf Meltano (`*-appro-refs`).

## Pourquoi
`contact` n'est pas joint par la chaîne appro, mais `stg_task` porte un test `relationships idcontact→contact`. Rafraîchir `prod_raw.contact` (côté Meltano) ne suffit pas : le test compare `stg_task` à **`stg_contact`**, qui n'était pas reconstruit par la voie rapide → test stale/flap.

## Changement
Ajout de `stg_oracle_{neshu,lcdp}__contact` aux selectors `passage_appro_fastlane_{neshu,lcdp}` (et au combiné). Le sous-graphe reconstruit donc `stg_contact` à chaque run rapide, frais → le test `relationships` reste **strict** sans flapper.

## Validé
dev : `relationships task.idcontact→contact` **PASS**, 116/116. `stg_contact` se construit (1.0k lignes), ses propres tests (unique/not_null, idcompany→company) passent.

## À faire côté Meltano (toi, repo elt)
- LCDP : corriger la typo `EVS-DEVICE` → `LCDP-DEVICE` dans `filter_tables` du tap `tap-oracle-lcdp-appro-refs` (sinon DEVICE n'est pas extrait par le tap réf). Fix déjà appliqué dans ton arbre local, à commit + push.
- Une fois cette PR mergée (image dbt-runner rebuildée), le `stg_contact` sera pris dans la voie rapide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)