### PR TITLE
feat(supply-chain): socle intermédiaire appro & fabrication LCDP

### DIFF
--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -1105,6 +1105,267 @@ models:
         tests:
           - not_null
 
+  - name: int_oracle_lcdp__entree_fabrication_tasks
+    description: >
+      [QUOI MÉTIER]
+      Entrées en fabrication LCDP (type 296) : une ligne par produit de café vert consommé par la
+      torréfaction. C'est l'intrant du process — le café vert sort du dépôt de stockage (source,
+      typiquement VERT) pour entrer dans le dépôt FABRICATION (destination).
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 296, code_status_record = '1', real_start_date non nul,
+      tous statuts conservés) croisé avec task_has_product (grain ligne produit), enrichi product et
+      task_status. Source et destination résolues sur company (COMPANY dans 100 % des cas). Seules
+      les lignes dont source ET destination se résolvent sont conservées. Quantité ramenée en unités
+      de base (real_quantity × coeff_multi / coeff_div).
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une entrée en fabrication). ~1 380 lignes
+      (~208 tâches, 39 cafés verts), depuis janvier 2025.
+
+      [NOTES]
+      Maillon amont de la chaîne de torréfaction : VERT (café vert, codes 11xxx « CV … ») →
+      [ENTREE_FABRICATION] → FABRICATION → [SORTIE_FABRICATION] → TORREFIEVRAC. Symétrique de
+      int_oracle_lcdp__sortie_fabrication_tasks (type 297, produits torréfiés 12xxx). Les deux flux
+      NE partagent PAS de document parent (task_idtask nul) : impossible de rattacher nativement un
+      lot de sortie à ses intrants (pas de nomenclature/BOM dans l'ERP). Aucun filtre statut ici
+      (tri en marts). Explique le stock de café vert du dépôt VERT reçu sans commande fournisseur.
+    columns:
+      # --- IDENTIFIANTS ---
+      - name: task_product_id
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
+        data_type: int64
+        tests:
+          - unique
+          - not_null
+      - name: task_id
+        description: "Tâche d'entrée en fabrication Oracle LCDP (EVS.TASK)."
+        data_type: int64
+        tests:
+          - not_null
+      - name: company_id
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
+        data_type: int64
+      - name: product_id
+        description: "Café vert consommé. FK → dim_lcdp__product."
+        data_type: int64
+        tests:
+          - not_null
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité **source** (dépôt d'où sort le café vert). Référence polymorphe :
+          COMPANY → stg_oracle_lcdp__company. Pas une FK produit.
+        data_type: int64
+      - name: product_source_type
+        description: "Type de l'entité source. Toujours COMPANY (dépôt café vert) sur ce type de tâche."
+        data_type: string
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité **destination** (dépôt FABRICATION). Référence polymorphe :
+          COMPANY → stg_oracle_lcdp__company.
+        data_type: int64
+      - name: product_destination_type
+        description: "Type de l'entité destination. Toujours COMPANY (dépôt FABRICATION) sur ce type de tâche."
+        data_type: string
+
+      # --- CODES ---
+      - name: source_code
+        description: "Code du dépôt source du café vert (company.code). Typiquement VERT."
+        data_type: string
+        tests:
+          - not_null
+      - name: destination_code
+        description: "Code du dépôt destination (company.code). Typiquement FABRICATION."
+        data_type: string
+        tests:
+          - not_null
+      - name: product_code
+        description: "Code métier du café vert (famille 11xxx)."
+        data_type: string
+      - name: task_status_code
+        description: "Code du statut de la tâche. Quasi exclusivement VALIDE. Aucun filtre ici (tri en marts)."
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
+      - name: task_start_date
+        description: "Date et heure réelle de l'entrée en fabrication."
+        data_type: timestamp
+        tests:
+          - not_null
+
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
+      - name: base_unit_quantity
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
+      - name: product_unit_price_task
+        description: "Prix unitaire du produit au moment de la tâche (net_price)."
+      - name: product_unit_price_latest
+        description: "Dernier prix d'achat unitaire du café vert (référentiel produit)."
+
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité de café vert consommée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
+      - name: valuation
+        description: "Valorisation de l'intrant en euros = quantity × prix d'achat unitaire. Mesure additive."
+
+      # --- MÉTADONNÉES ---
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp
+        tests:
+          - not_null
+
+  - name: int_oracle_lcdp__sortie_fabrication_tasks
+    description: >
+      [QUOI MÉTIER]
+      Sorties de fabrication LCDP (type 297) : une ligne par produit de café torréfié / mélange
+      produit par la torréfaction. C'est l'extrant du process — le café torréfié sort du dépôt
+      FABRICATION (source) vers le dépôt de café torréfié (destination, typiquement TORREFIEVRAC).
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 297, code_status_record = '1', real_start_date non nul,
+      tous statuts conservés) croisé avec task_has_product (grain ligne produit), enrichi product et
+      task_status. Source et destination résolues sur company (COMPANY dans 100 % des cas). Seules
+      les lignes dont source ET destination se résolvent sont conservées. Quantité ramenée en unités
+      de base (real_quantity × coeff_multi / coeff_div).
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une sortie de fabrication). ~2 300 lignes
+      (~347 tâches, 47 produits), depuis janvier 2025.
+
+      [NOTES]
+      Maillon aval de la chaîne de torréfaction : VERT (café vert) → [ENTREE_FABRICATION] →
+      FABRICATION → [SORTIE_FABRICATION] → TORREFIEVRAC (café torréfié, codes 12xxx « MELANGE … »,
+      vrac + conditionnés 250g). Symétrique de int_oracle_lcdp__entree_fabrication_tasks (type 296,
+      café vert). Les deux flux NE partagent PAS de document parent (task_idtask nul) : pas de
+      nomenclature/BOM ERP, donc pas de rattachement direct sortie↔intrants. Le rapprochement
+      entrée/sortie ne peut se faire qu'en agrégé (par période), et les quantités mélangent des
+      unités hétérogènes (vrac en kg vs conditionnés 250g) → un rendement de torréfaction n'est pas
+      calculable en l'état sans normalisation. valuation basée sur purchase_unit_price, souvent
+      absent pour les produits fabriqués (non achetés) → peut être nul. Aucun filtre statut ici.
+    columns:
+      # --- IDENTIFIANTS ---
+      - name: task_product_id
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
+        data_type: int64
+        tests:
+          - unique
+          - not_null
+      - name: task_id
+        description: "Tâche de sortie de fabrication Oracle LCDP (EVS.TASK)."
+        data_type: int64
+        tests:
+          - not_null
+      - name: company_id
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
+        data_type: int64
+      - name: product_id
+        description: "Café torréfié / mélange produit. FK → dim_lcdp__product."
+        data_type: int64
+        tests:
+          - not_null
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité **source** (dépôt FABRICATION). Référence polymorphe :
+          COMPANY → stg_oracle_lcdp__company. Pas une FK produit.
+        data_type: int64
+      - name: product_source_type
+        description: "Type de l'entité source. Toujours COMPANY (dépôt FABRICATION) sur ce type de tâche."
+        data_type: string
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité **destination** (dépôt du café torréfié). Référence polymorphe :
+          COMPANY → stg_oracle_lcdp__company.
+        data_type: int64
+      - name: product_destination_type
+        description: "Type de l'entité destination. Toujours COMPANY (dépôt torréfié) sur ce type de tâche."
+        data_type: string
+
+      # --- CODES ---
+      - name: source_code
+        description: "Code du dépôt source (company.code). Typiquement FABRICATION."
+        data_type: string
+        tests:
+          - not_null
+      - name: destination_code
+        description: "Code du dépôt destination du café torréfié (company.code). Typiquement TORREFIEVRAC."
+        data_type: string
+        tests:
+          - not_null
+      - name: product_code
+        description: "Code métier du café torréfié / mélange (famille 12xxx)."
+        data_type: string
+      - name: task_status_code
+        description: "Code du statut de la tâche. Quasi exclusivement VALIDE (1 ANNULE observé). Aucun filtre ici (tri en marts)."
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+
+      # --- DATE ---
+      - name: task_start_date
+        description: "Date et heure réelle de la sortie de fabrication."
+        data_type: timestamp
+        tests:
+          - not_null
+
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
+      - name: base_unit_quantity
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
+      - name: product_unit_price_task
+        description: "Prix unitaire du produit au moment de la tâche (net_price)."
+      - name: product_unit_price_latest
+        description: "Dernier prix d'achat unitaire (référentiel produit). Souvent nul pour un produit fabriqué (non acheté)."
+
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité de café torréfié produite en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive. Unités hétérogènes (vrac kg / conditionné 250g)."
+      - name: valuation
+        description: "Valorisation en euros = quantity × prix d'achat unitaire. Souvent nul (produit fabriqué sans prix d'achat au référentiel)."
+
+      # --- MÉTADONNÉES ---
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp
+        tests:
+          - not_null
+
   - name: int_oracle_lcdp__livraison_interne_tasks
     description: >
       [QUOI MÉTIER]

