### PR TITLE
feat(dev-env): isolation des builds dbt dev vers le projet GCP evs-datastack-dev

### DIFF
--- a/.github/workflows/dbt-ci.yml
+++ b/.github/workflows/dbt-ci.yml
@@ -79,12 +79,19 @@ jobs:
       - name: Setup Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Decode and write dev service account keyfile
+        run: echo "${{ secrets.DBT_BIGQUERY_KEYFILE_DEV }}" | base64 -d > $GITHUB_WORKSPACE/keyfile_dev.json
+
       - name: Export env variables for dbt
         run: |
           echo "DBT_BIGQUERY_PROJECT=${{ secrets.DBT_BIGQUERY_PROJECT }}" >> $GITHUB_ENV
           echo "DBT_BIGQUERY_KEYFILE=$GITHUB_WORKSPACE/keyfile.json" >> $GITHUB_ENV
           echo "DBT_BIGQUERY_DATASET_DEV=${{ secrets.DBT_BIGQUERY_DATASET_DEV }}" >> $GITHUB_ENV
           echo "DBT_BIGQUERY_DATASET_PROD=${{ secrets.DBT_BIGQUERY_DATASET_PROD }}" >> $GITHUB_ENV
+          # Target dev → projet isolé evs-datastack-dev via la clé du SA dbt-dev.
+          # Les sources restent lues dans evs-datastack-prod (var raw_project).
+          echo "DBT_BIGQUERY_PROJECT_DEV=evs-datastack-dev" >> $GITHUB_ENV
+          echo "DBT_BIGQUERY_KEYFILE_DEV=$GITHUB_WORKSPACE/keyfile_dev.json" >> $GITHUB_ENV
 
       - name: dbt deps + debug
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ keyfile.json
 # Local working files (not versioned)
 scripts/
 docs/audits/
+
+# Modèles d'analyse ad hoc / jetables (comparaisons vs prod, dev-only).
+# Non versionnés : ils tournent en local à la demande, hors CI.
+models/_analysis/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -136,6 +136,11 @@ snapshots:
 
 # Vars
 vars:
+  # Projet GCP du data lake (prod_raw, historic…). Les sources le lisent via
+  # database: "{{ var('raw_project') }}" pour que `dbt --target dev` (projet
+  # evs-datastack-dev) lise le lac en cross-project read-only sans le dupliquer.
+  # Cf. infra/dev_project_isolation.tf.
+  raw_project: 'evs-datastack-prod'
   # Required by dbt_date (transitive dep of dbt_expectations) for recency checks.
   # Cf. docs/freshness.md méthode B.
   'dbt_date:time_zone': 'Europe/Paris'

--- a/models/staging/gac/_gac__sources.yml
+++ b/models/staging/gac/_gac__sources.yml
@@ -2,6 +2,7 @@ version: 2
 
 sources:
   - name: gac
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     description: "Données brutes extraites du fichier suivi des sinistres envoyé par GAC vers le FTP SG"
     config:

--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -4,6 +4,7 @@ version: 2
 sources:
   - name: mssql_sage
     description: "Source des données issues de Sage (MSSQL) — données brutes extraites vers BigQuery"
+    database: "{{ var('raw_project') }}"
     schema: prod_raw
     config:
       tags: ['mssql_sage', 'source']  # Déplacé dans config

--- a/models/staging/nesp_co/_nesp_co__sources.yml
+++ b/models/staging/nesp_co/_nesp_co__sources.yml
@@ -3,6 +3,7 @@ version: 2
 
 sources:
   - name: nesp_co
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     description: "Données brutes extraites des fichiers excel Activité et Opportunités Nespresso depuis le FTP nespresso commerce"  
     config:

--- a/models/staging/nesp_tech/_nesp_tech__sources.yml
+++ b/models/staging/nesp_tech/_nesp_tech__sources.yml
@@ -3,6 +3,7 @@ version: 2
 
 sources:
   - name: nesp_tech
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     description: "Données brutes extraites du fichier excel depuis l'API Arbiter Nomad Repair afin de récupérer les interventions et les articles consommées"  
     config:

--- a/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
@@ -3,6 +3,7 @@ version: 2
 
 sources:
   - name: oracle_lcdp
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     description: "Données brutes extraites de l'ERP Oracle LCDP (mix full/incremental)"
 

--- a/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__sources.yml
+++ b/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__sources.yml
@@ -2,6 +2,7 @@ version: 2
 
 sources:
   - name: oracle_lcdp_gcs
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     tables:
       - name: ext_gcs_oracle_lcdp__stock_theorique

--- a/models/staging/oracle_neshu/_oracle_neshu__sources.yml
+++ b/models/staging/oracle_neshu/_oracle_neshu__sources.yml
@@ -3,6 +3,7 @@ version: 2
 
 sources:
   - name: oracle_neshu
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     description: "Données brutes extraites de l'ERP Oracle Neshu (mix full/incremental)"
 

--- a/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__sources.yml
+++ b/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__sources.yml
@@ -2,6 +2,7 @@ version: 2
 
 sources:
   - name: oracle_neshu_gcs
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     tables:
       - name: ext_gcs_oracle_neshu__stock_theorique

