### PR TITLE
feat(supply_chain): reconstruct Yuman depot-level stockouts on expected assortment

### DIFF
--- a/data/reference_data/yuman/_yuman__seeds.yml
+++ b/data/reference_data/yuman/_yuman__seeds.yml
@@ -235,3 +235,26 @@ seeds:
         description: "Nom du stock associé"
       - name: user_stock_agence
         description: "Agence de stock associée"
+
+  - name: ref_yuman__pseudo_article
+    description: >
+      Références Yuman qui ne sont pas des pièces stockables mais des lignes de
+      saisie d'intervention (prestation « Détartrage », mention « Pas de pièce »).
+      Exclues du calcul d'assortiment / rupture dépôt
+      (fct_supply_chain__rupture_depot_yuman). Ajouter une ligne suffit pour
+      exclure une nouvelle référence.
+    config:
+      column_types:
+        reference: STRING
+        designation: STRING
+        motif_exclusion: STRING
+    columns:
+      - name: reference
+        description: "Référence article Yuman à exclure (clé, format fichier stock)"
+        tests:
+          - not_null
+          - unique
+      - name: designation
+        description: "Désignation de la référence (informatif)"
+      - name: motif_exclusion
+        description: "Raison de l'exclusion (informatif)"

--- a/data/reference_data/yuman/ref_yuman__pseudo_article.csv
+++ b/data/reference_data/yuman/ref_yuman__pseudo_article.csv
@@ -1,0 +1,3 @@
+reference,designation,motif_exclusion
+EVS_NESPRESSO_0000100,Détartrage,Ligne de saisie d'intervention (prestation) — pas une pièce stockable
+EVS_NESPRESSO_0000001,Pas de pièce,Ligne de saisie d'intervention (aucune pièce utilisée) — pas une pièce stockable

--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -202,6 +202,94 @@ models:
           arguments:
             expression: "is_out_of_stock = (is_out_of_stock_depot and is_out_of_stock_technicien)"
 