--- a/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
+++ b/models/intermediate/oracle_lcdp/_oracle_lcdp__intermediate_models.yml
@@ -839,7 +839,9 @@ models:
       stg_oracle_lcdp__task (idtask_type = 121 BON RECEPTION, statuts FAIT/VALIDE/ANNULE/ANOMALIE,
       code_status_record = '1') croisé avec task_has_product (grain ligne produit), enrichi product.
       La destination est résolue quand product_destination_type = COMPANY → code dépôt (company).
-      Quantité ramenée en unités de base.
+      Quantité ramenée en unités de base. Enrichi avec la date de la commande fournisseur (type 120)
+      rattachée pour calculer le délai de livraison : le lien passe par le document parent partagé
+      (task_idtask, un GESCOM), une réception pointe vers au plus 1 commande.
 
       [GRAIN]
       1 ligne par task_product_id (ligne produit d'un bon de réception). ~8,7k lignes (~636 bons),
@@ -848,6 +850,12 @@ models:
       [NOTES]
       Symétrique de la livraison côté entrée : product_destination_id est polymorphe et vaut
       toujours COMPANY ici (réception dans un dépôt). Pas de source.
+      Délai de livraison : contrairement à NESHU (~98 % de réceptions rapprochées d'une commande),
+      seules ~37 % des réceptions LCDP ont une commande fournisseur rapprochable — le processus
+      commande y est moins systématique — donc commande_start_date et delivery_lead_time_days sont
+      NULL pour la majorité (attendu, pas un bug). De rares saisies incohérentes donnent un délai
+      négatif (réception datée avant la commande) et la distribution a une longue traîne (médiane 4 j
+      mais P90 ~97 j) : filtrer sur is_lead_time_valid et préférer la médiane à la moyenne en aval.
     columns:
       # --- IDENTIFIANTS ---
       - name: task_product_id
@@ -902,6 +910,21 @@ models:
         data_type: timestamp
         tests:
           - not_null
+      - name: commande_start_date
+        description: >
+          Date de la commande fournisseur (type 120) rattachée, via le document parent partagé
+          (task_idtask, GESCOM). NULL si la réception n'a pas de commande rapprochable (~63 % des cas
+          côté LCDP).
+        data_type: timestamp
+
+      # --- DÉLAI DE LIVRAISON ---
+      - name: delivery_lead_time_days
+        description: >
+          Délai fournisseur en jours = task_start_date − commande_start_date.
+          NULL si commande_start_date absente. Filtrer sur is_lead_time_valid.
+      - name: is_lead_time_valid
+        description: "Vrai si commande_start_date présente et délai ≥ 0 (réception après commande)."
+        data_type: boolean
 
       # --- CONDITIONNEMENT & PRIX ---
       - name: unit_coeff_multi
@@ -920,6 +943,150 @@ models:
         description: "Quantité reçue en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
       - name: valuation
         description: "Valorisation de la réception en euros = quantity × prix d'achat unitaire. Mesure additive."
+
+      # --- MÉTADONNÉES ---
+      - name: updated_at
+        description: "Timestamp de dernière modification en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: created_at
+        description: "Timestamp de création en source."
+        data_type: timestamp
+        tests:
+          - not_null
+      - name: extracted_at
+        description: "Timestamp d'extraction depuis Oracle."
+        data_type: timestamp
+        tests:
+          - not_null
+
+  - name: int_oracle_lcdp__commande_fournisseur_tasks
+    description: >
+      [QUOI MÉTIER]
+      Commandes fournisseur LCDP (type 120) : une ligne par produit commandé à un fournisseur
+      externe (source) et livré dans un dépôt (destination), avec son statut de livraison.
+      Approvisionnement externe, typiquement fournisseur → dépôt.
+
+      [COMMENT CONSTRUITE]
+      stg_oracle_lcdp__task (idtask_type = 120, code_status_record = '1', real_start_date non nul,
+      tous statuts de tâche conservés) croisé avec task_has_product (grain ligne produit), enrichi
+      product et task_status. Source (fournisseur) et destination (dépôt) résolues sur company
+      (type COMPANY dans 100 % des cas). Le statut de livraison est pivoté au grain tâche depuis le
+      label de famille STATUT_LIVRAISON (max(case ...)), puis rattaché aux lignes produit — pas de
+      déduplication. Seules les lignes dont source ET destination se résolvent sont conservées.
+
+      [GRAIN]
+      1 ligne par task_product_id (ligne produit d'une commande fournisseur). ~3 900 lignes
+      (~207 tâches), depuis décembre 2024.
+
+      [NOTES]
+      Transposition LCDP de int_oracle_neshu__commande_fournisseur_tasks (mêmes types Oracle 120/121,
+      même famille label STATUT_LIVRAISON). La source est un fournisseur externe et non un dépôt
+      interne ; logiquement en amont de int_oracle_lcdp__reception_tasks (type 121, bon de réception),
+      qui s'y rattache via le document parent partagé (task_idtask). Aucun filtre statut ici : le tri
+      FAIT/VALIDE/ANNULE se fait en marts / couche métier.
+    columns:
+      # --- IDENTIFIANTS ---
+      - name: task_product_id
+        description: "Clé primaire : ligne task_has_product (relation tâche↔produit). PK."
+        data_type: int64
+        tests:
+          - unique
+          - not_null
+      - name: task_id
+        description: "Tâche de commande fournisseur Oracle LCDP (EVS.TASK)."
+        data_type: int64
+        tests:
+          - not_null
+      - name: company_id
+        description: "Client (peer company) de la tâche. FK → dim_lcdp__company."
+        data_type: int64
+      - name: product_id
+        description: "Produit commandé. FK → dim_lcdp__product."
+        data_type: int64
+        tests:
+          - not_null
+      - name: product_source_id
+        description: >
+          Identifiant de l'entité **source** (le fournisseur). Référence polymorphe : table cible
+          nommée par product_source_type — COMPANY → stg_oracle_lcdp__company. Pas une FK produit.
+        data_type: int64
+      - name: product_source_type
+        description: "Type de l'entité source = table cible de product_source_id. Toujours COMPANY (fournisseur) sur ce type de tâche."
+        data_type: string
+      - name: product_destination_id
+        description: >
+          Identifiant de l'entité **destination** (le dépôt). Référence polymorphe : table cible
+          nommée par product_destination_type — COMPANY → stg_oracle_lcdp__company.
+        data_type: int64
+      - name: product_destination_type
+        description: "Type de l'entité destination = table cible de product_destination_id. Toujours COMPANY (dépôt) sur ce type de tâche."
+        data_type: string
+
+      # --- CODES ---
+      - name: source_code
+        description: "Code du fournisseur (company.code de la source)."
+        data_type: string
+        tests:
+          - not_null
+      - name: destination_code
+        description: "Code du dépôt destinataire (company.code de la destination)."
+        data_type: string
+        tests:
+          - not_null
+      - name: product_code
+        description: "Code métier du produit."
+        data_type: string
+      - name: task_status_code
+        description: >
+          Code du statut de la tâche. Valeurs observées : FAIT et VALIDE (majoritaires), plus PREVU
+          (commande prévue), ENCOURS (en cours) et ANNULE. PREVU/ENCOURS = commandes non encore
+          reçues (utiles pour l'encours fournisseur). Aucun filtre appliqué ici (tri en marts).
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [FAIT, VALIDE, PREVU, ENCOURS, ANNULE, ANOMALIE]
+              config:
+                severity: warn
+      - name: delivery_status_code
+        description: >
+          Statut de livraison de la commande fournisseur, pivoté au grain tâche depuis le label de
+          famille STATUT_LIVRAISON. Valeurs : LIVRE, LIVRE_PARTIEL, EN_ATTENTE. Nul si la tâche ne
+          porte aucun label.
+        data_type: string
+        tests:
+          - accepted_values:
+              arguments:
+                values: [LIVRE, LIVRE_PARTIEL, EN_ATTENTE]
+              config:
+                severity: warn
+
+      # --- DATE ---
+      - name: task_start_date
+        description: "Date et heure réelle de la commande fournisseur."
+        data_type: timestamp
+        tests:
+          - not_null
+
+      # --- CONDITIONNEMENT & PRIX ---
+      - name: unit_coeff_multi
+        description: "Coefficient multiplicateur de conditionnement (passage en unités de base)."
+      - name: unit_coeff_div
+        description: "Coefficient diviseur de conditionnement."
+      - name: base_unit_quantity
+        description: "Quantité brute saisie (real_quantity), avant application des coefficients."
+      - name: product_unit_price_task
+        description: "Prix unitaire HT du produit au moment de la tâche (net_price)."
+      - name: product_unit_price_latest
+        description: "Dernier prix d'achat unitaire HT du produit (référentiel produit)."
+
+      # --- MESURES ---
+      - name: quantity
+        description: "Quantité commandée en unités de base = real_quantity × coeff_multi / coeff_div. Mesure additive."
+      - name: valuation
+        description: "Valorisation de la commande en euros = quantity × prix d'achat unitaire. Mesure additive."
 
       # --- MÉTADONNÉES ---
       - name: updated_at

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__commande_fournisseur_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__commande_fournisseur_tasks.sql
@@ -1,0 +1,147 @@
+{{ config(materialized='table') }}
+
+with delivery_status as (
+
+    -- Pivot du label au grain tâche (1 label STATUT_LIVRAISON par tâche aujourd'hui).
+    -- Pivot plutôt que jointure + dédup : pas de fan-out sur les lignes produit,
+    -- robuste si une seconde famille de label apparaît un jour.
+    select
+        lht.idtask,
+        max(case when lf.code = 'STATUT_LIVRAISON' then la.code end) as delivery_status_code
+
+    from {{ ref('stg_oracle_lcdp__label_has_task') }} as lht
+    inner join {{ ref('stg_oracle_lcdp__label') }} as la
+        on lht.idlabel = la.idlabel
+    inner join {{ ref('stg_oracle_lcdp__label_family') }} as lf
+        on la.idlabel_family = lf.idlabel_family
+
+    group by lht.idtask
+),
+
+commande_fournisseur_base as (
+
+    select
+        -- Identifiants
+        thp.idtask_has_product as task_product_id,
+        t.idtask as task_id,
+        t.idcompany_peer as company_id,
+        thp.idproduct as product_id,
+        t.idproduct_source as product_source_id,
+        t.type_product_source as product_source_type,
+        t.idproduct_destination as product_destination_id,
+        t.type_product_destination as product_destination_type,
+
+        -- Codes (source = fournisseur, destination = dépôt : toujours COMPANY)
+        cs.code as source_code,
+        cd.code as destination_code,
+        p.code as product_code,
+        ts.code as task_status_code,
+
+        -- Informations date
+        t.real_start_date as task_start_date,
+
+        -- Informations de conditionnement
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity as base_unit_quantity,
+        thp.net_price as product_unit_price_task,
+        p.purchase_unit_price as product_unit_price_latest,
+
+        -- Métriques
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div) as quantity,
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div * p.purchase_unit_price) as valuation,
+
+        -- Timestamps techniques
+        t.updated_at,
+        t.created_at,
+        t.extracted_at
+
+    from {{ ref('stg_oracle_lcdp__task') }} as t
+    inner join {{ ref('stg_oracle_lcdp__task_has_product') }} as thp
+        on t.idtask = thp.idtask
+    left join {{ ref('stg_oracle_lcdp__product') }} as p
+        on thp.idproduct = p.idproduct
+    left join {{ ref('stg_oracle_lcdp__task_status') }} as ts
+        on t.idtask_status = ts.idtask_status
+
+    -- Source = COMPANY (fournisseur)
+    left join {{ ref('stg_oracle_lcdp__company') }} as cs
+        on
+            t.idproduct_source = cs.idcompany
+            and t.type_product_source = 'COMPANY'
+
+    -- Destination = COMPANY (dépôt)
+    left join {{ ref('stg_oracle_lcdp__company') }} as cd
+        on
+            t.idproduct_destination = cd.idcompany
+            and t.type_product_destination = 'COMPANY'
+
+    where
+        1 = 1
+        and t.idtask_type = 120  -- COMMANDE FOURNISSEUR
+        and t.code_status_record = '1'
+        and t.real_start_date is not null
+
+    group by
+        thp.idtask_has_product,
+        t.idtask,
+        t.idcompany_peer,
+        thp.idproduct,
+        t.idproduct_source,
+        t.type_product_source,
+        t.idproduct_destination,
+        t.type_product_destination,
+        cs.code, cd.code,
+        p.code, ts.code,
+        t.real_start_date,
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity,
+        thp.net_price,
+        p.purchase_unit_price,
+        t.updated_at, t.created_at, t.extracted_at
+)
+
+select
+    -- Identifiants
+    cfb.task_product_id,
+    cfb.task_id,
+    cfb.company_id,
+    cfb.product_id,
+    cfb.product_source_id,
+    cfb.product_source_type,
+    cfb.product_destination_id,
+    cfb.product_destination_type,
+
+    -- Codes
+    cfb.source_code,
+    cfb.destination_code,
+    cfb.product_code,
+    cfb.task_status_code,
+    ds.delivery_status_code,
+
+    -- Infos métier
+    cfb.task_start_date,
+
+    -- Infos de conditionnement
+    cfb.unit_coeff_multi,
+    cfb.unit_coeff_div,
+    cfb.base_unit_quantity,
+    cfb.product_unit_price_task,
+    cfb.product_unit_price_latest,
+
+    -- Métriques
+    cfb.quantity,
+    cfb.valuation,
+
+    -- Timestamps techniques
+    cfb.updated_at,
+    cfb.created_at,
+    cfb.extracted_at
+
+from commande_fournisseur_base as cfb
+left join delivery_status as ds
+    on cfb.task_id = ds.idtask
+where
+    cfb.source_code is not null
+    and cfb.destination_code is not null

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__entree_fabrication_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__entree_fabrication_tasks.sql
@@ -1,0 +1,126 @@
+{{ config(materialized='table') }}
+
+with entree_fabrication_base as (
+
+    select
+        -- Identifiants
+        thp.idtask_has_product as task_product_id,
+        t.idtask as task_id,
+        t.idcompany_peer as company_id,
+        thp.idproduct as product_id,
+        t.idproduct_source as product_source_id,
+        t.type_product_source as product_source_type,
+        t.idproduct_destination as product_destination_id,
+        t.type_product_destination as product_destination_type,
+
+        -- Codes (source = dépôt café vert, destination = FABRICATION : toujours COMPANY)
+        cs.code as source_code,
+        cd.code as destination_code,
+        p.code as product_code,
+        ts.code as task_status_code,
+
+        -- Informations date
+        t.real_start_date as task_start_date,
+
+        -- Informations de conditionnement
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity as base_unit_quantity,
+        thp.net_price as product_unit_price_task,
+        p.purchase_unit_price as product_unit_price_latest,
+
+        -- Métriques
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div) as quantity,
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div * p.purchase_unit_price) as valuation,
+
+        -- Timestamps techniques
+        t.updated_at,
+        t.created_at,
+        t.extracted_at
+
+    from {{ ref('stg_oracle_lcdp__task') }} as t
+    inner join {{ ref('stg_oracle_lcdp__task_has_product') }} as thp
+        on t.idtask = thp.idtask
+    left join {{ ref('stg_oracle_lcdp__product') }} as p
+        on thp.idproduct = p.idproduct
+    left join {{ ref('stg_oracle_lcdp__task_status') }} as ts
+        on t.idtask_status = ts.idtask_status
+
+    -- Source = COMPANY (dépôt d'où sort le café vert, typiquement VERT)
+    left join {{ ref('stg_oracle_lcdp__company') }} as cs
+        on
+            t.idproduct_source = cs.idcompany
+            and t.type_product_source = 'COMPANY'
+
+    -- Destination = COMPANY (dépôt FABRICATION)
+    left join {{ ref('stg_oracle_lcdp__company') }} as cd
+        on
+            t.idproduct_destination = cd.idcompany
+            and t.type_product_destination = 'COMPANY'
+
+    where
+        1 = 1
+        and t.idtask_type = 296  -- ENTREE_FABRICATION
+        and t.code_status_record = '1'
+        and t.real_start_date is not null
+
+    group by
+        thp.idtask_has_product,
+        t.idtask,
+        t.idcompany_peer,
+        thp.idproduct,
+        t.idproduct_source,
+        t.type_product_source,
+        t.idproduct_destination,
+        t.type_product_destination,
+        cs.code, cd.code,
+        p.code, ts.code,
+        t.real_start_date,
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity,
+        thp.net_price,
+        p.purchase_unit_price,
+        t.updated_at, t.created_at, t.extracted_at
+)
+
+select
+    -- Identifiants
+    task_product_id,
+    task_id,
+    company_id,
+    product_id,
+    product_source_id,
+    product_source_type,
+    product_destination_id,
+    product_destination_type,
+
+    -- Codes
+    source_code,
+    destination_code,
+    product_code,
+    task_status_code,
+
+    -- Infos métier
+    task_start_date,
+
+    -- Infos de conditionnement
+    unit_coeff_multi,
+    unit_coeff_div,
+    base_unit_quantity,
+    product_unit_price_task,
+    product_unit_price_latest,
+
+    -- Métriques
+    quantity,
+    valuation,
+
+    -- Timestamps techniques
+    updated_at,
+    created_at,
+    extracted_at
+
+from entree_fabrication_base
+where
+    source_code is not null
+    and destination_code is not null

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__reception_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__reception_tasks.sql
@@ -5,12 +5,33 @@
     )
 }}
 
