### PR TITLE
feat(supply_chain): Yuman article-level stock/out-of-stock + type_stock on stock_yuman

### DIFF
--- a/macros/yuman/yuman_stock_type.sql
+++ b/macros/yuman/yuman_stock_type.sql
@@ -1,0 +1,10 @@
+{# Source unique de vérité : un emplacement Yuman (nom_du_stock) est un dépôt si son
+   libellé contient 'DEPOT' (4 sites), sinon un stock technicien (van). #}
+
+{% macro yuman_is_depot(col) -%}
+({{ col }} like '%DEPOT%')
+{%- endmacro %}
+
+{% macro yuman_stock_type(col) -%}
+case when {{ yuman_is_depot(col) }} then 'DEPOT' else 'TECHNICIEN' end
+{%- endmacro %}

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -115,9 +115,9 @@ models:
   - name: fct_supply_chain__stock_yuman
     description: |
       [QUOI MÉTIER] Stock journalier des pièces détachées Yuman, par technicien et par dépôt.
-      [COMMENT CONSTRUITE] Lecture directe de stg_yuman_gcs__stock_theorique (export GCS quotidien Yuman), avec conversion export_date → DATE et filtre sur reference et nom_du_stock non NULL.
+      [COMMENT CONSTRUITE] Lecture directe de stg_yuman_gcs__stock_theorique (export GCS quotidien Yuman), avec conversion export_date → DATE et filtre sur reference et nom_du_stock non NULL. type_stock classe chaque emplacement en DEPOT/TECHNICIEN via la macro yuman_stock_type.
       [GRAIN] 1 ligne par (reference, stock, stock_date).
-      [NOTES] stock = libellé du stock physique (technicien ou dépôt Yuman).
+      [NOTES] stock = libellé du stock physique (technicien ou dépôt Yuman). Ne contient que des lignes en stock (quantite > 0) : les ruptures (sans emplacement) sont exclues et exposées au grain article dans fct_supply_chain__stock_article_yuman.
     columns:
       - name: reference
         description: "Référence de l'article"
@@ -127,6 +127,12 @@ models:
         description: "Désignation de l'article"
       - name: stock
         description: "Nom du stock (dépôt ou technicien)"
+      - name: type_stock
+        description: "Type d'emplacement : DEPOT (4 sites) ou TECHNICIEN (van), dérivé du libellé du stock via la macro yuman_stock_type"
+        tests:
+          - accepted_values:
+              arguments:
+                values: [DEPOT, TECHNICIEN]
       - name: quantite
         description: "Quantité de l'article dans le stock"
       - name: stock_date

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -134,6 +134,64 @@ models:
         tests:
           - not_null
 
+  - name: fct_supply_chain__stock_article_yuman
+    description: |
+      [QUOI MÉTIER] Stock journalier des articles Yuman au niveau **article** (tous magasins agrégés), avec le drapeau de rupture. Répond à « quels articles sont en rupture totale » et sert de base à un futur taux de disponibilité article.
+      [COMMENT CONSTRUITE] Agrégation de stg_yuman_gcs__stock_theorique par (reference, date). Chaque emplacement (nom_du_stock) est classé DÉPÔT (libellé contenant 'DEPOT', 4 sites) ou TECHNICIEN (van, actif 'ST - …' ou inactif). total_quantity = somme tous emplacements ; depot_quantity / technicien_quantity = sommes ventilées ; is_out_of_stock = total nul (absent partout) ; is_out_of_stock_depot = total dépôt nul (indisponible au réappro). Contrairement au mart par magasin, AUCUN filtre sur nom_du_stock : les lignes de rupture (quantite = 0, sans emplacement en source) sont conservées.
+      [GRAIN] 1 ligne par (reference, stock_date).
+      [NOTES] ⚠️ Spécificité Yuman : la rupture n'existe qu'au niveau **article**, pas par emplacement (l'export ne localise pas une rupture — contrairement à Neshu où stock_neshu la porte par entité). Les emplacements mêlent **dépôts ET techniciens** : un article présent uniquement chez un technicien est en stock globalement (is_out_of_stock = false) mais en rupture dépôt (is_out_of_stock_depot = true) → pour le réappro, se fier à is_out_of_stock_depot ; is_out_of_stock_technicien donne la vue terrain (vans). Invariant : is_out_of_stock = is_out_of_stock_depot AND is_out_of_stock_technicien. La distinction dépôt/technicien n'est possible que sur les lignes en stock (quantite > 0, seules à porter un emplacement) ; une rupture totale (quantite = 0) arrive sans emplacement et compte comme vide des deux côtés. Classification dépôt/technicien = heuristique sur le libellé ('DEPOT'). Le détail par emplacement reste dans fct_supply_chain__stock_yuman. ~181 couples reference/date ont 2 désignations en source → min() retenu.
+    columns:
+      - name: stock_date
+        description: "Date du stock (DATE), colonne de partition"
+        tests:
+          - not_null
+      - name: reference
+        description: "Référence de l'article"
+        tests:
+          - not_null
+      - name: designation
+        description: "Désignation de l'article (min() si plusieurs libellés en source)"
+      - name: is_out_of_stock
+        description: "TRUE si l'article est en rupture totale ce jour-là (aucun emplacement, dépôt ni technicien, total_quantity = 0). Vaut is_out_of_stock_depot AND is_out_of_stock_technicien."
+      - name: is_out_of_stock_depot
+        description: "TRUE si l'article n'est en stock dans aucun dépôt ce jour-là (depot_quantity = 0), même s'il reste du stock chez des techniciens. Indicateur de rupture pour le réappro."
+      - name: is_out_of_stock_technicien
+        description: "TRUE si l'article n'est en stock chez aucun technicien ce jour-là (technicien_quantity = 0), même s'il reste du stock en dépôt. Indicateur de disponibilité terrain (vans)."
+      - name: total_quantity
+        description: "Quantité totale de l'article, agrégée sur tous les emplacements (dépôts + techniciens ; 0 si rupture)"
+      - name: depot_quantity
+        description: "Quantité de l'article dans les dépôts uniquement (0 si aucun dépôt approvisionné)"
+      - name: technicien_quantity
+        description: "Quantité de l'article dans les stocks techniciens uniquement (total_quantity − depot_quantity)"
+      - name: nb_depots_en_stock
+        description: "Nombre de dépôts où l'article a une quantité > 0 ce jour-là"
+      - name: nb_techniciens_en_stock
+        description: "Nombre de stocks techniciens où l'article a une quantité > 0 ce jour-là"
+      - name: dbt_updated_at
+        description: "Timestamp de reconstruction de la table"
+      - name: dbt_invocation_id
+        description: "Identifiant du run dbt ayant produit la ligne"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - reference
+              - stock_date
+      # cohérence des drapeaux de rupture vs les mesures agrégées
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_out_of_stock = (total_quantity = 0)"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_out_of_stock_depot = (depot_quantity = 0)"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_out_of_stock_technicien = (technicien_quantity = 0)"
+      # invariant : rupture globale = rupture dépôt ET rupture technicien
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_out_of_stock = (is_out_of_stock_depot and is_out_of_stock_technicien)"
+
   - name: fct_supply_chain__disponibilite_article_neshu_depot_mensuel
     description: |
       [QUOI MÉTIER] Taux de disponibilité mensuel des articles dans les dépôts Neshu : part des jours du mois où l'article était en stock (> 0).

--- a/models/marts/supply_chain/fct_supply_chain__stock_article_yuman.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_article_yuman.sql
@@ -1,0 +1,53 @@
+{{ config(
+    materialized='table',
+    partition_by={
+        'field': 'stock_date',
+        'data_type': 'date'
+    }
+) }}
+
+-- Un emplacement de stock Yuman (nom_du_stock) est soit un DÉPÔT (libellé contenant 'DEPOT',
+-- 4 sites), soit un TECHNICIEN (van, actif 'ST - …' ou inactif 'Stock technicien - …').
+-- La rupture (quantite = 0) arrive en source sans emplacement (nom_du_stock NULL).
+
+with article_stock as (
+    select
+        -- Grain
+        date(export_date) as stock_date,
+        reference,
+
+        -- Attribut metier (min() = choix deterministe : ~181 couples reference/date
+        -- portent 2 designations distinctes en source)
+        min(designation) as designation,
+
+        -- Disponibilite : global (tous emplacements), depot (reappro), technicien (terrain).
+        -- Invariant : is_out_of_stock = is_out_of_stock_depot AND is_out_of_stock_technicien.
+        sum(quantite) = 0 as is_out_of_stock,
+        sum(case when {{ yuman_is_depot('nom_du_stock') }} then quantite else 0 end) = 0 as is_out_of_stock_depot,
+        sum(case when not {{ yuman_is_depot('nom_du_stock') }} then quantite else 0 end) = 0
+            as is_out_of_stock_technicien,
+
+        -- Mesures : quantites agregees
+        sum(quantite) as total_quantity,
+        sum(case when {{ yuman_is_depot('nom_du_stock') }} then quantite else 0 end) as depot_quantity,
+        sum(case when not {{ yuman_is_depot('nom_du_stock') }} then quantite else 0 end) as technicien_quantity,
+
+        -- Mesures : nb d'emplacements approvisionnes (quantite > 0)
+        count(distinct case
+            when {{ yuman_is_depot('nom_du_stock') }} and quantite > 0 then nom_du_stock
+        end) as nb_depots_en_stock,
+        count(distinct case
+            when not {{ yuman_is_depot('nom_du_stock') }} and quantite > 0 then nom_du_stock
+        end) as nb_techniciens_en_stock,
+
+        -- Metadonnees dbt
+        current_timestamp() as dbt_updated_at,
+        '{{ invocation_id }}' as dbt_invocation_id
+
+    from {{ ref('stg_yuman_gcs__stock_theorique') }}
+    where reference is not null
+    group by stock_date, reference
+)
+
+select *
+from article_stock

--- a/models/marts/supply_chain/fct_supply_chain__stock_yuman.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_yuman.sql
@@ -12,6 +12,7 @@ with filtered_stocks as (
         reference,
         designation,
         nom_du_stock as stock,
+        {{ yuman_stock_type('nom_du_stock') }} as type_stock,
 
         -- Mesure
         quantite,


### PR DESCRIPTION
## Contexte

La logistique veut suivre les **articles en rupture** côté Yuman. Or les stocks Yuman ne se comportent pas comme Neshu : la rupture n'existe qu'au **niveau article** (une ligne `quantite = 0` **sans emplacement**), pas par magasin. On ne peut donc pas ajouter un simple `is_out_of_stock` au mart stock par emplacement — d'où un mart séparé au grain article + une classification dépôt/technicien sur l'existant.

## Contenu

### 1. `fct_supply_chain__stock_article_yuman` (nouveau, grain article)
- **Grain** : 1 ligne par (`reference`, `stock_date`), rollup de tous les emplacements.
- **Construit** depuis `stg_yuman_gcs__stock_theorique` **sans** filtre `nom_du_stock` → les lignes de rupture (exclues du mart par emplacement) sont conservées.
- Les emplacements mêlant **dépôts (4 sites) et vans techniciens**, la disponibilité est déclinée en 3 niveaux :
  - `is_out_of_stock` (absent partout)
  - `is_out_of_stock_depot` (rien en dépôt = **signal réappro**)
  - `is_out_of_stock_technicien` (rien chez les techniciens = vue terrain)
  - invariant : `is_out_of_stock = is_out_of_stock_depot AND is_out_of_stock_technicien`
- Mesures : `total_quantity`, `depot_quantity`, `technicien_quantity`, `nb_depots_en_stock`, `nb_techniciens_en_stock`.
- La distinction dépôt/technicien ne s'applique qu'aux lignes en stock (`quantite > 0`, seules à porter un emplacement) ; une rupture totale (0, sans emplacement) compte comme vide des deux côtés.

### 2. `type_stock` (DEPOT / TECHNICIEN) sur `fct_supply_chain__stock_yuman`
- Classe chaque emplacement sur le mart **par emplacement** existant → filtrage/ventilation BI dépôts vs techniciens.
- **Pas** de `is_out_of_stock` ici (ce mart ne contient que du stock présent — un flag serait constant `false`).

### 3. Macro partagée `yuman_stock_type` / `yuman_is_depot`
- Source unique de la classification (heuristique libellé `'DEPOT'`), utilisée par les deux marts (DRY).

## Analyse données (prod)
- Rupture Yuman = niveau article uniquement (overlap 0 % entre lignes « en stock/localisées » et « rupture/sans emplacement »).
- Emplacements : 4 dépôts, 45 techniciens actifs, 5 inactifs — classification 100 % couverte.
- ~4 % des articles/jours sont « vide en dépôt mais encore chez un technicien » → invisibles avec le seul flag global, d'où `is_out_of_stock_depot`.

## Validation
- `sqlfluff lint` OK sur les 2 modèles.
- `dbt build` OK : 2 modèles, **12 tests PASS** (unicité (reference, stock_date), not_null, `accepted_values` type_stock, `expression_is_true` sur les 3 flags + invariant).

## Suite (hors PR)
Un **taux de disponibilité article** (mensuel, façon Neshu) est envisagé mais **volontairement pas construit ici** : plusieurs choix métier le conditionnent (niveau dépôt/global/technicien, pas de taux par dépôt individuel possible, base de temps ~6j/7). Cadrage métier en cours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)