### PR TITLE
feat(neshu): commande fournisseur intermediate + supplier lead time on reception

### DIFF
--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -626,6 +626,13 @@ models:
       [NOTES]
       Symétrique de la livraison mais côté entrée : product_destination_id est polymorphe et vaut
       toujours COMPANY ici (réception dans un dépôt). Pas de source.
+      Enrichi avec la date de la commande fournisseur (type 120) rattachée pour calculer le délai
+      de livraison : le lien passe par le document parent partagé (task_idtask), une réception
+      pointe vers au plus 1 commande. Certaines réceptions n'ont pas de commande rapprochable
+      (commande_start_date et délai NULL), et de rares saisies incohérentes donnent un délai négatif
+      (réception datée avant la commande) : filtrer sur is_lead_time_valid. Le statut de livraison
+      (LIVRE/PARTIEL/EN_ATTENTE), saisi manuellement côté ERP, est peu fiable et n'est pas repris
+      ici — tout écart de complétude quantité se traite côté métier.
     columns:
       # --- IDENTIFIANTS ---
       - name: task_product_id
@@ -682,6 +689,20 @@ models:
         data_type: timestamp
         tests:
           - not_null
+      - name: commande_start_date
+        description: >
+          Date de la commande fournisseur (type 120) rattachée, via le document parent partagé
+          (task_idtask). NULL si la réception n'a pas de commande rapprochable.
+        data_type: timestamp
+
+      # --- DÉLAI DE LIVRAISON ---
+      - name: delivery_lead_time_days
+        description: >
+          Délai fournisseur en jours = task_start_date − commande_start_date.
+          NULL si commande_start_date absente. Filtrer sur is_lead_time_valid.
+      - name: is_lead_time_valid
+        description: "Vrai si commande_start_date présente et délai ≥ 0 (réception après commande)."
+        data_type: boolean
 
       # --- CONDITIONNEMENT & PRIX ---
       - name: unit_coeff_multi

--- a/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
+++ b/models/intermediate/oracle_neshu/_oracle_neshu__intermediate_models.yml
@@ -1495,6 +1495,150 @@ models:
         tests:
           - not_null
 
