### PR TITLE
feat(neshu): add is_depot flag to dim_company

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -65,6 +65,15 @@ models:
         tests:
           - not_null
 
+      - name: is_depot
+        description: >
+          TRUE si la société est un dépôt / site de remise en état / stock /
+          logistique interne (company_type_id = 6). Le label TYPECOMPAGNIE étant
+          null pour ces entités, seul le type numérique les isole. Ce ne sont
+          jamais des clients (is_client_neshu = FALSE).
+        tests:
+          - not_null
+
       - name: key_account
         description: "KA grand compte (label KA)"
 

--- a/models/marts/neshu/dim_neshu__company.sql
+++ b/models/marts/neshu/dim_neshu__company.sql
@@ -110,6 +110,10 @@ select
         false
     ) as is_client_neshu,
 
+    -- 🏭 Dépôt / remise en état / stock / logistique interne (idcompany_type = 6).
+    -- Le label TYPECOMPAGNIE est null pour ces entités ; seul le type numérique les isole.
+    company_type_id = 6 as is_depot,
+
     -- 👥 Gestion commerciale
     key_account,
     katiers,


### PR DESCRIPTION
## Quoi

Ajoute la colonne booléenne `is_depot` à `dim_neshu__company`, dérivée de `company_type_id = 6`.

## Pourquoi

Le type 6 isole les entités **dépôt / remise en état / stock / logistique interne** : les 12 `DEPOT*` + LOG, RELYON, RERUNGIS, STOCKNUNSHEN. Le label `company_type` (TYPECOMPAGNIE) étant **null** pour ces sociétés, seul le type numérique permet de les flagger. Aucune n'est cliente (`is_client_neshu = false`).

Permet en BI de séparer les flux logistiques internes (rebut, remise en état, stock) des vrais clients Neshu — utile notamment pour l'analyse de consommation où ces dépôts apparaissent sinon mélangés aux `is_client_neshu = false`.

## Changements
- `dim_neshu__company.sql` : `company_type_id = 6 as is_depot`
- `_neshu__marts_models.yml` : doc colonne + test `not_null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)