+  - name: fct_supply_chain__rupture_depot_yuman
+    description: |
+      [QUOI MÉTIER] Suivi quotidien des ruptures de stock par dépôt Yuman, sur l'assortiment attendu de chaque dépôt. Répond à « quel dépôt doit réapprovisionner quelles références » et permet un taux de disponibilité par dépôt dans le temps. Règle métier validée avec la logistique (V. — juillet 2026).
+
+      [COMMENT CONSTRUITE] La rupture par dépôt n'existe pas en source (une rupture Yuman arrive sans emplacement) : elle est reconstruite. Assortiment attendu d'un dépôt = références consommées ≥ 2 fois sur les 180 jours glissants précédant chaque date d'export (fct_technique__consommation_article_yuman) par les techniciens rattachés au dépôt (dim_technique__technician.entrepot_rattachement). Pour chaque (date, dépôt, référence) de l'assortiment, le stock du jour (stg_yuman_gcs__stock_theorique) est ventilé : dépôt lui-même, autres dépôts, vans des techniciens du dépôt (mapping van→technicien via storehouses_name), tous vans. Absence de ligne de stock = quantité 0. Pseudo-références de saisie d'intervention exclues via le seed ref_yuman__pseudo_article.
+
+      [GRAIN] 1 ligne par (stock_date, depot, reference) — tout l'assortiment, en stock ou non.
+
+      [NOTES] Pas de transfert inter-dépôt en pratique : toute rupture renvoie vers une commande fournisseur, rupture_statut sert à prioriser (RUPTURE_TOTALE = plus rien nulle part ; STOCK_RESTANT_VANS = les vans du dépôt portent l'autonomie terrain restante ; STOCK_AILLEURS = informatif). Le rattachement technicien→dépôt est l'état courant (dim Type 1), appliqué à tout l'historique ; ~4 % des consommations (techniciens désactivés, comptes ASTREINTE, sans rattachement) sont hors périmètre. Le dépôt de Strasbourg n'a pas de technicien rattaché (secteur Est rattaché à Lyon/Dardilly) : il est structurellement absent. Les exports sont quotidiens sauf dimanche : les taux de disponibilité se calculent en jours observés. Consommations Nespresso (Nomad Repair) non intégrées à ce stade — extension prévue via un modèle dédié.
+    columns:
+      - name: stock_date
+        description: "Date de l'export stock Yuman (DATE), colonne de partition"
+        tests:
+          - not_null
+      - name: depot
+        description: "Libellé du dépôt Yuman (nom_du_stock), clé du grain"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values:
+                  - "06 - ATELIER RUNGIS DEPOT"
+                  - "07 - ATELIER LYON DEPOT"
+                  - "08 - ATELIER BORDEAUX DEPOT"
+                  - "09 - ATELIER STRASBOURG DEPOT"
+              config:
+                severity: warn
+      - name: reference
+        description: "Référence de l'article, clé du grain"
+        tests:
+          - not_null
+      - name: designation
+        description: "Désignation de l'article, résolue au grain référence (libellés-marqueur écartés via yuman_is_marqueur_designation)"
+      - name: rupture_statut
+        description: "Qualification de la rupture pour la priorisation, NULL si en stock. RUPTURE_TOTALE = 0 partout (commande urgente) ; STOCK_RESTANT_VANS = les vans des techniciens du dépôt ont du stock (l'autonomie terrain, qty_vans_depot, priorise la commande) ; STOCK_AILLEURS = du stock existe ailleurs (autre dépôt ou vans d'autres dépôts) mais pas chez nous — informatif, pas de transfert inter-dépôt en pratique"
+        tests:
+          - accepted_values:
+              arguments:
+                values: [RUPTURE_TOTALE, STOCK_RESTANT_VANS, STOCK_AILLEURS]
+      - name: derniere_conso_date
+        description: "Date de la dernière consommation de la référence par un technicien du dépôt dans la fenêtre de 180 jours"
+      - name: is_out_of_stock_depot
+        description: "TRUE si le dépôt n'a aucun stock de la référence ce jour-là (qty_depot = 0). C'est l'alerte de réapprovisionnement"
+      - name: is_out_of_stock_global
+        description: "TRUE si la référence est en rupture totale ce jour-là (aucun dépôt, aucun van)"
+      - name: qty_depot
+        description: "Quantité en stock dans le dépôt ce jour-là (0 si absent de l'export). Additive"
+      - name: qty_vans_depot
+        description: "Quantité dans les vans des techniciens rattachés au dépôt — l'autonomie terrain restante. Additive. Vans non mappés à un technicien exclus (comptés dans qty_vans_total)"
+      - name: qty_vans_total
+        description: "Quantité dans l'ensemble des vans techniciens, tous dépôts confondus. Additive"
+      - name: qty_autres_depots
+        description: "Quantité en stock dans les autres dépôts. Additive, informatif (pas de transfert inter-dépôt)"
+      - name: nb_conso_180j
+        description: "Nombre de consommations de la référence par les techniciens du dépôt sur les 180 jours glissants (≥ 2 par construction). Additive sur le grain, non sommable entre dates (fenêtres qui se recouvrent)"
+      - name: dbt_updated_at
+        description: "Timestamp de reconstruction de la table"
+      - name: dbt_invocation_id
+        description: "Identifiant du run dbt ayant produit la ligne"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - stock_date
+              - depot
+              - reference
+      # cohérence flags / mesures
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_out_of_stock_depot = (qty_depot = 0)"
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "is_out_of_stock_global = (qty_depot + qty_autres_depots + qty_vans_total = 0)"
+      # le statut n'est renseigné que sur les ruptures, et toujours sur les ruptures
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "(rupture_statut is not null) = is_out_of_stock_depot"
+      # seuil d'assortiment validé métier
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "nb_conso_180j >= 2"
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 10000
+            max_value: 2000000
+          config:
+            severity: warn
+
   - name: fct_supply_chain__disponibilite_article_neshu_depot_mensuel
     description: |
       [QUOI MÉTIER] Taux de disponibilité mensuel des articles dans les dépôts Neshu : part des jours du mois où l'article était en stock (> 0).

--- a/models/marts/supply_chain/fct_supply_chain__rupture_depot_yuman.sql
+++ b/models/marts/supply_chain/fct_supply_chain__rupture_depot_yuman.sql
@@ -1,0 +1,158 @@
+{{ config(
+    materialized='table',
+    partition_by={
+        'field': 'stock_date',
+        'data_type': 'date'
+    },
+    cluster_by=['depot', 'reference']
+) }}
+
+-- La rupture par dépôt n'existe pas en source : quand un article tombe à zéro,
+-- Yuman supprime les lignes d'emplacement (une ligne n'existe que si quantite > 0).
+-- On la reconstruit : les 4 dépôts étant fixes et présents chaque jour dans
+-- l'export, l'absence de ligne (dépôt, référence) = stock à zéro. L'assortiment
+-- attendu d'un dépôt (les références qu'il est censé stocker) est défini par la
+-- demande : consommations des 180 jours précédents des techniciens rattachés.
+
+with stock_dates as (
+    select distinct date(export_date) as stock_date
+    from {{ ref('stg_yuman_gcs__stock_theorique') }}
+),
+
+pseudo_articles as (
+    select reference from {{ ref('ref_yuman__pseudo_article') }}
+),
+
+conso as (
+    -- Consommations Yuman rattachées à un dépôt via le technicien.
+    -- Dim Type 1 : le rattachement est l'état courant, appliqué à tout l'historique.
+    select
+        t.entrepot_rattachement as depot,
+        c.product_reference as reference,
+        date(c.date_done) as conso_date
+    from {{ ref('fct_technique__consommation_article_yuman') }} as c
+    inner join {{ ref('dim_technique__technician') }} as t
+        on c.technician_id = t.user_id
+    left join pseudo_articles as pa
+        on c.product_reference = pa.reference
+    where
+        t.entrepot_rattachement is not null
+        and c.product_reference is not null
+        and pa.reference is null
+),
+
+assortiment as (
+    -- Assortiment attendu « as-of » chaque date d'export : références consommées
+    -- au moins 2 fois sur les 180 jours glissants précédents (seuil validé métier).
+    select
+        d.stock_date,
+        c.depot,
+        c.reference,
+        count(*) as nb_conso_180j,
+        max(c.conso_date) as derniere_conso_date
+    from stock_dates as d
+    inner join conso as c
+        on
+            date_sub(d.stock_date, interval 180 day) < c.conso_date
+            and d.stock_date >= c.conso_date
+    group by d.stock_date, c.depot, c.reference
+    having count(*) >= 2
+),
+
+vans_technicien as (
+    -- Van (magasin Yuman du technicien) -> dépôt de rattachement, pour ventiler
+    -- l'autonomie terrain par dépôt.
+    select
+        storehouses_name,
+        entrepot_rattachement as depot
+    from {{ ref('dim_technique__technician') }}
+    where storehouses_name is not null and entrepot_rattachement is not null
+),
+
+stock_ventile as (
+    -- Stock du jour par emplacement, qualifié dépôt / van (+ dépôt du van si connu).
+    -- Les lignes de rupture source (sans emplacement, quantite = 0) sont ignorées :
+    -- l'absence dans ce CTE vaut zéro dans l'agrégation finale.
+    select
+        date(s.export_date) as stock_date,
+        s.reference,
+        s.nom_du_stock,
+        s.quantite,
+        {{ yuman_is_depot('s.nom_du_stock') }} as is_depot,
+        v.depot as van_depot
+    from {{ ref('stg_yuman_gcs__stock_theorique') }} as s
+    left join vans_technicien as v
+        on s.nom_du_stock = v.storehouses_name
+    where s.reference is not null and s.nom_du_stock is not null
+),
+
+reference_designation as (
+    -- Désignation unique par référence : on écarte les libellés « marqueur »
+    -- (NE PAS UTILISER, OLD, Remplacé par...), fallback min() sinon.
+    select
+        reference,
+        coalesce(
+            min(case when not {{ yuman_is_marqueur_designation('designation') }} then designation end),
+            min(designation)
+        ) as designation
+    from {{ ref('stg_yuman_gcs__stock_theorique') }}
+    where reference is not null
+    group by reference
+),
+
+assortiment_stock as (
+    select
+        a.stock_date,
+        a.depot,
+        a.reference,
+        a.nb_conso_180j,
+        a.derniere_conso_date,
+        coalesce(sum(case when sv.is_depot and sv.nom_du_stock = a.depot then sv.quantite end), 0) as qty_depot,
+        coalesce(sum(case when sv.is_depot and sv.nom_du_stock != a.depot then sv.quantite end), 0)
+            as qty_autres_depots,
+        coalesce(sum(case when not sv.is_depot and sv.van_depot = a.depot then sv.quantite end), 0)
+            as qty_vans_depot,
+        coalesce(sum(case when not sv.is_depot then sv.quantite end), 0) as qty_vans_total
+    from assortiment as a
+    left join stock_ventile as sv
+        on a.stock_date = sv.stock_date and a.reference = sv.reference
+    group by a.stock_date, a.depot, a.reference, a.nb_conso_180j, a.derniere_conso_date
+)
+
+select
+    -- Grain
+    ast.stock_date,
+    ast.depot,
+    ast.reference,
+
+    -- Attributs
+    rd.designation,
+    -- Qualification de la rupture (NULL si en stock). Pas de transfert inter-dépôt
+    -- en pratique : STOCK_AILLEURS est informatif, le remède reste la commande.
+    case
+        when ast.qty_depot > 0 then null
+        when ast.qty_depot + ast.qty_autres_depots + ast.qty_vans_total = 0 then 'RUPTURE_TOTALE'
+        when ast.qty_vans_depot > 0 then 'STOCK_RESTANT_VANS'
+        else 'STOCK_AILLEURS'
+    end as rupture_statut,
+
+    -- Dates secondaires
+    ast.derniere_conso_date,
+
+    -- Flags
+    ast.qty_depot = 0 as is_out_of_stock_depot,
+    ast.qty_depot + ast.qty_autres_depots + ast.qty_vans_total = 0 as is_out_of_stock_global,
+
+    -- Mesures
+    ast.qty_depot,
+    ast.qty_vans_depot,
+    ast.qty_vans_total,
+    ast.qty_autres_depots,
+    ast.nb_conso_180j,
+
+    -- Métadonnées dbt
+    current_timestamp() as dbt_updated_at,
+    '{{ invocation_id }}' as dbt_invocation_id
+from assortiment_stock as ast
+left join reference_designation as rd
+    on ast.reference = rd.reference


