### PR TITLE
feat(gac): staging véhicule + mapping immat → code analytique

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -95,6 +95,9 @@ models:
       zoho_desk:
         +tags: ['intermediate', 'zoho_desk']
 
+      gac:
+        +tags: ['intermediate', 'gac']
+
     marts:
       +schema: marts
       +tags: ['marts']

--- a/models/intermediate/gac/_gac__intermediate_models.yml
+++ b/models/intermediate/gac/_gac__intermediate_models.yml
@@ -1,0 +1,46 @@
+version: 2
+
+models:
+  - name: int_gac__vehicule_code_analytique
+    description: >
+      [QUOI MÉTIER]
+      Table de correspondance immatriculation → code analytique (compta) du véhicule.
+      Brique réutilisable pour ventiler analytiquement un véhicule identifié par son immat
+      (équivalent dérivé de la source GAC du mapping compta mapping_immat_code.csv).
+
+      [COMMENT CONSTRUITE]
+      Dédup de stg_gac__vehicule (1 ligne par période de contrat type) à 1 ligne par
+      immatriculation, en gardant la période de contrat type la plus récente
+      (row_number partition by immat order by contrat_type_date_d_effet desc, contrat_id_gac desc).
+      Le code analytique provient de la colonne source collaborateur_fonction_actuelle, dont
+      le nom est trompeur : elle porte en réalité le code analytique (ex. SAVLYOTECH, COMLYOHOR),
+      pas un libellé de poste. Exclut les immatriculations non réelles (refs internes GAC
+      préfixées '#') et les véhicules sans code analytique (valeur NULL).
+
+      [GRAIN]
+      1 ligne par immatriculation (contrat_immatriculation_edi). Clé strictement unique.
+      ~126 immatriculations renseignées (sur 271 immats réels : ~145 véhicules de pool /
+      non affectés, sans code analytique, sont volontairement exclus).
+
+      [NOTES]
+      Le code analytique est constant sur toutes les lignes d'un même immat dans la source :
+      la dédup ne fait que choisir une ligne représentative, sans arbitrage de valeur.
+
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - contrat_immatriculation_edi
+
+    columns:
+      - name: contrat_immatriculation_edi
+        description: "Immatriculation du véhicule (format EDI, sans tiret). Clé du mapping."
+        tests:
+          - unique
+          - not_null
+      - name: code_analytique
+        description: >
+          Code analytique (compta) du véhicule, ex. SAVLYOTECH, COMLYOHOR. Issu de la colonne
+          source collaborateur_fonction_actuelle (nom source trompeur).
+        tests:
+          - not_null

--- a/models/intermediate/gac/int_gac__vehicule_code_analytique.sql
+++ b/models/intermediate/gac/int_gac__vehicule_code_analytique.sql
@@ -1,0 +1,30 @@
+{{ config(materialized='table') }}
+
+with vehicule as (
+    select * from {{ ref('stg_gac__vehicule') }}
+),
+
+deduplicated as (
+    select
+        contrat_immatriculation_edi,
+        -- Dans la source GAC, collaborateur_fonction_actuelle porte en réalité le code
+        -- analytique (compta), pas un libellé de poste. On l'expose sous son vrai nom.
+        collaborateur_fonction_actuelle as code_analytique,
+        row_number() over (
+            partition by contrat_immatriculation_edi
+            order by contrat_type_date_d_effet desc, contrat_id_gac desc
+        ) as rn
+    from vehicule
+    -- On écarte les immatriculations non réelles (refs internes GAC préfixées '#',
+    -- véhicules non immatriculés) et les véhicules sans code analytique.
+    where
+        contrat_immatriculation_edi is not null
+        and not starts_with(contrat_immatriculation_edi, '#')
+        and collaborateur_fonction_actuelle is not null
+)
+
+select
+    contrat_immatriculation_edi,
+    code_analytique
+from deduplicated
+where rn = 1

