### PR TITLE
fix(neshu): guard chargement_tasks grain against dual TYPE_LOADED labels

### DIFF
--- a/models/intermediate/oracle_neshu/int_oracle_neshu__chargement_tasks.sql
+++ b/models/intermediate/oracle_neshu/int_oracle_neshu__chargement_tasks.sql
@@ -8,7 +8,21 @@
     )
 }}
 
-with chargement_base as (
+with task_load_type as (
+
+    -- Type de chargement agrégé au grain tâche (1 ligne par idtask) pour ne pas
+    -- dédoubler le grain produit : une tâche peut porter plusieurs labels.
+    select
+        lht.idtask,
+        logical_or(la.code = 'LOADING') as has_loading,
+        logical_or(la.code = 'REMOVING') as has_removing
+    from {{ ref('stg_oracle_neshu__label_has_task') }} as lht
+    inner join {{ ref('stg_oracle_neshu__label') }} as la on lht.idlabel = la.idlabel
+    where la.code in ('LOADING', 'REMOVING')
+    group by lht.idtask
+),
+
+chargement_base as (
 
     select
         -- Identifiants
@@ -28,7 +42,14 @@ with chargement_base as (
         d.code as device_code,
         p.code as product_code,
         ts.code as task_status_code,
-        la.code as load_type_code,
+        -- Type de chargement : le label est porté au grain tâche. Si une tâche
+        -- porte les deux labels (anomalie ERP), on tranche au signe de la quantité.
+        case
+            when tlt.has_loading and tlt.has_removing
+                then case when thp.real_quantity < 0 then 'REMOVING' else 'LOADING' end
+            when tlt.has_removing then 'REMOVING'
+            when tlt.has_loading then 'LOADING'
+        end as load_type_code,
 
         -- Informations métier
         l.access_info as task_location_info,
@@ -56,8 +77,7 @@ with chargement_base as (
     left join {{ ref('stg_oracle_neshu__device') }} as d on t.iddevice = d.iddevice
     left join {{ ref('stg_oracle_neshu__product') }} as p on thp.idproduct = p.idproduct
     left join {{ ref('stg_oracle_neshu__location') }} as l on t.idlocation = l.idlocation
-    left join {{ ref('stg_oracle_neshu__label_has_task') }} as lht on t.idtask = lht.idtask
-    left join {{ ref('stg_oracle_neshu__label') }} as la on lht.idlabel = la.idlabel
+    left join task_load_type as tlt on t.idtask = tlt.idtask
     left join {{ ref('stg_oracle_neshu__task_status') }} as ts on t.idtask_status = ts.idtask_status
 
     where
@@ -73,7 +93,7 @@ with chargement_base as (
         t.idproduct_destination, t.type_product_destination,
         thp.idproduct,
         c.code, d.code, p.code,
-        ts.code, la.code,
+        ts.code, tlt.has_loading, tlt.has_removing,
         l.access_info, t.real_start_date,
         thp.unit_coeff_multi,
         thp.unit_coeff_div,


### PR DESCRIPTION
## Problème

Le run prod neshu (Cloud Run jobs) a échoué sur le test
`unique_int_oracle_neshu__chargement_tasks_task_product_id` :
> Got 1 result, configured to fail if != 0

## Cause racine

La tâche **33970312** (neuve, `real_start_date` au 2026-06-25) est arrivée taguée
dans l'ERP avec **deux labels de la famille `TYPE_LOADED`** : `LOADING` (286) **et**
`REMOVING` (287). Le modèle dérivait `load_type_code` via un `left join` sur
`label_has_task` → `label` avec `la.code` placé **dans le `GROUP BY`**, sans contrainte
de famille ni de cardinalité. L'unique ligne produit (`task_product_id = 28781760`)
s'est donc dédoublée (1 ligne `LOADING`, 1 ligne `REMOVING`) → violation du grain.

Ce n'est **pas** un artefact d'incrémental : `label_has_task` contient physiquement
les 2 labels aujourd'hui, le dédoublement se produit dans un seul build.

## Correctif

- `load_type_code` isolé dans un CTE `task_load_type` agrégé **au grain tâche**
  (`logical_or`) → une tâche multi-labellisée ne peut plus dédoubler le grain produit.
- Tie-break sur les tâches contradictoires (LOADING **et** REMOVING) : signe de la
  quantité (`real_quantity < 0 → REMOVING`, sinon `LOADING`). Pour 28781760
  (qty = 67 > 0) → `LOADING`.
- Les tâches mono-label conservent leur label d'origine intact.

## Validation (sur prod, lecture seule)

| Contrôle | Résultat |
|---|---|
| Clés `task_product_id` dupliquées | 0 |
| Tâche 28781760 résolue | `LOADING` |
| LOADING / REMOVING / null | 1 145 047 / 3 927 / 0 |
| Total | 1 148 974 (= avant − 1 doublon) |

Aucune reclassification collatérale : le label reste la source de vérité, le signe ne
tranche que les conflits (les 546 lignes « signe ≠ label » mono-label sont intactes).

## ⚠️ Après merge

Le modèle est incrémental (`merge`) : le déploiement du code ne purge pas le doublon
déjà matérialisé (le `merge` mettrait les 2 lignes cibles à jour sans en supprimer une).
Lancer un **full-refresh ciblé en prod** :

```bash
dbt build -s int_oracle_neshu__chargement_tasks --full-refresh --target prod
```

`fct_neshu__consommation` (matérialisé `table`) se nettoiera ensuite tout seul.

## Suivi métier

Anomalie ERP à signaler : un produit chargé **et** retiré sur la même tâche. À corriger
à la source pour éviter d'autres tâches double-labellisées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)