### PR TITLE
feat(technique): add Nespresso (Nomad Repair) article consumption fact

### DIFF
--- a/data/reference_data/yuman/ref_yuman__pseudo_article.csv
+++ b/data/reference_data/yuman/ref_yuman__pseudo_article.csv
@@ -1,3 +1,5 @@
 reference,designation,motif_exclusion
 EVS_NESPRESSO_0000100,Détartrage,Ligne de saisie d'intervention (prestation) — pas une pièce stockable
 EVS_NESPRESSO_0000001,Pas de pièce,Ligne de saisie d'intervention (aucune pièce utilisée) — pas une pièce stockable
+EVS_NESPRESSO_MINIPREV,Mini préventive,Flag de facturation mini-préventive (Nomad Repair) — pas une pièce stockable
+EVS_NESPRESSO_AVERTISSEMENT,Avertissement mauvaise utilisation client,Ligne de saisie d'intervention (Nomad Repair) — pas une pièce stockable

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -749,6 +749,132 @@ models:
           config:
             severity: warn
 
+  - name: fct_technique__consommation_article_nespresso
+    description: >
+      [QUOI MÉTIER]
+      Consommation d'articles (pièces détachées, consommables) lors des interventions
+      techniques Nespresso (Nomad Repair) — le pendant Nespresso de
+      `fct_technique__consommation_article_yuman` : ces interventions ne passent pas
+      par les bons Yuman, mais leurs articles sont centralisés dans le référentiel
+      Yuman sous le préfixe `EVS_NESPRESSO_` (colonne product_reference = clé de
+      rapprochement avec les stocks Yuman).
+
+      [COMMENT CONSTRUITE]
+      `int_nesp_tech__articles_dedup` (une ligne = un article posé sur une
+      intervention), joint (inner join) à `int_nesp_tech__interventions_dedup`
+      restreint aux agences EVS ('evs', 'evs paris', 'evs idf', 'evs paris 2' —
+      'nespresso sud' = sous-traitant hors flux de stock EVS, plus actif depuis 2025)
+      pour l'état, l'agence et les horodatages début/fin. technician_id résolu via
+      le matricule Nomad (n_tech ↔ dim_technique__technician.nomad_id, unique).
+      product_reference = 'EVS_NESPRESSO_' + upper(code_article).
+
+      [GRAIN]
+      1 ligne par (n_planning, code_article). ~168k lignes depuis nov. 2023.
+
+      [NOTES]
+      Aucun filtre d'état : une ligne de la table articles = une pose réelle
+      (validé métier ; 99,95 % des lignes portent un état terminé), etat_intervention
+      est exposé en information. Contient les lignes de saisie non stockables
+      (Détartrage '0000100', Pas de pièce '0000001', flag 'miniprev') — à exclure
+      selon l'usage via le seed ref_yuman__pseudo_article (sur product_reference).
+      Source extraite chaque lundi (fenêtre 7 jours glissants) : fraîcheur
+      hebdomadaire, pas quotidienne. Flux disjoint des bons Yuman (outils non
+      mélangés, vérifié métier).
+    columns:
+      - name: n_planning
+        description: "Intervention Nomad Repair concernée (clé du grain). Dimension dégénérée."
+        tests:
+          - not_null
+      - name: code_article
+        description: "Code article source Nomad (clé du grain, lowercase). Valeurs spéciales : '0000100' Détartrage, '0000001' Pas de pièce, 'miniprev' flag mini-préventive."
+        tests:
+          - not_null
+      - name: technician_id
+        description: "FK vers dim_technique__technician (user Yuman), résolue via le matricule Nomad. NULL si le matricule n'est plus dans le référentiel."
+        tests:
+          - relationships:
+              arguments:
+                to: ref('dim_technique__technician')
+                field: user_id
+              config:
+                severity: warn
+      - name: product_reference
+        description: "Référence article dans le référentiel Yuman ('EVS_NESPRESSO_' + code article en majuscules). Clé de rapprochement avec les stocks Yuman."
+        tests:
+          - not_null
+      - name: nom_article
+        description: "Libellé de l'article (source Nomad)"
+      - name: n_tech
+        description: "Matricule Nomad du technicien (type 'tec-xxxxx')"
+      - name: nom_tech
+        description: "Nom du technicien (source Nomad)"
+      - name: prenom_tech
+        description: "Prénom du technicien (source Nomad)"
+      - name: n_client
+        description: "Identifiant client Nespresso (Nessoft)"
+      - name: raison_sociale_client
+        description: "Raison sociale du client"
+      - name: n_site
+        description: "Identifiant du site d'intervention"
+      - name: nom_site
+        description: "Nom du site d'intervention"
+      - name: code_machine
+        description: "Code de la machine intervenue"
+      - name: nom_machine
+        description: "Nom / modèle de la machine"
+      - name: num_serie_machine
+        description: "Numéro de série de la machine"
+      - name: etat_intervention
+        description: "État de l'intervention porteuse (information, non filtré) : 'terminée signée' (~99,7 %), 'signature différée', 'terminée non signée', 'mise en échec', 'annulée'"
+        tests:
+          - accepted_values:
+              arguments:
+                values:
+                  - "terminée signée"
+                  - "signature différée"
+                  - "terminée non signée"
+                  - "mise en échec"
+                  - "annulée"
+              config:
+                severity: warn
+      - name: agency
+        description: "Agence EVS en charge de l'intervention (périmètre filtré aux agences EVS)"
+        tests:
+          - accepted_values:
+              arguments:
+                values: [evs, evs paris, evs idf, evs paris 2]
+      - name: date_heure_debut
+        description: "Date/heure de début réel de l'intervention (colonne de partition). La date de la table articles source correspond à cette date (99,95 % des lignes)."
+        tests:
+          - not_null
+      - name: date_heure_fin
+        description: "Date/heure de fin de l'intervention"
+      - name: qty_consommee
+        description: "Quantité de l'article posée sur l'intervention. Additive"
+        tests:
+          - not_null
+          - dbt_utils.expression_is_true:
+              arguments:
+                expression: "> 0"
+              config:
+                severity: warn
+      - name: dbt_updated_at
+        description: "Timestamp de reconstruction de la table"
+      - name: dbt_invocation_id
+        description: "Identifiant du run dbt ayant produit la ligne"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - n_planning
+              - code_article
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 100000
+            max_value: 1000000
+          config:
+            severity: warn
+
   - name: fct_technique__suivi_partenaire
     description: |
       [QUOI MÉTIER]