+  - name: int_oracle_neshu__commande_fournisseur_tasks
+    description: >
+      [QUOI MÉTIER]
+      Commandes fournisseur NESHU (type 120) : une ligne par produit commandé à un fournisseur
+      externe (source) et livré dans un dépôt (destination), avec son statut de livraison.
+      Approvisionnement externe, typiquement fournisseur → dépôt.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_neshu__task (idtask_type = 120, code_status_record = '1', real_start_date non nul,
+      tous statuts de tâche conservés) croisé avec task_has_product (grain ligne produit), enrichi
+      product et task_status. Source (fournisseur) et destination (dépôt) résolues sur company
+      (type COMPANY dans 100 % des cas). Le statut de livraison est pivoté au grain tâche depuis le
+      label de famille STATUT_LIVRAISON (max(case ...)), puis rattaché aux lignes produit — pas de
+      déduplication. Seules les lignes dont source ET destination se résolvent sont conservées.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une commande fournisseur). ~7 760 lignes
+      (~1 670 tâches), depuis 2022.
+
+      [NOTES]
+      Jumeau structurel de int_oracle_neshu__commande_interne_tasks (flux COMPANY → COMPANY), mais
+      la source est un fournisseur externe (NESPRESSO, NUNSHEN, LIDIS…) et non un dépôt interne ;
+      logiquement en amont de int_oracle_neshu__reception_tasks (type 121, bon de réception).
+      Contrairement à commande_interne, le label est pivoté au grain tâche (1 label STATUT_LIVRAISON
+      par tâche aujourd'hui) plutôt que dédupliqué. Aucun filtre statut ici : le tri
+      FAIT/VALIDE/ANNULE se fait en marts / couche métier.
+    columns:
+      # --- IDENTIFIANTS ---
+      - name: task_product_id
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
+        data_type: int64
+        tests:
+          - unique
+          - not_null
+      - name: task_id
+        description: "Tâche de commande fournisseur Oracle (EVS.TASK)."
+        data_type: int64
+        tests:
+          - not_null
+      - name: company_id
+        description: "Client (peer company) de la tâche. FK → dim_neshu__company."
+        data_type: int64
+      - name: product_id
+        description: "Produit commandé. FK → dim_neshu__product."
+        data_type: int64
+        tests:
+          - not_null
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité **source** (le fournisseur). Référence polymorphe : table cible
+          nommée par product_source_type — COMPANY → stg_oracle_neshu__company. Pas une FK produit.
+        data_type: int64
+      - name: product_source_type
+        description: "Type de l'entité source = table cible de product_source_id. Toujours COMPANY (fournisseur) sur ce type de tâche."
+        data_type: string
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité **destination** (le dépôt). Référence polymorphe : table cible
+          nommée par product_destination_type — COMPANY → stg_oracle_neshu__company.
+        data_type: int64
+      - name: product_destination_type
+        description: "Type de l'entité destination = table cible de product_destination_id. Toujours COMPANY (dépôt) sur ce type de tâche."
+        data_type: string
+
+      # --- CODES ---
+      - name: source_code
+        description: "Code du fournisseur (company.code de la source). Ex. NESPRESSO, NUNSHEN, LIDIS PARIS."
+        data_type: string
+        tests:
+          - not_null
+      - name: destination_code
+        description: "Code du dépôt destinataire (company.code de la destination). Ex. DEPOTRUNGIS, DEPOTLYON."
+        data_type: string
+        tests:
+          - not_null
+      - name: product_code
+        description: "Code métier du produit."
+        data_type: string
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche. Valeurs observées : FAIT (réalisé, majoritaire), VALIDE, ANNULE.
+          Aucun filtre appliqué ici (tri en marts / couche métier).
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+      - name: delivery_status_code
+        description: >
+          Statut de livraison de la commande fournisseur, pivoté au grain tâche depuis le label de
+          famille STATUT_LIVRAISON. Valeurs : LIVRE (livré, majoritaire), LIVRE_PARTIEL (livraison
+          partielle), EN_ATTENTE (en attente). Nul si la tâche ne porte aucun label.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [LIVRE, LIVRE_PARTIEL, EN_ATTENTE]
+              config:
+                severity: warn
+
+      # --- DATE ---
+      - name: task_start_date
+        description: "Date et heure réelle de la commande fournisseur."
+        data_type: timestamp
+        tests:
+          - not_null
+
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
+      - name: base_unit_quantity
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
+      - name: product_unit_price_task
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
+      - name: product_unit_price_latest
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
+
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité commandée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
+      - name: valuation
+        description: "Valorisation de la commande en euros = quantity × prix d'achat unitaire. Mesure additive."
+
+      # --- MÉTADONNÉES ---
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp
+        tests:
+          - not_null
+
   - name: int_oracle_neshu__valorisation_parc_machines
     description: >
       [QUOI MÉTIER]

--- a/models/intermediate/oracle_neshu/int_oracle_neshu__commande_fournisseur_tasks.sql
+++ b/models/intermediate/oracle_neshu/int_oracle_neshu__commande_fournisseur_tasks.sql
@@ -1,0 +1,147 @@
+{{ config(materialized='table') }}
+
+with delivery_status as (
+
+    -- Pivot du label au grain tâche (1 label STATUT_LIVRAISON par tâche aujourd'hui).
+    -- Pivot plutôt que jointure + dédup : pas de fan-out sur les lignes produit,
+    -- robuste si une seconde famille de label apparaît un jour.
+    select
+        lht.idtask,
+        max(case when lf.code = 'STATUT_LIVRAISON' then la.code end) as delivery_status_code
+
+    from {{ ref('stg_oracle_neshu__label_has_task') }} as lht
+    inner join {{ ref('stg_oracle_neshu__label') }} as la
+        on lht.idlabel = la.idlabel
+    inner join {{ ref('stg_oracle_neshu__label_family') }} as lf
+        on la.idlabel_family = lf.idlabel_family
+
+    group by lht.idtask
+),
+
+commande_fournisseur_base as (
+
+    select
+        -- Identifiants
+        thp.idtask_has_product as task_product_id,
+        t.idtask as task_id,
+        t.idcompany_peer as company_id,
+        thp.idproduct as product_id,
+        t.idproduct_source as product_source_id,
+        t.type_product_source as product_source_type,
+        t.idproduct_destination as product_destination_id,
+        t.type_product_destination as product_destination_type,
+
+        -- Codes (source = fournisseur, destination = dépôt : toujours COMPANY)
+        cs.code as source_code,
+        cd.code as destination_code,
+        p.code as product_code,
+        ts.code as task_status_code,
+
+        -- Informations date
+        t.real_start_date as task_start_date,
+
+        -- Informations de conditionnement
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity as base_unit_quantity,
+        thp.net_price as product_unit_price_task,
+        p.purchase_unit_price as product_unit_price_latest,
+
+        -- Métriques
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div) as quantity,
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div * p.purchase_unit_price) as valuation,
+
+        -- Timestamps techniques
+        t.updated_at,
+        t.created_at,
+        t.extracted_at
+
+    from {{ ref('stg_oracle_neshu__task') }} as t
+    inner join {{ ref('stg_oracle_neshu__task_has_product') }} as thp
+        on t.idtask = thp.idtask
+    left join {{ ref('stg_oracle_neshu__product') }} as p
+        on thp.idproduct = p.idproduct
+    left join {{ ref('stg_oracle_neshu__task_status') }} as ts
+        on t.idtask_status = ts.idtask_status
+
+    -- Source = COMPANY (fournisseur)
+    left join {{ ref('stg_oracle_neshu__company') }} as cs
+        on
+            t.idproduct_source = cs.idcompany
+            and t.type_product_source = 'COMPANY'
+
+    -- Destination = COMPANY (dépôt)
+    left join {{ ref('stg_oracle_neshu__company') }} as cd
+        on
+            t.idproduct_destination = cd.idcompany
+            and t.type_product_destination = 'COMPANY'
+
+    where
+        1 = 1
+        and t.idtask_type = 120  -- COMMANDE FOURNISSEUR
+        and t.code_status_record = '1'
+        and t.real_start_date is not null
+
+    group by
+        thp.idtask_has_product,
+        t.idtask,
+        t.idcompany_peer,
+        thp.idproduct,
+        t.idproduct_source,
+        t.type_product_source,
+        t.idproduct_destination,
+        t.type_product_destination,
+        cs.code, cd.code,
+        p.code, ts.code,
+        t.real_start_date,
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity,
+        thp.net_price,
+        p.purchase_unit_price,
+        t.updated_at, t.created_at, t.extracted_at
+)
+
+select
+    -- Identifiants
+    cfb.task_product_id,
+    cfb.task_id,
+    cfb.company_id,
+    cfb.product_id,
+    cfb.product_source_id,
+    cfb.product_source_type,
+    cfb.product_destination_id,
+    cfb.product_destination_type,
+
+    -- Codes
+    cfb.source_code,
+    cfb.destination_code,
+    cfb.product_code,
+    cfb.task_status_code,
+    ds.delivery_status_code,
+
+    -- Infos métier
+    cfb.task_start_date,
+
+    -- Infos de conditionnement
+    cfb.unit_coeff_multi,
+    cfb.unit_coeff_div,
+    cfb.base_unit_quantity,
+    cfb.product_unit_price_task,
+    cfb.product_unit_price_latest,
+
+    -- Métriques
+    cfb.quantity,
+    cfb.valuation,
+
+    -- Timestamps techniques
+    cfb.updated_at,
+    cfb.created_at,
+    cfb.extracted_at
+
+from commande_fournisseur_base as cfb
+left join delivery_status as ds
+    on cfb.task_id = ds.idtask
+where
+    cfb.source_code is not null
+    and cfb.destination_code is not null