### PR DESCRIPTION
## Summary

Yuman never localizes a stockout: when an article hits zero everywhere, the per-location rows disappear and a single location-less row (quantity 0) remains. This PR reconstructs depot-level stockouts, following the business rule validated with logistics (Vincent, July 2026 mail thread).

- **New mart `fct_supply_chain__rupture_depot_yuman`** — grain `(stock_date, depot, reference)` over the full expected assortment of each depot (in-stock rows included, enabling availability-rate tracking over time).
  - Expected assortment = references consumed **>= 2 times in the trailing 180 days** (computed as-of each export date) by technicians attached to the depot (`entrepot_rattachement`, exact string match with the stock export depot labels).
  - The 4 depots are fixed and present daily in the export, so a missing (depot, reference) row = zero stock.
  - `rupture_statut` prioritizes stockouts (no inter-depot transfers in practice, every stockout resolves to a supplier order): `RUPTURE_TOTALE` (zero everywhere) / `STOCK_RESTANT_VANS` (the depot's own technicians' vans still hold stock = remaining field autonomy, van->technician mapping via `storehouses_name`) / `STOCK_AILLEURS` (informational residual). NULL when in stock.
  - Measures: `qty_depot`, `qty_vans_depot`, `qty_vans_total`, `qty_autres_depots`, `nb_conso_180j`.
