### PR TITLE
fix(docker): install git in dbt-runner image for git-sourced packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,11 @@
 # =============================================================================
 FROM python:3.11-slim
 
+# git is required by `dbt deps` to install git-sourced packages (e.g. dbt_orphan).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt requirements-lock.txt ./
 RUN pip install --no-cache-dir -r requirements-lock.txt
 


### PR DESCRIPTION
## Problème

Depuis le merge de #156, le job Cloud Run `dbt-runner` échoue au `dbt deps` :

```
Could not find command, ensure it is in the user's PATH: "git"
Container called exit(2).
```

`dbt_orphan` est un package **git**, or l'image `python:3.11-slim` ne contient pas `git`. `entrypoint.sh` lance `dbt deps` à chaque exécution → toutes les pipelines (EL via Cloud Workflows) cassent.

## Fix

Installe `git` dans l'image dbt-runner (layer apt minimal, nettoyage des listes).

## Vérification

Image rebuildée localement + `dbt deps` exécuté dans le conteneur → résout dbt_utils, dbt_expectations **et** clone `dbt_orphan` sans erreur.

## Déploiement

Au merge, la CI (`dbt-ci.yml` job `cd`) rebuild+push `:latest` ; le job Cloud Run re-résout `:latest` à chaque exécution → prochaine run OK automatiquement. Redeploy manuel immédiat possible si besoin de ne pas attendre la prochaine run planifiée.

🤖 Generated with [Claude Code](https://claude.com/claude-code)