--- a/models/staging/yuman/_yuman__sources.yml
+++ b/models/staging/yuman/_yuman__sources.yml
@@ -3,6 +3,7 @@ version: 2
 
 sources:
   - name: yuman_api
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     description: "Données brutes extraites de l'API Yuman (full refresh quotidien)"
 

--- a/models/staging/yuman_gcs/_yuman_gcs__sources.yml
+++ b/models/staging/yuman_gcs/_yuman_gcs__sources.yml
@@ -2,6 +2,7 @@ version: 2
 
 sources:
   - name: yuman_gcs
+    database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     config:
       tags: ['yuman_gcs', 'source']

--- a/models/staging/zoho_desk/_zoho_desk__sources.yml
+++ b/models/staging/zoho_desk/_zoho_desk__sources.yml
@@ -18,6 +18,7 @@ sources:
     description: >
       Données brutes extraites de l'API Zoho Desk (EU region) via dlt (data load tool).
       Dataset BigQuery : evs-datastack-prod.prod_raw.
+    database: "{{ var('raw_project') }}"
     schema: prod_raw
     config:
       tags: ['zoho_desk', 'source']

--- a/profiles.yml
+++ b/profiles.yml
@@ -2,23 +2,26 @@
 dbt_warehouse:
   target: "{{ env_var('DBT_TARGET', 'dev') }}"
   outputs:
+    # Isolation projet : le target dev écrit dans evs-datastack-dev et
+    # s'authentifie avec le SA dbt-dev (droits dev + lecture prod_raw only).
+    # Les sources restent lues dans evs-datastack-prod via var('raw_project').
     dev:
       type: bigquery
       method: service-account
-      project: "{{ env_var('DBT_BIGQUERY_PROJECT') }}"
+      project: "{{ env_var('DBT_BIGQUERY_PROJECT_DEV', 'evs-datastack-dev') }}"
       dataset: "{{ env_var('DBT_BIGQUERY_DATASET_DEV') }}"
       threads: 6
       location: europe-west1
-      keyfile: "{{ env_var('DBT_BIGQUERY_KEYFILE') }}"
+      keyfile: "{{ env_var('DBT_BIGQUERY_KEYFILE_DEV') }}"
 
     dev_analyst:
       type: bigquery
       method: service-account
-      project: "{{ env_var('DBT_BIGQUERY_PROJECT') }}"
+      project: "{{ env_var('DBT_BIGQUERY_PROJECT_DEV', 'evs-datastack-dev') }}"
       dataset: "{{ env_var('DBT_BIGQUERY_DATASET_DEV') }}"  # Utilisera dev_analyst via .env
       threads: 6
       location: europe-west1
-      keyfile: "{{ env_var('DBT_BIGQUERY_KEYFILE') }}"
+      keyfile: "{{ env_var('DBT_BIGQUERY_KEYFILE_DEV') }}"
       
     prod:
       type: bigquery


### PR DESCRIPTION
## Objectif

Isoler les builds `dbt --target dev` dans un **projet GCP dédié** (`evs-datastack-dev`) au lieu de partager le projet prod. Un seul data lake conservé : dev **lit** `prod_raw` (et le reste du raw layer) en **read-only cross-projet**, et **écrit** dans le projet dev. Aucune duplication de pipeline (contexte solo).

## Changements (repo dbt)

- **Sources découplées** : `database: "{{ var('raw_project') }}"` sur les 11 sources staging + var `raw_project=evs-datastack-prod` dans `dbt_project.yml`. Les sources sont donc toujours lues dans prod, quel que soit le target.
- **`profiles.yml`** : targets `dev`/`dev_analyst` → `project=DBT_BIGQUERY_PROJECT_DEV` + `keyfile=DBT_BIGQUERY_KEYFILE_DEV` (SA `dbt-dev`). Target **`prod` inchangé**.
- **CI (`dbt-ci.yml`)** : le job `pr-check` fournit la clé du SA `dbt-dev` + `DBT_BIGQUERY_PROJECT_DEV`/`DBT_BIGQUERY_KEYFILE_DEV`. Job `cd` (prod) inchangé.
- **`.gitignore`** : `models/_analysis/` (scratch ad hoc dev-only, hors CI).

## Prérequis déjà en place

- Infra appliquée (PR compagnon `CebrailEVS/terraform@feature/dev-project-isolation`) : SA `dbt-dev`, datasets, grants read-only (`prod_raw`, bucket GCS, `historic`, couches transformées prod).
- Secret GitHub `DBT_BIGQUERY_KEYFILE_DEV` posé.

## Validation

- `dbt build --target dev` complet en local : **0 erreur** (staging, intermediate, marts, tests).
- Vérifié : les modèles écrivent dans `evs-datastack-dev`, lisent `evs-datastack-prod`, **aucune écriture en prod**.
- `dbt debug --target prod` OK sans les variables `_DEV` (le target prod n'est pas impacté).

## Après merge (séparé)

Nettoyage des datasets `dev_*` legacy dans le projet prod (changement destructif dédié).