### PR TITLE
feat(supply_chain): expose depot code/name on forecast marts (hybrid pattern)

### DIFF
--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -544,7 +544,7 @@ models:
   - name: fct_supply_chain__classification_article_neshu
     description: |
       [QUOI MÉTIER] Classification des articles Neshu par dépôt pour piloter le forecast/réappro : l'"aiguilleur" qui range chaque couple (dépôt, article) selon son comportement de demande, son cycle de vie et son importance, et en déduit la méthode de prévision à appliquer. N'émet AUCUN forecast (calculé par le modèle de prévision en aval).
-      [COMMENT CONSTRUITE] À partir du socle int_oracle_neshu__demande_mensuelle. Stats de demande sur la vie active (min→max des mois observés, sparse) : adi = span / nb de mois avec demande, cv2 = (écart-type/moyenne)² des mois non nuls. classe_demande via la grille Syntetos-Boylan (seuils ADI 1,32 / CV² 0,49 ; indetermine si < 3 mois d'historique). statut_vie (ACTION) au grain couple : actif si vente < 4 mois (le réel gagne, quel que soit le label), hors_saison (saisonnier silencieux hors de sa saison), sinon arrete (product_exploit=NON) ou inactif. Saisonnalité = plano été/hiver (dim_neshu__product) × calendrier ISO (seed ref_general__calendrier_saison) : est_saisonnier (une seule saison plano à OUI), en_saison (dans sa saison ce jour). alerte_exploit (WARNING, grain ARTICLE) : arrete_mais_vend / actif_mais_silencieux (label exploit ↔ réel). alerte_saison (WARNING, grain ARTICLE) : plano hiver qui vend ≥ 25 % l'été, ou plano été qui vend < 50 % l'été (Oasis/Orangina). classe_abc = Pareto en VALEUR (€ = demande_12m × prix d'achat), cumulé par dépôt (A ≤ 80 % / B ≤ 95 % / C). methode_prevision = exclu (arrete/inactif), reference_saisonniere (saisonnier avec ≥ 13 mois d'historique), naif (indetermine), moyenne_mobile_surveille (intermittent/lumpy), moyenne_mobile sinon. Périmètre : 5 dépôts de distribution produits (dim_neshu__company.company_code Rungis/Lyon/Bordeaux/Strasbourg/Marseille), articles product_owner='Neshu', hors familles PRESENTOIR/PRESTATION SERVICE et hors BADGENESHU.
+      [COMMENT CONSTRUITE] À partir du socle int_oracle_neshu__demande_mensuelle. Stats de demande sur la vie active (min→max des mois observés, sparse) : adi = span / nb de mois avec demande, cv2 = (écart-type/moyenne)² des mois non nuls. classe_demande via la grille Syntetos-Boylan (seuils ADI 1,32 / CV² 0,49 ; indetermine si < 3 mois d'historique). statut_vie (ACTION) au grain couple : actif si vente < 4 mois (le réel gagne, quel que soit le label), hors_saison (saisonnier silencieux hors de sa saison), sinon arrete (product_exploit=NON) ou inactif. Saisonnalité = plano été/hiver (dim_neshu__product) × calendrier ISO (seed ref_general__calendrier_saison) : est_saisonnier (une seule saison plano à OUI), en_saison (dans sa saison ce jour). alerte_exploit (WARNING, grain ARTICLE) : arrete_mais_vend / actif_mais_silencieux (label exploit ↔ réel). alerte_saison (WARNING, grain ARTICLE) : plano hiver qui vend ≥ 25 % l'été, ou plano été qui vend < 50 % l'été (Oasis/Orangina). classe_abc = Pareto en VALEUR (€ = demande_12m × prix d'achat), cumulé par dépôt (A ≤ 80 % / B ≤ 95 % / C). methode_prevision = exclu (arrete/inactif), reference_saisonniere (saisonnier avec ≥ 13 mois d'historique), naif (indetermine), moyenne_mobile_surveille (intermittent/lumpy), moyenne_mobile sinon. Périmètre : 5 dépôts de distribution produits (dim_neshu__company.company_code Rungis/Lyon/Bordeaux/Strasbourg/Marseille), articles product_owner='Neshu', hors familles PRESENTOIR/PRESTATION SERVICE et hors BADGENESHU. company_code/company_name aplatis depuis dim_neshu__company (pattern hybride, propagés à la prévision et au point de commande).
       [GRAIN] 1 ligne par (company_id, product_id) — état courant recalculé à chaque build.
       [NOTES] V1. L'ABC ne pilote QUE le niveau de service (stock de sécurité en aval), JAMAIS l'exclusion (exclu = cycle de vie uniquement : un article classe C mais actif est prévu). alerte_exploit au grain article (le label exploit est article-level) pour éviter les faux positifs d'un article actif ailleurs mais silencieux à un dépôt ; elle s'auto-résout quand le métier corrige le label. Saisonnalité : les saisonniers hors-saison passent en statut hors_saison (pas exclus) et, avec ≥ 13 mois d'historique, sont routés vers reference_saisonniere (anticipation N-1) dans la prévision ; alerte_saison signale les plano incohérents avec le comportement réel. La détection saisonnière repose entièrement sur les labels plano : un saisonnier NON étiqueté n'est pas détecté (pas de filet automatique, contrairement au cycle de vie). Croston/SBA (intermittent/lumpy) = V2 ; en V1 ils passent en moyenne_mobile_surveille. date_calcul = date d'exécution (photo du jour, non historisée).
     columns:
@@ -562,6 +562,12 @@ models:
                 field: company_id
               config:
                 severity: warn
+      - name: company_code
+        description: "Code du dépôt (ex. DEPOTRUNGIS), aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
+        tests:
+          - not_null
+      - name: company_name
+        description: "Nom du dépôt, aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
       - name: product_id
         description: "Identifiant du produit (FK vers dim_neshu__product)"
         tests:
@@ -675,6 +681,12 @@ models:
                 field: company_id
               config:
                 severity: warn
+      - name: company_code
+        description: "Code du dépôt (ex. DEPOTRUNGIS), aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
+        tests:
+          - not_null
+      - name: company_name
+        description: "Nom du dépôt, aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
       - name: product_id
         description: "Identifiant du produit (FK vers dim_neshu__product)"
         tests:
@@ -745,6 +757,12 @@ models:
                 field: company_id
               config:
                 severity: warn
+      - name: company_code
+        description: "Code du dépôt (ex. DEPOTRUNGIS), aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
+        tests:
+          - not_null
+      - name: company_name
+        description: "Nom du dépôt, aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
       - name: product_id
         description: "Identifiant du produit (FK vers dim_neshu__product)"
         tests:

--- a/models/marts/supply_chain/fct_supply_chain__classification_article_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__classification_article_neshu.sql
@@ -78,8 +78,11 @@ depots as (
 
     -- Les 5 dépôts de distribution produits uniquement. Exclut ateliers, périmés, rebus, stock
     -- Nunshen, et les entités non-dépôt (fournisseur, client, logistique) qui polluent l'historique
-    -- source. Aligné avec le périmètre du mart de couverture.
-    select company_id
+    -- source. Aligné avec le périmètre du mart de couverture. code/nom aplatis (pattern hybride).
+    select
+        company_id,
+        company_code,
+        company_name
     from {{ ref('dim_neshu__company') }}
     where company_code in (
         'DEPOTRUNGIS', 'DEPOTLYON', 'DEPOTBORDEAUX', 'DEPOTSTRASBOURG', 'DEPOTMARSEILLE'
@@ -92,6 +95,8 @@ produit as (
     -- Périmètre (dépôts + articles) + enrichissement produit (label exploit, prix pour l'ABC valeur).
     select
         s.*,
+        d.company_code,
+        d.company_name,
         p.product_name,
         p.product_exploit,
         p.product_planoete,
@@ -215,6 +220,8 @@ select
     current_date() as date_calcul,
     company_id,
     product_id,
+    company_code,
+    company_name,
     product_code,
     product_name,
     statut_vie,

--- a/models/marts/supply_chain/fct_supply_chain__point_commande_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__point_commande_neshu.sql
@@ -33,6 +33,8 @@ with prevision as (
     select
         company_id,
         product_id,
+        company_code,
+        company_name,
         product_code,
         product_name,
         statut_vie,
@@ -123,6 +125,8 @@ assemble as (
     select
         p.company_id,
         p.product_id,
+        p.company_code,
+        p.company_name,
         p.product_code,
         p.product_name,
         p.statut_vie,
@@ -202,6 +206,8 @@ select
     current_date() as date_calcul,
     company_id,
     product_id,
+    company_code,
+    company_name,
     product_code,
     product_name,
     statut_vie,

--- a/models/marts/supply_chain/fct_supply_chain__prevision_demande_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__prevision_demande_neshu.sql
@@ -22,6 +22,8 @@ with classification as (
     select
         company_id,
         product_id,
+        company_code,
+        company_name,
         product_code,
         product_name,
         statut_vie,
@@ -79,6 +81,8 @@ prevision as (
     select
         c.company_id,
         c.product_id,
+        c.company_code,
+        c.company_name,
         c.product_code,
         c.product_name,
         c.statut_vie,
@@ -105,6 +109,8 @@ select
     current_date() as date_calcul,
     company_id,
     product_id,
+    company_code,
+    company_name,
     product_code,
     product_name,
     statut_vie,


### PR DESCRIPTION
## Quoi

Aplatit `company_code` + `company_name` (depuis `dim_neshu__company`) sur les 3 marts de la chaîne forecast NESHU :

- `fct_supply_chain__classification_article_neshu` (source de l'aplatissement — CTE dépôts déjà existant, zéro jointure ajoutée)
- `fct_supply_chain__prevision_demande_neshu` (hérité)
- `fct_supply_chain__point_commande_neshu` (hérité)

## Pourquoi

La prévision et le point de commande sont calculés **par dépôt** : le grain doit être lisible sans jointure (`DEPOTRUNGIS` / `01 - RUNGIS DEPOT PRODUITS` au lieu de `114`). Conforme au pattern hybride de `docs/conventions/marts.md` (attributs d'affichage du parent direct, 1-3 colonnes) — l'ancien mart `couverture_stock_neshu` expose déjà `entity_code`/`entity_name`.

## Détails

- Colonnes placées après les clés du grain (`company_id`, `product_id`), ordre grain-first.
- YAML : colonnes documentées sur les 3 modèles + test `not_null` sur `company_code`.
- Changement additif : aucune colonne existante modifiée, aucune valeur calculée impactée.
- Validé dev : build + 50/50 tests verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)