-with reception_base as (
+with commande_header as (
+
+    -- Date de la commande fournisseur (type 120) rattachée à la réception.
+    -- Le lien passe par le document parent partagé (task_idtask) : commande et réception
+    -- pointent vers le même parent GESCOM. 1 commande par parent -> au plus 1 date par réception,
+    -- donc pas de fan-out. min() = collapse défensif des lignes produit de la commande.
+    -- NB LCDP : ~37 % seulement des réceptions ont une commande rapprochable (vs ~98 % NESHU) :
+    -- le processus commande fournisseur y est moins systématique -> délai souvent NULL (attendu).
+    select
+        task_idtask as parent_id,
+        min(real_start_date) as commande_start_date
+
+    from {{ ref('stg_oracle_lcdp__task') }}
+    where
+        idtask_type = 120  -- COMMANDE FOURNISSEUR
+        and code_status_record = '1'
+        and task_idtask is not null
+    group by task_idtask
+),
+
+reception_base as (
 
     select
         -- Identifiants
         thp.idtask_has_product as task_product_id,
         t.idtask as task_id,
+        t.task_idtask as parent_id,  -- interne : clé de jointure vers la commande (non exposé)
         t.idcompany_peer as company_id,
         thp.idproduct as product_id,
         t.idproduct_destination as product_destination_id,
@@ -62,7 +83,7 @@ with reception_base as (
         and t.real_start_date is not null
 
     group by
-        thp.idtask_has_product, t.idtask, t.idcompany_peer,
+        thp.idtask_has_product, t.idtask, t.task_idtask, t.idcompany_peer,
         t.idproduct_destination, t.type_product_destination,
         thp.idproduct,
         thp.unit_coeff_multi,
@@ -78,35 +99,43 @@ with reception_base as (
 
 select
     -- Identifiants
-    task_product_id,
-    task_id,
-    company_id,
-    product_id,
-    product_destination_id,
-    product_destination_type,
+    rb.task_product_id,
+    rb.task_id,
+    rb.company_id,
+    rb.product_id,
+    rb.product_destination_id,
+    rb.product_destination_type,
 
     -- Codes
-    destination_code,
-    product_code,
-    task_status_code,
+    rb.destination_code,
+    rb.product_code,
+    rb.task_status_code,
 
     -- Infos métier
-    task_start_date,
+    rb.task_start_date,
+    ch.commande_start_date,
+
+    -- Délai de livraison fournisseur (commande -> réception)
+    date_diff(date(rb.task_start_date), date(ch.commande_start_date), day) as delivery_lead_time_days,
+    ch.commande_start_date is not null
+    and rb.task_start_date >= ch.commande_start_date as is_lead_time_valid,
 
     -- Infos de conditionnement
-    unit_coeff_multi,
-    unit_coeff_div,
-    base_unit_quantity,
-    product_unit_price_task,
-    product_unit_price_latest,
+    rb.unit_coeff_multi,
+    rb.unit_coeff_div,
+    rb.base_unit_quantity,
+    rb.product_unit_price_task,
+    rb.product_unit_price_latest,
 
     -- Métriques
-    quantity,
-    valuation,
+    rb.quantity,
+    rb.valuation,
 
     -- Timestamps techniques
-    updated_at,
-    created_at,
-    extracted_at
+    rb.updated_at,
+    rb.created_at,
+    rb.extracted_at
 
-from reception_base
+from reception_base as rb
+left join commande_header as ch
+    on rb.parent_id = ch.parent_id

--- a/models/intermediate/oracle_lcdp/int_oracle_lcdp__sortie_fabrication_tasks.sql
+++ b/models/intermediate/oracle_lcdp/int_oracle_lcdp__sortie_fabrication_tasks.sql
@@ -1,0 +1,126 @@
+{{ config(materialized='table') }}
+
+with sortie_fabrication_base as (
+
+    select
+        -- Identifiants
+        thp.idtask_has_product as task_product_id,
+        t.idtask as task_id,
+        t.idcompany_peer as company_id,
+        thp.idproduct as product_id,
+        t.idproduct_source as product_source_id,
+        t.type_product_source as product_source_type,
+        t.idproduct_destination as product_destination_id,
+        t.type_product_destination as product_destination_type,
+
+        -- Codes (source = FABRICATION, destination = dépôt torréfié : toujours COMPANY)
+        cs.code as source_code,
+        cd.code as destination_code,
+        p.code as product_code,
+        ts.code as task_status_code,
+
+        -- Informations date
+        t.real_start_date as task_start_date,
+
+        -- Informations de conditionnement
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity as base_unit_quantity,
+        thp.net_price as product_unit_price_task,
+        p.purchase_unit_price as product_unit_price_latest,
+
+        -- Métriques
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div) as quantity,
+        sum(thp.real_quantity * thp.unit_coeff_multi / thp.unit_coeff_div * p.purchase_unit_price) as valuation,
+
+        -- Timestamps techniques
+        t.updated_at,
+        t.created_at,
+        t.extracted_at
+
+    from {{ ref('stg_oracle_lcdp__task') }} as t
+    inner join {{ ref('stg_oracle_lcdp__task_has_product') }} as thp
+        on t.idtask = thp.idtask
+    left join {{ ref('stg_oracle_lcdp__product') }} as p
+        on thp.idproduct = p.idproduct
+    left join {{ ref('stg_oracle_lcdp__task_status') }} as ts
+        on t.idtask_status = ts.idtask_status
+
+    -- Source = COMPANY (dépôt FABRICATION)
+    left join {{ ref('stg_oracle_lcdp__company') }} as cs
+        on
+            t.idproduct_source = cs.idcompany
+            and t.type_product_source = 'COMPANY'
+
+    -- Destination = COMPANY (dépôt du café torréfié, typiquement TORREFIEVRAC)
+    left join {{ ref('stg_oracle_lcdp__company') }} as cd
+        on
+            t.idproduct_destination = cd.idcompany
+            and t.type_product_destination = 'COMPANY'
+
+    where
+        1 = 1
+        and t.idtask_type = 297  -- SORTIE_FABRICATION
+        and t.code_status_record = '1'
+        and t.real_start_date is not null
+
+    group by
+        thp.idtask_has_product,
+        t.idtask,
+        t.idcompany_peer,
+        thp.idproduct,
+        t.idproduct_source,
+        t.type_product_source,
+        t.idproduct_destination,
+        t.type_product_destination,
+        cs.code, cd.code,
+        p.code, ts.code,
+        t.real_start_date,
+        thp.unit_coeff_multi,
+        thp.unit_coeff_div,
+        thp.real_quantity,
+        thp.net_price,
+        p.purchase_unit_price,
+        t.updated_at, t.created_at, t.extracted_at
+)
+
+select
+    -- Identifiants
+    task_product_id,
+    task_id,
+    company_id,
+    product_id,
+    product_source_id,
+    product_source_type,
+    product_destination_id,
+    product_destination_type,
+
+    -- Codes
+    source_code,
+    destination_code,
+    product_code,
+    task_status_code,
+
+    -- Infos métier
+    task_start_date,
+
+    -- Infos de conditionnement
+    unit_coeff_multi,
+    unit_coeff_div,
+    base_unit_quantity,
+    product_unit_price_task,
+    product_unit_price_latest,
+
+    -- Métriques
+    quantity,
+    valuation,
+
+    -- Timestamps techniques
+    updated_at,
+    created_at,
+    extracted_at
+
+from sortie_fabrication_base
+where
+    source_code is not null
+    and destination_code is not null


### PR DESCRIPTION
## Contexte

Socle **intermédiaire** pour préparer le suivi d'approvisionnement / réapprovisionnement LCDP (dans la continuité du forecast NESHU). Transposition des patterns Oracle NESHU existants vers la BU LCDP, avec les écarts métier identifiés et documentés.

Aucun mart ici — que du `intermediate/` (le DE en est owner). Tout est buildé + testé en dev (`evs-datastack-dev`).

## Contenu

### 1. Approvisionnement fournisseur (commit `46a82f46`)
- **Nouveau** `int_oracle_lcdp__commande_fournisseur_tasks` (type Oracle 120) — transposition de la version NESHU : source fournisseur → destination dépôt, pivot du label `STATUT_LIVRAISON` (EN_ATTENTE / LIVRE / LIVRE_PARTIEL). ~3 900 lignes / 207 commandes / 16 fournisseurs, depuis déc. 2024.
- **Enrichi** `int_oracle_lcdp__reception_tasks` — ajout du lien vers la commande fournisseur (document parent partagé `task_idtask` / GESCOM) et des colonnes `commande_start_date`, `delivery_lead_time_days`, `is_lead_time_valid` (comme NESHU).

### 2. Fabrication / torréfaction (commit `c8240006`)
LCDP est un **torréfacteur de café**. Chaîne : `VERT (café vert 11xxx) → [ENTREE_FAB 296] → FABRICATION → [SORTIE_FAB 297] → TORREFIEVRAC (mélanges torréfiés 12xxx)`.
- **Nouveau** `int_oracle_lcdp__entree_fabrication_tasks` (type 296) — café vert consommé. ~1 380 lignes / 208 tâches / 911 k€.
- **Nouveau** `int_oracle_lcdp__sortie_fabrication_tasks` (type 297) — café torréfié produit. ~2 300 lignes / 347 tâches / 1,06 M€.

## Différences BU vs NESHU (documentées dans les YAML)

| Point | Constat LCDP | Traitement |
|---|---|---|
| Rattachement réception → commande | **~42 %** seulement (vs ~98 % NESHU) — process commande moins systématique | `is_lead_time_valid` gère les NULL ; délai NULL pour la majorité (attendu) |
| Distribution du lead time | Médiane 3 j saine, mais grosse traîne (P90 97 j) tirée par une commande de go-live | En aval : médiane par article + délai par défaut, exclure l'artefact |
| `task_status_code` commande | Inclut PREVU / ENCOURS (commandes non reçues) | Ajoutés aux `accepted_values` |
| Fabrication : lien entrée ↔ sortie | Pas de document parent (`task_idtask` nul) → pas de BOM ERP | Rapprochement seulement en agrégé ; rendement non calculable en l'état (unités hétérogènes) |

## Tests

Buildé + testé en dev sur les 4 modèles : **tous les tests verts** (PK `unique`/`not_null`, FK, `accepted_values` sur statuts).

## Note qualité de données (hors code)
Un sanity check des flux commande/réception a été mené pour la logistique (dépôt VERT approvisionné sans commande = stock d'intrants torréfaction, label EN_ATTENTE obsolète, artefact go-live). Rapport transmis à la logistique — en attente de règles métier avant d'attaquer le mart de réappro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)