--- a/models/intermediate/oracle_neshu/int_oracle_neshu__reception_tasks.sql
+++ b/models/intermediate/oracle_neshu/int_oracle_neshu__reception_tasks.sql
@@ -5,12 +5,31 @@
     )
 }}
 
-with reception_base as (
+with commande_header as (
+
+    -- Date de la commande fournisseur (type 120) rattachée à la réception.
+    -- Le lien passe par le document parent partagé (task_idtask) : commande et réception
+    -- pointent vers le même parent. 1 commande par parent -> au plus 1 date par réception,
+    -- donc pas de fan-out. min() = collapse défensif des lignes produit de la commande.
+    select
+        task_idtask as parent_id,
+        min(real_start_date) as commande_start_date
+
+    from {{ ref('stg_oracle_neshu__task') }}
+    where
+        idtask_type = 120  -- COMMANDE FOURNISSEUR
+        and code_status_record = '1'
+        and task_idtask is not null
+    group by task_idtask
+),
+
+reception_base as (
 
     select
         -- Identifiants
         thp.idtask_has_product as task_product_id,
         t.idtask as task_id,
+        t.task_idtask as parent_id,  -- interne : clé de jointure vers la commande (non exposé)
         t.idcompany_peer as company_id,
         thp.idproduct as product_id,
         t.idproduct_destination as product_destination_id,
@@ -62,7 +81,7 @@ with reception_base as (
         and t.real_start_date is not null
 
     group by
-        thp.idtask_has_product, t.idtask, t.idcompany_peer,
+        thp.idtask_has_product, t.idtask, t.task_idtask, t.idcompany_peer,
         t.idproduct_destination, t.type_product_destination,
         thp.idproduct,
         thp.unit_coeff_multi,
@@ -78,35 +97,43 @@ with reception_base as (
 
 select
     -- Identifiants
-    task_product_id,
-    task_id,
-    company_id,
-    product_id,
-    product_destination_id,
-    product_destination_type,
+    rb.task_product_id,
+    rb.task_id,
+    rb.company_id,
+    rb.product_id,
+    rb.product_destination_id,
+    rb.product_destination_type,
 
     -- Codes
-    destination_code,
-    product_code,
-    task_status_code,
+    rb.destination_code,
+    rb.product_code,
+    rb.task_status_code,
 
     -- Infos métier
-    task_start_date,
+    rb.task_start_date,
+    ch.commande_start_date,
+
+    -- Délai de livraison fournisseur (commande -> réception)
+    date_diff(date(rb.task_start_date), date(ch.commande_start_date), day) as delivery_lead_time_days,
+    ch.commande_start_date is not null
+    and rb.task_start_date >= ch.commande_start_date as is_lead_time_valid,
 
     -- Infos de conditionnement
-    unit_coeff_multi,
-    unit_coeff_div,
-    base_unit_quantity,
-    product_unit_price_task,
-    product_unit_price_latest,
+    rb.unit_coeff_multi,
+    rb.unit_coeff_div,
+    rb.base_unit_quantity,
+    rb.product_unit_price_task,
+    rb.product_unit_price_latest,
 
     -- Métriques
-    quantity,
-    valuation,
+    rb.quantity,
+    rb.valuation,
 
     -- Timestamps techniques
-    updated_at,
-    created_at,
-    extracted_at
+    rb.updated_at,
+    rb.created_at,
+    rb.extracted_at
 
-from reception_base
+from reception_base as rb
+left join commande_header as ch
+    on rb.parent_id = ch.parent_id


### PR DESCRIPTION
## Contexte

Ajout de la tâche **COMMANDE FOURNISSEUR** (`idtask_type = 120`) dans la couche intermediate NESHU, puis exploitation du lien commande ↔ réception pour ajouter un **délai de livraison fournisseur** sur les réceptions.

## Contenu

### 1. Nouveau modèle `int_oracle_neshu__commande_fournisseur_tasks` (type 120)
- Grain : `task_product_id` (ligne de commande). Flux **fournisseur (source) → dépôt (destination)**, toujours `COMPANY → COMPANY`.
- **Pivot du label** `STATUT_LIVRAISON` au grain **tâche** via `max(case ...)` puis `left join` sur les lignes produit → pas de dédup, pas de fan-out (amélioration vs le pattern join+dédup de `commande_interne`).
- Tous les statuts de tâche conservés (filtrage renvoyé en marts / métier).
- Doc YAML 4 blocs + tests : `unique`/`not_null` sur la PK, `accepted_values` (warn) sur `task_status_code` et `delivery_status_code`.

### 2. Enrichissement `int_oracle_neshu__reception_tasks` — lead time fournisseur
- Lien commande ↔ réception via le **document parent partagé** (`task_idtask`, type 109 GESCOM). Une réception pointe vers **au plus 1 commande** → jointure `left join` qui **ne change pas le grain** (PK `task_product_id` reste unique).
- Nouvelles colonnes : `commande_start_date`, `delivery_lead_time_days`, `is_lead_time_valid`.
- Garde-fous DQ : réceptions non rapprochées → `NULL` ; rares délais négatifs (saisie ERP) neutralisés via `is_lead_time_valid`.
- Le label de livraison (saisi manuellement, peu fiable) n'est **pas** repris : tout écart de complétude quantité se traite côté métier (documenté dans `[NOTES]`).

## Analyse données (prod)
- 120 : 1 677 tâches / 7 762 lignes, source fournisseur → dépôt dépôt.
- Lien 120↔121 indirect via parent GESCOM : ~1 commande / GESCOM, 0..6 BL (livraisons partielles).
- Rapprochement réceptions → commande : ~97 % ; délai médian ~5 j.

## Validation
- `sqlfluff lint` OK sur les 2 modèles.
- `dbt build` OK : commande fournisseur (7,7k lignes, 12 tests PASS), reception_tasks (9,6k lignes, PK unique, 9 tests PASS).
- `dbt parse` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)