### PR TITLE
ci(dev-env): defer des builds dev vers prod (snapshots lus depuis prod)

### DIFF
--- a/.github/workflows/dbt-ci.yml
+++ b/.github/workflows/dbt-ci.yml
@@ -126,11 +126,11 @@ jobs:
       - name: dbt build
         run: |
           if [[ -f "state/manifest.json" ]]; then
-            echo "Running SELECTIVE build (state:modified+), excluding snapshots..."
-            dbt build --target dev --select state:modified+ --exclude resource_type:snapshot --state state/
+            echo "SELECTIVE build (state:modified+) + --defer: snapshots & unbuilt refs resolve to PROD"
+            dbt build --target dev --select state:modified+ --defer --state state/ --exclude resource_type:snapshot
           else
-            echo "Running FULL build (no state available), excluding snapshots..."
-            dbt build --target dev --exclude resource_type:snapshot
+            echo "No prod manifest to defer to -> full standalone build (snapshots included)"
+            dbt build --target dev
           fi
 
 # ============================================================

--- a/models/marts/neshu/dim_neshu__device_history.sql
+++ b/models/marts/neshu/dim_neshu__device_history.sql
@@ -1,5 +1,10 @@
 {{ config(materialized='table') }}
 
+-- Dépend du snapshot SCD2 snap_oracle_neshu__device. Les snapshots sont un
+-- artefact de PROD (historique accumulé) et ne sont pas reconstruits en dev.
+-- Le build dev tourne donc avec --defer : ref('snap_...') résout vers la
+-- version prod (evs-datastack-prod.snapshots). Cf. CI pr-check.
+
 with snapshot as (
     select * from {{ ref('snap_oracle_neshu__device') }}
 )


### PR DESCRIPTION
## Objectif

Les snapshots (SCD2) sont un **artefact de prod** : leur valeur vient de l'accumulation continue. En dev, buildé sporadiquement, un snapshot serait troué/inutile. On fait donc **lire les snapshots de prod** en dev via `dbt defer`, au lieu d'en fabriquer en dev.

## Changement

- **CI `pr-check`** : le build dev passe en `--defer --state state/`. Les snapshots (exclus du build) et tout `ref()` non reconstruit résolvent vers la relation **PROD**. Le manifest prod est déjà téléchargé pour le `state:modified+`.
- **Fallback** (pas de manifest) : build standalone complet, snapshots inclus (bootstrap).
- **`dim_neshu__device_history`** (seul modèle dépendant d'un snapshot) : commentaire de doc + déclenche son build dans cette PR pour **valider defer en CI**.

## Prérequis (déjà en place)

- Le SA `dbt-dev` a la lecture sur le dataset `snapshots` de prod (grant déjà mergé).
- Environnement CI = Python 3.11 + `requirements-lock.txt` (dbt-core 1.11.11), aligné avec le manifest prod.

## Validation attendue

Le `pr-check` doit builder `dim_neshu__device_history` dans `evs-datastack-dev` en lisant le snapshot depuis `evs-datastack-prod.snapshots` — 0 erreur.

Cloud Run (`--target prod`) : non concerné, aucun defer côté prod.