- **New seed `ref_yuman__pseudo_article`** — excludes intervention bookkeeping lines that are not stockable parts (Detartrage, Pas de piece). Adding a row is enough to exclude a new reference.

Known scope limits (documented in the model NOTES): Strasbourg depot structurally absent (Est sector technicians attached to Lyon/Dardilly), ~4% of consumption unattributable (technicians deleted from Yuman users, ASTREINTE accounts), Nespresso (Nomad Repair) consumption flow deferred to a dedicated V2 model.

## Validation

- Built in dev with the full upstream chain: 38.7k rows over 187 export days (since 2025-11-28), 120 tests PASS.
- Figures match the ad-hoc analysis shared with logistics: **43/31/10 stockouts** (Rungis/Lyon/Bordeaux) on 2026-07-07, total stockouts 8/3/3.
- Mail-thread examples verified in the mart: POMPE-UP -> RUPTURE_TOTALE, JOINT GRIS MIXEUR -> STOCK_RESTANT_VANS (36 in Rungis vans), Sachet TM Desana at Bordeaux -> STOCK_AILLEURS (its 46 units sit in Lyon vans).

## Tests

11 tests on the new mart: unique combination on the grain, not_null on grain columns, accepted_values on depot (warn) and rupture_statut, 4 expression_is_true invariants (flag/measure coherence, statut partition, assortment threshold), row-count range (warn).

No exposure yet — no Power BI report consumes the mart at this stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)