--- a/models/staging/gac/_gac__models.yml
+++ b/models/staging/gac/_gac__models.yml
@@ -1,0 +1,55 @@
+version: 2
+
+models:
+  - name: stg_gac__vehicule
+    columns:
+      - name: contrat_id_gac
+        description: "Identifiant GAC du contrat (non unique au grain de la table : un contrat porte plusieurs lignes de contrat type)"
+        tests:
+          - not_null
+      - name: contrat_immatriculation_edi
+        description: "Immatriculation du véhicule (format EDI, sans tiret)"
+        tests:
+          - not_null
+      - name: contrat_statut_actuel
+        description: "Statut actuel du contrat"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['A la route', 'Clos', 'En attente de livraison']
+              config:
+                severity: warn
+      - name: contrat_motif_de_cloture
+        description: "Motif de clôture du contrat (NULL si contrat non clos)"
+      - name: contrat_type_etat
+        description: "État de la ligne de contrat type / déclaration AEN"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Actif', 'Inactif']
+              config:
+                severity: warn
+      - name: contrat_type_date_d_effet
+        description: "Date d'effet de la ligne de contrat type"
+      - name: contrat_type_date_de_fin
+        description: "Date de fin de la ligne de contrat type"
+      - name: dernier_evenement_disponibilite_du_vehicule
+        description: "Disponibilité du véhicule au dernier événement"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Disponible', 'Affecté', 'Indisponible', 'En maintenance']
+              config:
+                severity: warn
+      - name: dernier_evenement_date_d_effet
+        description: "Date d'effet du dernier événement de disponibilité"
+      - name: dernier_evenement_date_de_fin
+        description: "Date de fin du dernier événement de disponibilité"
+      - name: collaborateur_fonction_actuelle
+        description: "Nom source trompeur : porte en réalité le code analytique (compta) du véhicule, ex. SAVLYOTECH. Voir int_gac__vehicule_code_analytique."
+      - name: date_de_saisie
+        description: "Date de saisie du contrat (horodatée)"
+      - name: extracted_at
+        description: "Timestamp d'extraction Meltano (_sdc_extracted_at)"
+      - name: deleted_at
+        description: "Timestamp de suppression Meltano (_sdc_deleted_at), NULL si actif"

--- a/models/staging/gac/_gac__sources.yml
+++ b/models/staging/gac/_gac__sources.yml
@@ -13,6 +13,33 @@ sources:
         warn_after: {count: 7, period: day}
         error_after: {count: 14, period: day}
     tables:
+      - name: gac_parc_vehicule
+        description: "Export du parc véhicule (GAC → SFTP SG), fichier statique parc_vehicule.csv. 1 ligne = 1 période de contrat type (déclaration AEN) ; un véhicule/immat peut porter plusieurs lignes."
+        columns:
+          - name: contrat_id_gac
+            description: "Identifiant GAC du contrat"
+          - name: contrat_immatriculation_edi
+            description: "Immatriculation du véhicule (format EDI, sans tiret)"
+          - name: contrat_statut_actuel
+            description: "Statut actuel du contrat (A la route, Clos, En attente de livraison)"
+          - name: contrat_motif_de_cl_ture
+            description: "Motif de clôture du contrat (Restitution, Mise en épave, Vente)"
+          - name: contrat_type_etat
+            description: "État de la ligne de contrat type / déclaration AEN (Actif, Inactif)"
+          - name: contrat_type_date_d_effet
+            description: "Date d'effet de la ligne de contrat type"
+          - name: contrat_type_date_de_fin
+            description: "Date de fin de la ligne de contrat type"
+          - name: dernier_v_nement_disponibilit_du_v_hicule
+            description: "Disponibilité du véhicule au dernier événement (Disponible, Affecté, Indisponible, En maintenance)"
+          - name: dernier_v_nement_date_d_effet
+            description: "Date d'effet du dernier événement de disponibilité"
+          - name: dernier_v_nement_date_de_fin
+            description: "Date de fin du dernier événement de disponibilité"
+          - name: collaborateur_fonction_actuelle
+            description: "Nom trompeur : porte en réalité le code analytique (compta) du véhicule, ex. SAVLYOTECH"
+          - name: date_de_saisie
+            description: "Date de saisie du contrat (horodatée)"
       - name: gac_sinistre
         description: "Snapshots quotidiens cumulatifs des sinistres véhicules (GAC → SFTP SG). Chargé en append immuable : 1 ligne = 1 sinistre dans 1 snapshot daté. L'état courant est dérivé par dédup dans stg_gac__sinistres."
         columns:

