### PR TITLE
feat(yuman): rework article consumption fact + fix stock article designation dedup

### DIFF
--- a/macros/yuman/yuman_is_marqueur_designation.sql
+++ b/macros/yuman/yuman_is_marqueur_designation.sql
@@ -1,0 +1,10 @@
+{# Vrai si la désignation Yuman est un "marqueur" (note de gestion) et non un vrai libellé
+   d'article : "- NE PAS UTILISER -", "OLD - ...", "Remplacé par 1055767", etc.
+   Sert à écarter ces libellés quand une même référence porte plusieurs désignations
+   (dédup de designation dans fct_supply_chain__stock_article_yuman).
+   Regex volontairement étroite (validée sur données) pour NE PAS attraper de vraies pièces
+   ("VANNE D'ARRET", "Kit remplacement …", "… HOLDER"). #}
+
+{% macro yuman_is_marqueur_designation(col) -%}
+regexp_contains(upper({{ col }}), r'NE PAS UTILISER|^OLD |REMPLAC.{0,4}PAR')
+{%- endmacro %}

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -145,7 +145,7 @@ models:
       [QUOI MÉTIER] Stock journalier des articles Yuman au niveau **article** (tous magasins agrégés), avec le drapeau de rupture. Répond à « quels articles sont en rupture totale » et sert de base à un futur taux de disponibilité article.
       [COMMENT CONSTRUITE] Agrégation de stg_yuman_gcs__stock_theorique par (reference, date). Chaque emplacement (nom_du_stock) est classé DÉPÔT (libellé contenant 'DEPOT', 4 sites) ou TECHNICIEN (van, actif 'ST - …' ou inactif). total_quantity = somme tous emplacements ; depot_quantity / technicien_quantity = sommes ventilées ; is_out_of_stock = total nul (absent partout) ; is_out_of_stock_depot = total dépôt nul (indisponible au réappro). Contrairement au mart par magasin, AUCUN filtre sur nom_du_stock : les lignes de rupture (quantite = 0, sans emplacement en source) sont conservées.
       [GRAIN] 1 ligne par (reference, stock_date).
-      [NOTES] ⚠️ Spécificité Yuman : la rupture n'existe qu'au niveau **article**, pas par emplacement (l'export ne localise pas une rupture — contrairement à Neshu où stock_neshu la porte par entité). Les emplacements mêlent **dépôts ET techniciens** : un article présent uniquement chez un technicien est en stock globalement (is_out_of_stock = false) mais en rupture dépôt (is_out_of_stock_depot = true) → pour le réappro, se fier à is_out_of_stock_depot ; is_out_of_stock_technicien donne la vue terrain (vans). Invariant : is_out_of_stock = is_out_of_stock_depot AND is_out_of_stock_technicien. La distinction dépôt/technicien n'est possible que sur les lignes en stock (quantite > 0, seules à porter un emplacement) ; une rupture totale (quantite = 0) arrive sans emplacement et compte comme vide des deux côtés. Classification dépôt/technicien = heuristique sur le libellé ('DEPOT'). Le détail par emplacement reste dans fct_supply_chain__stock_yuman. ~181 couples reference/date ont 2 désignations en source → min() retenu.
+      [NOTES] ⚠️ Spécificité Yuman : la rupture n'existe qu'au niveau **article**, pas par emplacement (l'export ne localise pas une rupture — contrairement à Neshu où stock_neshu la porte par entité). Les emplacements mêlent **dépôts ET techniciens** : un article présent uniquement chez un technicien est en stock globalement (is_out_of_stock = false) mais en rupture dépôt (is_out_of_stock_depot = true) → pour le réappro, se fier à is_out_of_stock_depot ; is_out_of_stock_technicien donne la vue terrain (vans). Invariant : is_out_of_stock = is_out_of_stock_depot AND is_out_of_stock_technicien. La distinction dépôt/technicien n'est possible que sur les lignes en stock (quantite > 0, seules à porter un emplacement) ; une rupture totale (quantite = 0) arrive sans emplacement et compte comme vide des deux côtés. Classification dépôt/technicien = heuristique sur le libellé ('DEPOT'). Le détail par emplacement reste dans fct_supply_chain__stock_yuman. La désignation est résolue au grain référence en écartant les libellés-marqueur (voir macro yuman_is_marqueur_designation).
     columns:
       - name: stock_date
         description: "Date du stock (DATE), colonne de partition"
@@ -156,7 +156,11 @@ models:
         tests:
           - not_null
       - name: designation
-        description: "Désignation de l'article (min() si plusieurs libellés en source)"
+        description: >
+          Désignation de l'article, résolue au grain **référence** (même libellé sur toutes les dates).
+          Quand une référence porte plusieurs libellés en source, les libellés « marqueur »
+          (« NE PAS UTILISER », « OLD … », « Remplacé par … ») sont écartés via la macro
+          yuman_is_marqueur_designation ; fallback min() si la référence n'a que des marqueurs.
       - name: is_out_of_stock
         description: "TRUE si l'article est en rupture totale ce jour-là (aucun emplacement, dépôt ni technicien, total_quantity = 0). Vaut is_out_of_stock_depot AND is_out_of_stock_technicien."
       - name: is_out_of_stock_depot

--- a/models/marts/supply_chain/fct_supply_chain__stock_article_yuman.sql
+++ b/models/marts/supply_chain/fct_supply_chain__stock_article_yuman.sql
@@ -10,15 +10,27 @@
 -- 4 sites), soit un TECHNICIEN (van, actif 'ST - …' ou inactif 'Stock technicien - …').
 -- La rupture (quantite = 0) arrive en source sans emplacement (nom_du_stock NULL).
 
-with article_stock as (
+with reference_designation as (
+    -- Désignation unique par référence (attribut article, invariant dans le temps).
+    -- Une même référence porte parfois plusieurs libellés : on écarte les "marqueurs"
+    -- (NE PAS UTILISER, OLD, Remplacé par...) et on retient le plus petit des libellés
+    -- valides ; fallback sur min(tout) si la référence n'a QUE des marqueurs (jamais NULL).
+    select
+        reference,
+        coalesce(
+            min(case when not {{ yuman_is_marqueur_designation('designation') }} then designation end),
+            min(designation)
+        ) as designation
+    from {{ ref('stg_yuman_gcs__stock_theorique') }}
+    where reference is not null
+    group by reference
+),
+
+article_stock as (
     select
         -- Grain
         date(export_date) as stock_date,
         reference,
-
-        -- Attribut metier (min() = choix deterministe : ~181 couples reference/date
-        -- portent 2 designations distinctes en source)
-        min(designation) as designation,
 
         -- Disponibilite : global (tous emplacements), depot (reappro), technicien (terrain).
         -- Invariant : is_out_of_stock = is_out_of_stock_depot AND is_out_of_stock_technicien.
@@ -49,5 +61,20 @@ with article_stock as (
     group by stock_date, reference
 )
 
-select *
-from article_stock
+select
+    a.stock_date,
+    a.reference,
+    rd.designation,
+    a.is_out_of_stock,
+    a.is_out_of_stock_depot,
+    a.is_out_of_stock_technicien,
+    a.total_quantity,
+    a.depot_quantity,
+    a.technicien_quantity,
+    a.nb_depots_en_stock,
+    a.nb_techniciens_en_stock,
+    a.dbt_updated_at,
+    a.dbt_invocation_id
+from article_stock as a
+left join reference_designation as rd
+    on a.reference = rd.reference

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -471,7 +471,7 @@ models:
 
       [NOTES]
       Dimension conforme : sert aux analyses technique (consommation
-      d'articles via `fct_technique__workorder_product`) et supply_chain
+      d'articles via `fct_technique__consommation_article_yuman`) et supply_chain
       (le stock `fct_supply_chain__stock_yuman` se joint via
       `product_code` = `reference`). Les prix achat/vente sont les prix
       courants Yuman, sans historique — toute valorisation est indicative.
@@ -522,30 +522,40 @@ models:
           config:
             severity: warn
 
-  - name: fct_technique__workorder_product
+  - name: fct_technique__consommation_article_yuman
     description: |
       [QUOI MÉTIER]
-      Consommation d'articles (pièces détachées, consommables) par
-      intervention Yuman. Permet l'analyse des pièces consommées par client /
-      site / machine / technicien, et le rapprochement avec les stocks
-      théoriques (`fct_supply_chain__stock_yuman`).
+      Consommation d'articles (pièces détachées, consommables) lors des
+      interventions Yuman — « article » au sens catalogue Yuman, à ne pas
+      confondre avec la consommation de boissons NESHU (`fct_neshu__consommation`).
+      Permet l'analyse des articles consommés par client / site / machine /
+      technicien / type d'intervention, et le rapprochement avec les stocks
+      (`fct_supply_chain__stock_yuman`, `fct_supply_chain__stock_article_yuman`)
+      via `dim_technique__product` (product_code = reference).
 
       [COMMENT CONSTRUITE]
       Agrégation de `stg_yuman__workorder_products` (lignes de saisie) au
-      grain workorder x produit (`sum(quantity)`), enrichie via
-      `int_yuman__demands_workorders_enriched` (dédupliqué par workorder)
-      pour porter les FK client / site / matériel / technicien et la date
-      d'intervention.
+      grain workorder x article (`sum(quantity)`), jointe (inner join) à
+      `int_yuman__demands_workorders_enriched` (dédupliqué par workorder,
+      restreint aux workorders rattachés à une demande) pour porter les FK
+      client / site / matériel / technicien, l'état métier canonique
+      `intervention_state` et les motifs de non-intervention / pause.
 
       [GRAIN]
-      1 ligne par couple (`workorder_id`, `product_id`).
+      1 ligne par couple (`workorder_id`, `product_id`). ~16,6k lignes.
 
       [NOTES]
-      Les workorders hors flux demande (~6) ont leurs FK et `date_done` null
-      (left join sur l'intermediate). Pas de valorisation dans le fait : les
-      prix Yuman sont courants, sans historique — valoriser une consommation
-      passée au prix du jour serait faux (calcul indicatif possible côté PBI
-      via `dim_technique__product`).
+      Périmètre : les workorders **hors flux demande** (sans demande rattachée,
+      ~10 lignes, FK non exploitables) sont **exclus**. Aucun filtre de statut en
+      revanche : ~99,8 % de la conso est sur des interventions REALISEE, le reste
+      (NON_REALISEE / EN_COURS / EN_PAUSE) est conservé et qualifié par
+      `intervention_state` pour laisser le choix au métier — filtrer
+      `intervention_state = 'REALISEE'` pour la conso confirmée. Les NON_REALISEE
+      sont majoritairement des « Erreur de saisie » (cf.
+      `workorder_motif_non_intervention`) → conso probablement erronée. Les
+      interventions EN_COURS ont `date_done` null (partition null). Pas de
+      valorisation : prix Yuman courants sans historique (calcul indicatif
+      possible côté PBI via `dim_technique__product`).
     columns:
       - name: workorder_id
         description: Identifiant du bon de travail (dimension dégénérée).
@@ -555,7 +565,9 @@ models:
       - name: demand_id
         description: >
           Identifiant de la demande d'intervention rattachée (dimension
-          dégénérée). Null pour les interventions hors flux demande.
+          dégénérée). Toujours renseigné : les workorders sans demande sont exclus.
+        tests:
+          - not_null
 
       - name: product_id
         description: Identifiant de l'article consommé (FK).
@@ -571,8 +583,8 @@ models:
       - name: material_id
         description: >
           Identifiant du matériel concerné par l'intervention (FK).
-          Nullable : null quand le workorder n'a pas de machine rattachée
-          (interventions hors flux demande). Pas de not_null volontairement.
+          Nullable : null quand la demande n'a pas de machine rattachée
+          (~819 lignes, cas légitime). Pas de not_null volontairement.
         tests:
           - relationships:
               arguments:
@@ -583,8 +595,8 @@ models:
 
       - name: site_id
         description: >
-          Identifiant du site client (FK). Nullable (idem material_id :
-          interventions hors flux demande).
+          Identifiant du site client (FK). Non null : toute conso est rattachée
+          à une demande (les workorders hors flux demande sont exclus).
         tests:
           - relationships:
               arguments:
@@ -595,8 +607,8 @@ models:
 
       - name: client_id
         description: >
-          Identifiant du client (FK). Nullable (idem material_id :
-          interventions hors flux demande).
+          Identifiant du client (FK). Non null : toute conso est rattachée à une
+          demande (workorders hors flux demande exclus).
         tests:
           - relationships:
               arguments:
@@ -608,7 +620,7 @@ models:
       - name: technician_id
         description: >
           Identifiant du technicien associé (FK vers dim_technique__technician,
-          PK user_id). Nullable pour les interventions hors flux demande.
+          PK user_id). Non null : les workorders hors flux demande sont exclus.
         tests:
           - relationships:
               arguments:
@@ -616,6 +628,14 @@ models:
                 field: user_id
               config:
                 severity: warn
+
+      - name: product_reference
+        description: >
+          Référence de l'article consommé (aplati pour lecture directe ; 1:1
+          avec product_id). Identique au `product_code` de dim_technique__product
+          et à la `reference` du stock Yuman → clé de rapprochement conso ↔ stock.
+          Pour les autres attributs article, joindre dim_technique__product via
+          product_id.
 
       - name: partner_name
         description: Partenaire client de l'intervention (attribut d'affichage).
@@ -639,28 +659,48 @@ models:
           Catégorie libre du bon de travail (complément de workorder_type,
           plus granulaire mais non normalisé).
 
-      - name: workorder_status
-        description: Statut du bon de travail (attribut d'affichage).
-
       - name: demand_category_name
         description: Catégorie métier de la demande d'intervention.
 
-      - name: demand_status
+      - name: intervention_state
         description: >
-          Statut de la demande rattachée. Toujours « Accepted » sur les
-          interventions du flux normal ; null pour les interventions hors
-          flux demande (contrôle qualité : permet d'isoler ces cas).
+          État métier canonique de l'intervention, repris de
+          `int_yuman__demands_workorders_enriched` (source de vérité). Valeurs :
+          REALISEE, NON_REALISEE, EN_COURS, EN_PAUSE, PLANIFIEE,
+          DEMANDE_OUVERTE, DEMANDE_REJETEE, AUTRE. Axe de filtrage principal de
+          la consommation.
+        tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - REALISEE
+                  - NON_REALISEE
+                  - EN_COURS
+                  - EN_PAUSE
+                  - PLANIFIEE
+                  - DEMANDE_OUVERTE
+                  - DEMANDE_REJETEE
+                  - AUTRE
+              config:
+                severity: warn
 
-      - name: is_workorder_paused
+      - name: workorder_motif_non_intervention
         description: >
-          True si l'intervention est en pause (raison/explication de mise en
-          pause renseignée).
+          Motif de non-intervention (renseigné quand
+          intervention_state = NON_REALISEE). Ex. « Erreur de saisie »
+          (majoritaire → conso probablement erronée), « Résolue roadman ».
+          Permet au métier d'écarter la conso non pertinente.
 
-      - name: is_workorder_not_done
+      - name: workorder_detail_non_intervention
+        description: Détail complémentaire du motif de non-intervention, si renseigné.
+
+      - name: workorder_raison_mise_en_pause
         description: >
-          True si l'intervention n'a pas été réalisée (motif/détail de
-          non-intervention renseigné). Des pièces consommées sur un workorder
-          à true sont une anomalie à surveiller.
+          Raison de mise en pause de l'intervention (renseignée si pause active
+          ou historique). Ex. « PB Stock véhicule », « PB technique non résolu ».
+
+      - name: workorder_explication_mise_en_pause
+        description: Explication détaillée de la mise en pause, si renseignée.
 
       - name: date_done
         description: >

--- a/models/marts/technique/fct_technique__consommation_article_yuman.sql
+++ b/models/marts/technique/fct_technique__consommation_article_yuman.sql
@@ -11,6 +11,8 @@ with consumed_products as (
     select
         workorder_id,
         product_id,
+        -- Référence article = 1:1 avec product_id (et = dim product_code / clé stock)
+        min(product_reference) as product_reference,
         sum(product_quantity) as quantity,
         min(product_created_at) as first_recorded_at,
         max(product_updated_at) as last_updated_at
@@ -30,38 +32,57 @@ workorders as (
         workorder_number,
         workorder_type,
         workorder_category,
-        workorder_status,
         demand_category_name,
-        demand_status,
-        is_workorder_paused,
-        is_workorder_not_done,
+        -- État métier canonique (source de vérité de l'intermediate) + détails
+        intervention_state,
+        workorder_motif_non_intervention,
+        workorder_detail_non_intervention,
+        workorder_raison_mise_en_pause,
+        workorder_explication_mise_en_pause,
         date_done
     from {{ ref('int_yuman__demands_workorders_enriched') }}
-    where workorder_id is not null
+    -- Exclut les workorders hors flux demande (orphelins / absents de l'intermediate) :
+    -- FK non exploitables. Toute conso conservée est rattachée à une demande.
+    where workorder_id is not null and demand_id is not null
     qualify row_number() over (partition by workorder_id order by date_done desc) = 1
 )
 
 select
+    -- Grain (dimensions dégénérées + FK produit)
     cp.workorder_id,
     w.demand_id,
     cp.product_id,
+
+    -- FK dimensions
     w.material_id,
     w.site_id,
     w.client_id,
     w.technician_id,
+
+    -- Attributs d'affichage
+    cp.product_reference,
     w.partner_name,
     w.workorder_number,
     w.workorder_type,
     w.workorder_category,
-    w.workorder_status,
     w.demand_category_name,
-    w.demand_status,
-    w.is_workorder_paused,
-    w.is_workorder_not_done,
+
+    -- État métier de l'intervention (canonique) + motifs
+    w.intervention_state,
+    w.workorder_motif_non_intervention,
+    w.workorder_detail_non_intervention,
+    w.workorder_raison_mise_en_pause,
+    w.workorder_explication_mise_en_pause,
+
+    -- Date d'intervention
     w.date_done,
+
+    -- Mesure
     cp.quantity,
+
+    -- Métadonnées
     cp.first_recorded_at,
     cp.last_updated_at
 from consumed_products as cp
-left join workorders as w
+inner join workorders as w
     on cp.workorder_id = w.workorder_id


### PR DESCRIPTION
Deux évolutions autour des **articles Yuman** (technique + supply_chain).

## 1. `fct_technique__consommation_article_yuman` (ex-`fct_technique__workorder_product`)
Refonte du fait de consommation d'articles/pièces sur interventions Yuman.

- **Renommage** : `workorder_product` → `consommation_article_yuman` (terme métier « article » ; suffixe `_yuman` pour désambiguïser d'un futur équivalent nesp_tech ; « consommation » seul est ambigu vs `fct_neshu__consommation` / `alerting_consommation_aguila`).
- **État canonique** : remplace les statuts bruts (`workorder_status`, `demand_status`, `is_workorder_not_done`, `is_workorder_paused` *historique*) par **`intervention_state`** (source de vérité de l'intermediate). Booléens dérivés `is_realized` / `is_workorder_currently_paused` retirés (redondants).
- **Motifs remontés** : `workorder_motif_non_intervention`, `workorder_detail_non_intervention`, `workorder_raison_mise_en_pause`, `workorder_explication_mise_en_pause` → permet au métier de trier finement (ex. écarter les NON_REALISEE « Erreur de saisie »).
- **`product_reference`** ajouté (1:1 avec product_id, = `product_code` dim = `reference` stock → clé conso↔stock).
- **Périmètre** : workorders hors flux demande exclus (`inner join` + `demand_id not null`) → `demand_id`/site/client/technician non nuls. Aucun filtre de statut (choix laissé au métier via `intervention_state`).

## 2. `fct_supply_chain__stock_article_yuman` — dédup désignation
Une même référence Yuman porte parfois plusieurs désignations ; `min(designation)` pouvait retenir un **libellé-marqueur** au lieu du vrai nom (ex. `BRIT_1041560` → « Remplacé par 1055767 », `BRIT_1053673` → « - NE PAS UTILISER - », `TWYD_700107` → « OLD - … »).

- Nouvelle macro **`yuman_is_marqueur_designation`** (regex étroite `NE PAS UTILISER | ^OLD | REMPLAC..PAR`, validée : **0 faux positif** sur de vraies pièces type « VANNE D'ARRET », « Kit remplacement… »).
- Désignation résolue **au grain référence** (CTE `reference_designation`) en écartant les marqueurs, fallback `min()` (jamais nul). Bonus : désignation **cohérente sur toutes les dates** (collapse aussi les ~64 doublons cosmétiques casse/accent).
- Mono-marqueurs (articles obsolètes dont le seul libellé est « doublon »/« NE PLUS UTILISER ») laissés tels quels : pas un cas de dédup.

## Validation
- `sqlfluff lint` OK · `dbt build` OK sur les 2 modèles : **23 tests PASS** (unicité, relationships, not_null, accepted_values `intervention_state`, invariants stock).

## Note post-merge
Table prod `fct_technique__workorder_product` orpheline après renommage → à dropper manuellement une fois la nouvelle en prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)