--- a/models/marts/technique/fct_technique__consommation_article_nespresso.sql
+++ b/models/marts/technique/fct_technique__consommation_article_nespresso.sql
@@ -1,0 +1,81 @@
+{{ config(
+    materialized='table',
+    partition_by={"field": "date_heure_debut", "data_type": "timestamp"},
+    cluster_by=['product_reference', 'technician_id']
+) }}
+
+-- Pendant Nespresso (Nomad Repair) de fct_technique__consommation_article_yuman :
+-- les interventions Nespresso ne passent pas par les bons Yuman, mais leurs articles
+-- sont centralisés dans le référentiel Yuman sous le préfixe EVS_NESPRESSO_.
+-- Une ligne de la table articles = une pose réelle (vérifié : 99,95 % des lignes
+-- portent un état terminé) — aucun filtre d'état, l'état est exposé en information.
+
+with articles as (
+    select * from {{ ref('int_nesp_tech__articles_dedup') }}
+),
+
+interventions as (
+    -- Contexte d'intervention : états, agence, horodatages début/fin.
+    -- Périmètre agences EVS uniquement ('nespresso sud' = sous-traitant,
+    -- hors flux de stock EVS, plus actif depuis 2025).
+    select
+        n_planning,
+        etat_intervention,
+        agency,
+        date_heure_debut,
+        date_heure_fin
+    from {{ ref('int_nesp_tech__interventions_dedup') }}
+    where agency in ('evs', 'evs paris', 'evs idf', 'evs paris 2')
+),
+
+technicians as (
+    -- Rattachement au référentiel technicien Yuman via le matricule Nomad
+    -- (nomad_id unique dans la dim, pas de fan-out).
+    select
+        user_id,
+        nomad_id
+    from {{ ref('dim_technique__technician') }}
+    where nomad_id is not null
+)
+
+select
+    -- Grain
+    a.n_planning,
+    a.code_article,
+
+    -- FK dimensions
+    t.user_id as technician_id,
+
+    -- Attributs d'affichage
+    concat('EVS_NESPRESSO_', upper(a.code_article)) as product_reference,
+    a.nom_article,
+    a.n_tech,
+    a.nom_tech,
+    a.prenom_tech,
+    a.n_client,
+    a.raison_sociale_client,
+    a.n_site,
+    a.nom_site,
+    a.code_machine,
+    a.nom_machine,
+    a.num_serie_machine,
+
+    -- État métier de l'intervention (information, non filtré)
+    i.etat_intervention,
+    i.agency,
+
+    -- Dates d'intervention (horodatages iso interventions_dedup)
+    i.date_heure_debut,
+    i.date_heure_fin,
+
+    -- Mesure
+    a.quantite_article as qty_consommee,
+
+    -- Métadonnées dbt
+    current_timestamp() as dbt_updated_at,
+    '{{ invocation_id }}' as dbt_invocation_id
+from articles as a
+inner join interventions as i
+    on a.n_planning = i.n_planning
+left join technicians as t
+    on lower(a.n_tech) = lower(cast(t.nomad_id as string))