--- a/models/staging/gac/stg_gac__vehicule.sql
+++ b/models/staging/gac/stg_gac__vehicule.sql
@@ -1,0 +1,44 @@
+{{
+  config(
+    materialized='table',
+    description='Parc véhicule EVS (GAC → SFTP SG), nettoyé et restreint aux colonnes utiles. Grain source 1:1 (1 ligne = 1 période de contrat type / déclaration AEN)',
+  )
+}}
+
+
+with source as (
+    select * from {{ source('gac', 'gac_parc_vehicule') }}
+),
+
+cleaned as (
+    select
+        -- Contrat
+        nullif(trim(contrat_id_gac), '') as contrat_id_gac,
+        nullif(trim(contrat_immatriculation_edi), '') as contrat_immatriculation_edi,
+        nullif(trim(contrat_statut_actuel), '') as contrat_statut_actuel,
+        nullif(trim(contrat_motif_de_cl_ture), '') as contrat_motif_de_cloture,
+
+        -- Ligne de contrat type (déclaration AEN)
+        nullif(trim(contrat_type_etat), '') as contrat_type_etat,
+
+        -- Disponibilité (dernier événement)
+        nullif(trim(dernier_v_nement_disponibilit_du_v_hicule), '') as dernier_evenement_disponibilite_du_vehicule,
+
+        -- Collaborateur
+        nullif(trim(collaborateur_fonction_actuelle), '') as collaborateur_fonction_actuelle,
+
+        -- Dates
+        safe.parse_timestamp('%d/%m/%Y %H:%M:%S', nullif(trim(date_de_saisie), '')) as date_de_saisie,
+        safe.parse_date('%d/%m/%Y', nullif(trim(contrat_type_date_d_effet), '')) as contrat_type_date_d_effet,
+        safe.parse_date('%d/%m/%Y', nullif(trim(contrat_type_date_de_fin), '')) as contrat_type_date_de_fin,
+        safe.parse_date('%d/%m/%Y', nullif(trim(dernier_v_nement_date_d_effet), '')) as dernier_evenement_date_d_effet,
+        safe.parse_date('%d/%m/%Y', nullif(trim(dernier_v_nement_date_de_fin), '')) as dernier_evenement_date_de_fin,
+
+        -- Métadonnées Meltano
+        _sdc_extracted_at as extracted_at,
+        _sdc_deleted_at as deleted_at
+
+    from source
+)
+
+select * from cleaned


### PR DESCRIPTION
## Contexte

Nouvelle source `gac_parc_vehicule` dans `prod_raw` (export du parc véhicule GAC déposé sur le SFTP SG — fichier statique `parc_vehicule.csv`, ~424 lignes / ~400 colonnes dont la grande majorité inutiles). Objectif : un staging propre restreint aux colonnes utiles + un mapping réutilisable **immatriculation → code analytique** pour la compta.

## Ce que fait la PR

### 1. Staging — `stg_gac__vehicule` (1:1)
- **Fidèle à la source**, pas de dédup : la logique métier (« contrat le plus récent par immat ») est déportée en intermediate, conformément aux conventions de couche.
- Restreint aux **12 colonnes utiles** ; typos d'accents du loader réparées (`cl_ture`→`cloture`, `v_nement`→`evenement`, `v_hicule`→`vehicule`, `disponibilit_`→`disponibilite`), **noms d'origine conservés** par ailleurs.
- Casts : `date_de_saisie` en `parse_timestamp`, dates `contrat_type_*` / `dernier_evenement_*` en `safe.parse_date('%d/%m/%Y')` ; `nullif(trim(...), '')` systématique.

### 2. Intermediate — `int_gac__vehicule_code_analytique` (le mapping)
- Mapping **immatriculation → code analytique** (compta), réutilisable via `ref()`.
- Dédup à **1 ligne par immat**, en gardant la période de contrat type la plus récente :
  `row_number() over (partition by immat order by contrat_type_date_d_effet desc, contrat_id_gac desc)`.
  > `contrat_type_date_d_effet` est la **seule** clé qui départage les lignes d'un même immat. `dernier_evenement_date_d_effet` est constant par immat → écarté (ex æquo non déterministe).
- **Filtres** : immats préfixés `#` (refs internes GAC, véhicules non immatriculés) + véhicules sans code analytique (pool / non affectés). Résultat : **126 immats renseignés** sur 271 réels.
- ⚠️ La colonne source `collaborateur_fonction_actuelle` porte en réalité le **code analytique** (ex. `SAVLYOTECH`, `COMLYOHOR`), pas un libellé de poste — nom source trompeur. Documenté partout, colonne de sortie aliasée `code_analytique`.

## Grain & clés

| Modèle | Grain | Clé |
|---|---|---|
| `stg_gac__vehicule` | 1 ligne / période de contrat type | (non unique) |
| `int_gac__vehicule_code_analytique` | 1 ligne / immatriculation | `contrat_immatriculation_edi` (unique) |

## Tests
- Staging : `not_null` sur `contrat_id_gac` + `contrat_immatriculation_edi` ; `accepted_values` (warn) sur statut / type_etat / disponibilité.
- Intermediate : `unique` + `not_null` sur la clé, `not_null` sur `code_analytique`, `unique_combination_of_columns`.

## Validation
- Build **dev** OK : staging 6 PASS, intermediate 5 PASS, **0 erreur**.
- `sqlfluff` clean, `dbt parse` OK.
- Source déclarée dans `_gac__sources.yml` (freshness héritée du tier Relaxe GAC).

## Notes
- `dbt_project.yml` : ajout du bloc `gac:` sous `intermediate` (tags `['intermediate', 'gac']`).
- Ce mapping est l'équivalent dérivé automatiquement du mapping compta manuel `mapping_immat_code.csv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)