### PR TITLE
feat(finance): view écritures 6/7 non ventilées pour l'app compta

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -139,4 +139,6 @@ vars:
   # Required by dbt_date (transitive dep of dbt_expectations) for recency checks.
   # Cf. docs/freshness.md méthode B.
   'dbt_date:time_zone': 'Europe/Paris'
+  # Plancher de date des écritures à ventiler (fct_finance__ecriture_non_ventilee).
+  ecriture_non_ventilee_floor: '2025-01-01'
     

--- a/models/intermediate/mssql_sage/_mssql_sage__intermediate_models.yml
+++ b/models/intermediate/mssql_sage/_mssql_sage__intermediate_models.yml
@@ -122,3 +122,47 @@ models:
         description: Timestamp de création de l'écriture en source (coalesce analytique / comptable).
       - name: updated_at
         description: Timestamp de dernière modification en source (coalesce analytique / comptable).
+
+  - name: int_mssql_sage__ecriture_non_ventilee
+    description: >
+      [QUOI MÉTIER]
+      Écritures comptables de charge (classe 6) ou de produit (classe 7) qui n'ont reçu
+      aucune ventilation analytique dans Sage — la file de travail des écritures restant
+      à ventiler par la comptabilité.
+
+      [COMMENT CONSTRUITE]
+      stg_mssql_sage__f_ecriturec filtré aux comptes de classe 6 et 7 et à partir du plancher
+      var('ecriture_non_ventilee_floor'), en anti-jointure sur les écritures analytiques
+      (stg_mssql_sage__f_ecriturea) : on ne garde que les ec_no absents de la table analytique.
+      date_facturation est reconstruite (jm_date + (ec_jour-1) jours).
+
+      [GRAIN]
+      1 ligne par écriture comptable (numero_ecriture_comptable).
+
+      [NOTES]
+      Modèle ephemeral (inliné dans fct_finance__ecriture_non_ventilee) : aucune table physique,
+      la logique vit ici pour respecter la séparation des couches. Pas de tests portés ici (un
+      modèle ephemeral n'a pas de relation interrogeable) — les tests sont sur la view du mart.
+      Le montant est brut (non signé) ; sens_ecriture (0 = débit, 1 = crédit) permet de l'interpréter.
+
+    columns:
+      - name: numero_ecriture_comptable
+        description: Numéro de l'écriture comptable Sage (ec_no). Grain du modèle.
+      - name: numero_compte_general
+        description: Numéro de compte général, filtré aux classes 6 (charges) et 7 (produits).
+      - name: libelle_ecriture
+        description: Libellé libre de l'écriture comptable (ec_intitule).
+      - name: sens_ecriture
+        description: "Sens comptable de l'écriture : 0 = débit, 1 = crédit."
+      - name: montant
+        description: Montant (€) de l'écriture, brut non signé (ec_montant).
+      - name: date_facturation
+        description: Date de facturation reconstruite (jm_date + (ec_jour-1) jours).
+      - name: date_ecriture_comptable
+        description: Date de l'écriture comptable (ec_date).
+      - name: date_periode_facturation
+        description: Date de la période de facturation (jm_date), avant ajout du jour.
+      - name: jour_facturation
+        description: Jour du mois de facturation (ec_jour) utilisé pour reconstruire date_facturation.
+      - name: extracted_at
+        description: Timestamp d'extraction de la source (fraîcheur de la donnée).

--- a/models/intermediate/mssql_sage/int_mssql_sage__ecriture_non_ventilee.sql
+++ b/models/intermediate/mssql_sage/int_mssql_sage__ecriture_non_ventilee.sql
@@ -1,0 +1,30 @@
+{{ config(materialized='ephemeral') }}
+
+with ventilations as (
+    select distinct ec_no
+    from {{ ref('stg_mssql_sage__f_ecriturea') }}
+),
+
+ecritures_6_7 as (
+    select
+        ec_no as numero_ecriture_comptable,
+        cg_num as numero_compte_general,
+        ec_intitule as libelle_ecriture,
+        ec_sens as sens_ecriture,
+        ec_montant as montant,
+        date_add(date(jm_date), interval ec_jour - 1 day) as date_facturation,
+        date(ec_date) as date_ecriture_comptable,
+        date(jm_date) as date_periode_facturation,
+        ec_jour as jour_facturation,
+        extracted_at
+    from {{ ref('stg_mssql_sage__f_ecriturec') }}
+    where
+        (cg_num like '6%' or cg_num like '7%')
+        and ec_date >= timestamp('{{ var("ecriture_non_ventilee_floor") }}')
+)
+
+select e.*
+from ecritures_6_7 as e
+left join ventilations as v
+    on e.numero_ecriture_comptable = v.ec_no
+where v.ec_no is null

--- a/models/marts/finance/_finance__marts_models.yml
+++ b/models/marts/finance/_finance__marts_models.yml
@@ -80,3 +80,40 @@ models:
 
       - name: evolution_pct_ytd
         description: Évolution en pourcentage entre YTD N et YTD N-1
+
+  - name: fct_finance__ecriture_non_ventilee
+    description: |
+      [QUOI MÉTIER] Liste des écritures comptables de charge (classe 6) ou produit (classe 7) sans aucune ventilation analytique dans Sage — la file des écritures restant à ventiler par la comptabilité, consommée par l'app compta.
+      [COMMENT CONSTRUITE] int_mssql_sage__ecriture_non_ventilee : f_ecriturec filtré aux classes 6/7 et >= var('ecriture_non_ventilee_floor', défaut 2025-01-01), en anti-jointure sur les écritures analytiques f_ecriturea (ec_no absents). date_facturation = jm_date + (ec_jour-1) jours.
+      [GRAIN] 1 ligne par écriture comptable (ecriture_comptable_id).
+      [NOTES] Matérialisée en **view** (et non table) : déviation assumée à la convention marts, justifiée par un petit volume (~27k lignes), une conso opérationnelle par l'app compta (/mnt/data/project/compta) sensible à la fraîcheur et un requêtage peu fréquent. montant brut non signé ; sens_ecriture (0 = débit, 1 = crédit) pour l'interpréter.
+
+    tests:
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "substr(numero_compte_general, 1, 1) in ('6', '7')"
+
+    columns:
+      - name: date_facturation
+        description: Date de facturation reconstruite (jm_date + (ec_jour-1) jours). Axe temporel principal.
+        tests:
+          - not_null
+      - name: ecriture_comptable_id
+        description: Numéro de l'écriture comptable Sage. Clé primaire / grain.
+        tests:
+          - unique
+          - not_null
+      - name: numero_compte_general
+        description: Numéro de compte général (classe 6 = charges, 7 = produits).
+        tests:
+          - not_null
+      - name: libelle_ecriture
+        description: Libellé libre de l'écriture comptable.
+      - name: sens_ecriture
+        description: "Sens comptable de l'écriture : 0 = débit, 1 = crédit."
+      - name: date_ecriture_comptable
+        description: Date de l'écriture comptable Sage (ec_date).
+      - name: montant
+        description: Montant (€) de l'écriture, brut non signé.
+      - name: extracted_at
+        description: Timestamp d'extraction de la source (fraîcheur de la donnée exposée à l'app).

