### PR TITLE
chore(deps): add dbt_orphan package + maintenance doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Toujours verifier avec `git diff` apres un `sqlfluff fix`. Voir [CONVENTIONS.md]
 |---------|---------|------|
 | `dbt-utils` | 1.1.1 | Tests avances (unique_combination, expression_is_true) |
 | `dbt_expectations` | 0.10.10 | Tests de qualite (row count, date range, distributions) |
+| `dbt_orphan` | v0.1.3 (git) | Detection/suppression des objets orphelins (cf. [docs/maintenance.md](docs/maintenance.md)) |
 
 ---
 
@@ -265,6 +266,7 @@ dbt ls --select +mon_modele            # Voir les dependances d'un modele
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Workflow Git et collaboration
 - [CONVENTIONS.md](CONVENTIONS.md) — Conventions de nommage et qualite
 - [docs/pipeline-schedule.md](docs/pipeline-schedule.md) — Horaires extract/transform/snapshot et synchro par BU
+- [docs/maintenance.md](docs/maintenance.md) — Nettoyage des objets orphelins BigQuery (`dbt_orphan`)
 
 ---
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -1,0 +1,81 @@
+# Maintenance — nettoyage des objets orphelins
+
+Cette doc couvre le nettoyage des **objets orphelins** dans BigQuery : tables/vues
+qui existent encore dans un dataset mais ne correspondent plus à aucun modèle dbt
+(séquelles d'une suppression ou d'un renommage de modèle). dbt ne les supprime
+jamais tout seul — d'où cet outillage.
+
+## Outil — `dbt_orphan`
+
+Package : [`Matts52/dbt-orphan`](https://github.com/Matts52/dbt-orphan) (installé via
+git dans `packages.yml`, pin `v0.1.3` — **pas publié sur dbt Hub**).
+
+Comment il fonctionne : il liste `INFORMATION_SCHEMA.TABLES` du dataset scanné, puis
+flague tout objet dont le nom n'est pas un `model`/`seed`/`snapshot` du graph dbt.
+Les **snapshots sont reconnus** par le graph, donc protégés.
+
+## Procédure
+
+> **Toujours commencer en `dry_run: true`** (lecture seule, aucun `DROP`), vérifier
+> la liste, puis seulement décider.
+
+### 1. Auditer (dry-run, lecture seule)
+
+```bash
+# prod — scanner les datasets voulus
+./dbt_venv/bin/dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["prod_marts", "prod_staging", "prod_intermediate"], dry_run: true}' \
+  --target prod
+
+# dev (target par défaut)
+./dbt_venv/bin/dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["dev_marts", "dev_staging", "dev_intermediate"], dry_run: true}'
+```
+
+### 2. Vérifier avant de supprimer
+
+Avant tout `dry_run: false`, confirmer qu'aucun rapport Power BI (exposure) ni
+l'application (`evs-app`) ne consomme encore l'objet listé.
+
+### 3. Supprimer (cleanup réel)
+
+```bash
+./dbt_venv/bin/dbt run-operation dbt_orphan.cleanup_orphans \
+  --args '{schemas: ["prod_marts"], dry_run: false}' --target prod
+```
+
+### Variante — audit en modèle
+
+`get_orphans()` matérialise la liste des orphelins dans une table d'analyse, sans
+rien dropper :
+
+```sql
+-- models/_analysis/orphaned_objects.sql
+{{ dbt_orphan.get_orphans(schemas=['prod_marts'], exclude_patterns=[], include_patterns=[]) }}
+```
+
+## Arguments
+
+| Arg | Défaut | Rôle |
+|---|---|---|
+| `schemas` | `[target.schema]` | datasets à scanner (liste — à passer explicitement) |
+| `dry_run` | `true` | `true` = log seulement · `false` = `DROP` |
+| `database` | `target.database` | projet BQ (auto) |
+| `exclude_patterns` | `[]` | protège des tables (LIKE SQL, ex. `["snap_%"]`) |
+| `include_patterns` | `[]` | ne cible que ces tables (LIKE SQL) |
+
+## Règles d'usage
+
+- **`dry_run: true` d'abord, systématiquement.** Cf. hard rule « never drop unless
+  explicitly asked ».
+- **Aligner le target sur le dataset scanné** : le macro compare les noms aux nodes
+  dont `node.schema` == schema scanné. Scanner `prod_marts` depuis le target `dev`
+  → faux positifs massifs (aucun node ne résout vers `prod_marts`).
+- **Jamais en post-hook automatique** ni dans un workflow planifié. Nettoyage
+  toujours manuel et validé.
+- **Snapshots** : déjà protégés par le graph ; en cleanup réel sur le dataset
+  `snapshots`, ajouter `exclude_patterns: ["snap_%"]` par sécurité (perte SCD2
+  irréversible).
+- **Limite connue** : le macro compare `node.name`, pas l'`alias`. Un modèle avec un
+  `alias` ≠ nom de fichier serait faussement vu comme orphelin (les alias actuels
+  sont no-op, donc OK).

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -5,7 +5,10 @@ packages:
   - name: dbt_expectations
     package: metaplane/dbt_expectations
     version: 0.10.10
+  - git: https://github.com/Matts52/dbt-orphan.git
+    name: dbt_orphan
+    revision: 529960b00ad9ff664b4c2146e0b5023b1bd851fb
   - name: dbt_date
     package: godatadriven/dbt_date
-    version: 0.17.1
-sha1_hash: d46262da56c4456d8e21914ec17a05de5964329b
+    version: 0.19.0
+sha1_hash: 9bfd52c62a3ed7c305482ec573801c9050fcaf32

--- a/packages.yml
+++ b/packages.yml
@@ -3,3 +3,5 @@ packages:
     version: 1.3.3
   - package: metaplane/dbt_expectations
     version: 0.10.10
+  - git: "https://github.com/Matts52/dbt-orphan.git"
+    revision: v0.1.3


### PR DESCRIPTION
## Quoi

Ajoute le package [`Matts52/dbt-orphan`](https://github.com/Matts52/dbt-orphan) (via **git**, pin `v0.1.3` — pas publié sur dbt Hub) pour détecter et nettoyer les **objets orphelins** BigQuery : tables/vues laissées dans un dataset après suppression/renommage de modèle (dbt ne les drop jamais seul).

## Pourquoi

La refacto marts by BU et divers renommages laissent des reliquats. Outil léger, lecture seule en `dry_run`, snapshots protégés par le graph. Validé par dry-run sur prod + dev :

| Target | Datasets | Orphelins |
|---|---|---|
| prod | prod_staging / prod_intermediate / snapshots | 0 |
| prod | prod_marts | 1 (`fct_neshu__monitoring_passage_appro`, depuis supprimé manuellement) |
| dev | dev_* + snapshots_dev | 0 |

## Changements

- `packages.yml` + `package-lock.yml` : ajout `dbt_orphan` (git `v0.1.3`)
- `docs/maintenance.md` (nouveau) : procédure de nettoyage (dry-run d'abord, alignement target, jamais en post-hook auto, snapshots protégés, limite alias)
- `README.md` : entrée dans le tableau des packages dbt + lien dans Ressources

## Notes

- **Compat** dbt 1.11.x (`require-dbt-version >=1.10.0,<3.0.0`)
- **Pas de post-hook automatique** : nettoyage manuel et validé uniquement (hard rule « never drop unless explicitly asked »)

🤖 Generated with [Claude Code](https://claude.com/claude-code)