--- a/models/staging/nesp_tech/stg_nesp_tech__articles.sql
+++ b/models/staging/nesp_tech/stg_nesp_tech__articles.sql
@@ -56,7 +56,13 @@ cleaned_data as (
         end as date_intervention,
 
         -- Metadata
-        safe.parse_timestamp('%Y-%m-%d %H:%M:%S%Ez', extracted_at) as extracted_at,
+        -- L'extracteur a changé deux fois de format ('YYYY-MM-DD HH:MM:SS+TZ',
+        -- puis nanosecondes, puis ISO 'T') : safe_cast couvre les formats ISO,
+        -- %E*S accepte les fractions de seconde de longueur libre (nanosecondes).
+        coalesce(
+            safe_cast(extracted_at as timestamp),
+            safe.parse_timestamp('%Y-%m-%d %H:%M:%E*S%Ez', extracted_at)
+        ) as extracted_at,
         source_file
 
     from source_data

--- a/models/staging/nesp_tech/stg_nesp_tech__interventions.sql
+++ b/models/staging/nesp_tech/stg_nesp_tech__interventions.sql
@@ -118,7 +118,13 @@ cleaned_data as (
         end as date_planning_nomadrepair,
 
         -- Metadata
-        safe.parse_timestamp('%Y-%m-%d %H:%M:%S%Ez', extracted_at) as extracted_at,
+        -- L'extracteur a changé deux fois de format ('YYYY-MM-DD HH:MM:SS+TZ',
+        -- puis nanosecondes, puis ISO 'T') : safe_cast couvre les formats ISO,
+        -- %E*S accepte les fractions de seconde de longueur libre (nanosecondes).
+        coalesce(
+            safe_cast(extracted_at as timestamp),
+            safe.parse_timestamp('%Y-%m-%d %H:%M:%E*S%Ez', extracted_at)
+        ) as extracted_at,
         source_file
 
     from source_data


### PR DESCRIPTION
## Summary

New mart **`fct_technique__consommation_article_nespresso`** — the Nespresso twin of `fct_technique__consommation_article_yuman`. Nespresso interventions do not go through Yuman workorders, but their articles live in the Yuman referential under the `EVS_NESPRESSO_` prefix: `product_reference` (`'EVS_NESPRESSO_' + upper(code_article)`) is the join key to Yuman stock.

Design decisions (validated with the data owner):
- **Grain** `(n_planning, code_article)` from `int_nesp_tech__articles_dedup`, inner-joined to `int_nesp_tech__interventions_dedup` for state, agency and **start/end timestamps** (iso with the interventions naming — the articles source `date` is the intervention start date, verified at 99.95%).
- **Scope: EVS agencies only** (`nespresso sud` subcontractor excluded — outside the EVS stock flow, inactive since 2025).
- **No intervention-state filter**: an article line = a real part usage (99.95% of lines carry a completed state; zero orphan article lines). `etat_intervention` is exposed as information.
- `technician_id` resolved via the Nomad matricule (`n_tech` ↔ `dim_technique__technician.nomad_id`, unique — no fan-out). 100% resolution on the built table.
- Seed `ref_yuman__pseudo_article` extended with the two Nomad bookkeeping lines (`miniprev` billing flag, `avertissement` client-misuse note) for downstream exclusion.

## Validation (dev build)

- 167 654 rows, 66 281 interventions, 410 distinct references, Nov 2023 → 2026-07-04 (weekly Monday extraction, verified in infra).
- 100% technician mapping, **99.5% of lines match the Yuman stock file**; the remainder are catalog-retired parts (e.g. `0146560`, last used Nov 2024) or the bookkeeping lines above.
- Yuman/Nomad overlap checked and dismissed with the data owner (tools not mixed; sample case verified by closing timestamps).
- 15/15 tests PASS (unique grain, not_null, accepted_values on agency/state, relationships on technician_id, quantity > 0, row-count range).

## Next step (separate PR)

Fold this fact into the depot-stockout assortment (`fct_supply_chain__rupture_depot_yuman`) — the assortment will grow ~4× on consumption volume; figures will be re-validated before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)