--- a/models/marts/finance/fct_finance__ecriture_non_ventilee.sql
+++ b/models/marts/finance/fct_finance__ecriture_non_ventilee.sql
@@ -1,0 +1,12 @@
+{{ config(materialized='view') }}
+
+select
+    date_facturation,
+    numero_ecriture_comptable as ecriture_comptable_id,
+    numero_compte_general,
+    libelle_ecriture,
+    sens_ecriture,
+    date_ecriture_comptable,
+    montant,
+    extracted_at
+from {{ ref('int_mssql_sage__ecriture_non_ventilee') }}


### PR DESCRIPTION
## Quoi

Nouvelle **view** `prod_marts.fct_finance__ecriture_non_ventilee` : liste des écritures comptables de charge (classe 6) ou produit (classe 7) **sans ventilation analytique** dans Sage. Destinée à la conso autonome par l'app compta (`/mnt/data/project/compta`).

Remplace une requête ad-hoc sur le `prod_raw` brut.

## Comment

- **`int_mssql_sage__ecriture_non_ventilee`** (`ephemeral`) : `stg_mssql_sage__f_ecriturec` filtré classes 6/7 et `>= var('ecriture_non_ventilee_floor')`, en anti-jointure sur `stg_mssql_sage__f_ecriturea` (écritures analytiques). `date_facturation` reconstruite (`jm_date + (ec_jour-1) j`).
- **`fct_finance__ecriture_non_ventilee`** (`view`) : sortie servie à l'app.
- var `ecriture_non_ventilee_floor` (défaut `2025-01-01`).

## Décisions de design

- **Matérialisation `view`** (déviation assumée à la convention marts « tout en table ») : ~75 lignes / ~60 Mo scannés, conso opérationnelle sensible à la fraîcheur, requêtage peu fréquent. Documentée dans le bloc `[NOTES]` du YAML.
- **Couche marts** (et non intermediate) : la view est un point de conso externe (app) → contrat stable + frontière de permissions `prod_marts`. L'intermediate `ephemeral` loge la logique sans créer de table → **un seul objet physique** au total.
- Tests sur la view (un modèle ephemeral n'est pas testable).

## Validation (prod_staging, lecture seule)

- 75 lignes / 75 écritures distinctes → grain unique ✅
- 0 compte hors 6/7 → invariant OK ✅
- 0 `date_facturation` NULL ✅
- `parse` + `compile` OK, lint OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)