### PR TITLE
feat(supply-chain): backtest prévisions NESHU (V2.0, walk-forward champion-challenger)

### DIFF
--- a/models/marts/supply_chain/_supply_chain__marts_models.yml
+++ b/models/marts/supply_chain/_supply_chain__marts_models.yml
@@ -847,6 +847,110 @@ models:
           arguments:
             expression: "stock_securite >= 0"
 
+  - name: fct_supply_chain__erreur_prevision_neshu
+    description: |
+      [QUOI MÉTIER] Backtest de la prévision de demande Neshu : pour chaque mois passé, la prévision telle qu'elle aurait été calculée pendant ce mois (avec uniquement les données antérieures — walk-forward, pas de fuite du futur) face à la demande réelle. Fondation V2 : mesure l'erreur et le biais du forecast article par article, et arbitre les évolutions de méthode (champion-challenger). En V2.1, l'écart-type de l'erreur remplacera l'écart-type de la demande brute dans le stock de sécurité du point de commande.
+      [COMMENT CONSTRUITE] Rejeu déterministe des formules de fct_supply_chain__prevision_demande_neshu sur le socle int_oracle_neshu__demande_mensuelle, en remplaçant current_date() par chaque mois de coupure : prevision_moyenne_mobile = somme des N mois complets précédant le mois cible / N (var prevision_nb_mois_moyenne, défaut 3) ; prevision_saisonniere = demande N-1 sur la fenêtre [M-12, M-10] / 3 (fidèle à ③, fenêtre telle que vue pendant le mois cible) ; prevision_naive = demande de la fenêtre / nb de mois avec demande. prevision_retenue = la candidate routée par methode_prevision de fct_supply_chain__classification_article_neshu (classification ACTUELLE, non rejouée à date — limite assumée, cf. NOTES). erreur = demande_reelle − prevision_retenue (positive = sous-prévision). Mois cibles : janv. 2024 → dernier mois clos (généré à chaque build : le mois qui vient de se clore entre automatiquement). Un couple n'entre qu'à partir de son premier mois de demande.
+      [GRAIN] 1 ligne par (mois_cible, company_id, product_id) — full rebuild quotidien, ~10 000 lignes.
+      [NOTES] Les 3 méthodes candidates sont exposées côte à côte (champion-challenger) : comparer les colonnes suffit à arbitrer V2.1-V2.4 sans re-backtester. Le routage utilise la classification d'aujourd'hui, pas celle qu'on aurait eue à chaque date (rejouer Syntetos-Boylan/ABC à date = coût élevé, gain faible ; la vraie classif à date s'accumulera via le snapshot mensuel de la classification, volet séparé). Pas de MAPE au grain ligne (demande sparse → division par zéro) : erreurs en unités, WMAPE à calculer en agrégé. Filtrer nb_mois_anciennete >= 3 pour écarter les premiers mois de vie (fenêtre incomplète). date_calcul en fuseau Europe/Paris (contrairement aux marts V1, encore en UTC).
+    columns:
+      - name: mois_cible
+        description: "Mois prédit (1er du mois) : la prévision est rejouée comme calculée pendant ce mois, le réel est celui de ce mois"
+        tests:
+          - not_null
+      - name: company_id
+        description: "Identifiant du dépôt (FK vers dim_neshu__company)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__company')
+                field: company_id
+              config:
+                severity: warn
+      - name: product_id
+        description: "Identifiant du produit (FK vers dim_neshu__product)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('dim_neshu__product')
+                field: product_id
+              config:
+                severity: warn
+      - name: company_code
+        description: "Code du dépôt (ex. DEPOTRUNGIS), aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
+        tests:
+          - not_null
+      - name: company_name
+        description: "Nom du dépôt, aplati depuis dim_neshu__company (pattern hybride, attribut d'affichage)"
+      - name: product_code
+        description: "Code métier du produit"
+        tests:
+          - not_null
+      - name: product_name
+        description: "Nom du produit"
+      - name: statut_vie
+        description: "Statut cycle de vie hérité de la classification ACTUELLE (actif/inactif/arrete)"
+      - name: classe_abc
+        description: "Classe ABC en valeur héritée de la classification ACTUELLE (A/B/C, NULL si pas de demande récente)"
+      - name: methode_prevision
+        description: "Méthode routée par la classification ACTUELLE (moyenne_mobile, moyenne_mobile_surveille, reference_saisonniere, naif, exclu) — détermine prevision_retenue"
+        tests:
+          - not_null
+      - name: nb_mois_anciennete
+        description: "Ancienneté du couple au mois cible (mois écoulés depuis son premier mois de demande ; 0 = premier mois de vie). Filtrer >= 3 pour des fenêtres de prévision complètes"
+      - name: nb_mois_avec_demande
+        description: "Nombre de mois avec demande dans la fenêtre rejouée (dénominateur de la méthode naive)"
+      - name: demande_reelle
+        description: "Demande réelle du mois cible (unités, socle demande mensuelle ; 0 si aucune demande)"
+        tests:
+          - not_null
+      - name: prevision_moyenne_mobile
+        description: "Candidate : moyenne mobile des N mois complets précédant le mois cible (rejouée)"
+      - name: prevision_saisonniere
+        description: "Candidate : référence saisonnière N-1, fenêtre [M-12, M-10] / 3 (rejouée)"
+      - name: prevision_naive
+        description: "Candidate : moyenne des mois avec demande dans la fenêtre (rejouée)"
+      - name: prevision_retenue
+        description: "Prévision de la méthode routée par la classification (0 pour exclu) — celle que le système aurait servie au point de commande"
+        tests:
+          - not_null
+      - name: erreur
+        description: "Erreur signée = demande_reelle − prevision_retenue. Positive = sous-prévision (le réel a dépassé la prévision). Sa moyenne par couple = le biais ; son écart-type = le sigma d'erreur (V2.1)"
+        tests:
+          - not_null
+      - name: erreur_absolue
+        description: "Valeur absolue de l'erreur (unités) — base du MAE par article"
+      - name: date_calcul
+        description: "Date d'exécution du calcul (fuseau Europe/Paris)"
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - mois_cible
+              - company_id
+              - product_id
+      # cohérence : une prévision n'est jamais négative
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "prevision_retenue >= 0 and prevision_moyenne_mobile >= 0 and prevision_saisonniere >= 0"
+      # invariant : un article exclu a une prévision retenue nulle
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "methode_prevision != 'exclu' or prevision_retenue = 0"
+      # cohérence : l'erreur absolue est bien la valeur absolue de l'erreur signée
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "erreur_absolue = abs(erreur)"
+      # garde-fou volumétrie : ~342 couples x ~30 mois, moins l'entrée en vie des jeunes articles
+      - dbt_expectations.expect_table_row_count_to_be_between:
+          arguments:
+            min_value: 4000
+            max_value: 30000
+          config:
+            severity: warn
+
   - name: fct_supply_chain__disponibilite_article_lcdp_depot_mensuel
     description: |
       [QUOI MÉTIER] Taux de disponibilité mensuel des articles dans les dépôts LCDP : part des jours du mois où l'article était en stock (> 0).

--- a/models/marts/supply_chain/fct_supply_chain__erreur_prevision_neshu.sql
+++ b/models/marts/supply_chain/fct_supply_chain__erreur_prevision_neshu.sql
@@ -1,0 +1,200 @@
+{{
+    config(
+        materialized='table',
+        cluster_by=['company_id', 'product_id']
+    )
+}}
+
+-- Backtest « prévision rejouée vs réel » (V2.0 — fondation de la feuille de route V2).
+-- Pour chaque mois cible passé, rejoue les 3 méthodes de prévision V1 telles qu'elles
+-- auraient été calculées pendant ce mois (walk-forward : seules les données STRICTEMENT
+-- antérieures au mois cible sont visibles — pas de fuite du futur), puis compare au réel.
+-- Possible sans ré-entraînement car les méthodes sont des formules déterministes de
+-- l'historique : on remplace le current_date() de la prévision (③) par le mois de coupure.
+-- Champion-challenger : les 3 candidates sont exposées côte à côte pour arbitrer les
+-- évolutions V2.1+ (sigma d'erreur, Croston, saisonniers) sans re-backtester.
+-- Limite assumée : prevision_retenue route selon la classification ACTUELLE (②), pas
+-- celle rejouée à chaque date (la classif à date s'accumulera via le snapshot mensuel).
+
+with classification as (
+
+    select
+        company_id,
+        product_id,
+        company_code,
+        company_name,
+        product_code,
+        product_name,
+        statut_vie,
+        classe_abc,
+        methode_prevision
+    from {{ ref('fct_supply_chain__classification_article_neshu') }}
+
+),
+
+mois_cibles as (
+
+    -- Mois complets rejoués : janv. 2024 (le socle démarre déc. 2022 -> 13 mois d'amont,
+    -- la référence saisonnière N-1 est toujours couverte) jusqu'au dernier mois clos.
+    -- Le mois qui vient de se clore entre automatiquement au build suivant.
+    select mois_cible
+    from unnest(generate_date_array(
+        date '2024-01-01',
+        date_sub(date_trunc(current_date('Europe/Paris'), month), interval 1 month),
+        interval 1 month
+    )) as mois_cible
+
+),
+
+premiere_demande as (
+
+    select
+        company_id,
+        product_id,
+        min(demande_mois) as premiere_demande_mois
+    from {{ ref('int_oracle_neshu__demande_mensuelle') }}
+    group by company_id, product_id
+
+),
+
+grille as (
+
+    -- Un couple n'entre dans le backtest qu'à partir de son premier mois de demande
+    -- (avant : prévision 0 vs réel 0 = lignes vides qui flatteraient les erreurs).
+    select
+        c.company_id,
+        c.product_id,
+        c.company_code,
+        c.company_name,
+        c.product_code,
+        c.product_name,
+        c.statut_vie,
+        c.classe_abc,
+        c.methode_prevision,
+        m.mois_cible,
+        date_diff(m.mois_cible, p.premiere_demande_mois, month) as nb_mois_anciennete
+    from classification as c
+    inner join premiere_demande as p
+        on c.company_id = p.company_id and c.product_id = p.product_id
+    inner join mois_cibles as m
+        on p.premiere_demande_mois <= m.mois_cible
+
+),
+
+retropolation as (
+
+    -- Rejoue, pour chaque (couple, mois cible), les agrégats que la prévision (③) aurait
+    -- calculés pendant ce mois : fenêtre = N mois complets avant le mois cible ;
+    -- saison = fenêtre N-1 telle que vue pendant le mois cible ([M-12, M-10], fidèle à ③).
+    select
+        g.company_id,
+        g.product_id,
+        g.mois_cible,
+        coalesce(sum(
+            case
+                when
+                    s.demande_mois >= date_sub(
+                        g.mois_cible, interval {{ var('prevision_nb_mois_moyenne', 3) }} month
+                    )
+                    and s.demande_mois < g.mois_cible
+                    then s.quantite_demandee
+            end
+        ), 0) as demande_fenetre,
+        count(
+            case
+                when
+                    s.demande_mois >= date_sub(
+                        g.mois_cible, interval {{ var('prevision_nb_mois_moyenne', 3) }} month
+                    )
+                    and s.demande_mois < g.mois_cible
+                    then s.demande_mois
+            end
+        ) as nb_mois_avec_demande,
+        coalesce(sum(
+            case
+                when
+                    s.demande_mois between date_sub(g.mois_cible, interval 12 month)
+                    and date_sub(g.mois_cible, interval 10 month)
+                    then s.quantite_demandee
+            end
+        ), 0) as demande_saison_n1_totale,
+        coalesce(sum(
+            case when s.demande_mois = g.mois_cible then s.quantite_demandee end
+        ), 0) as demande_reelle
+    from grille as g
+    left join {{ ref('int_oracle_neshu__demande_mensuelle') }} as s
+        on
+            g.company_id = s.company_id
+            and g.product_id = s.product_id
+            and s.demande_mois between date_sub(g.mois_cible, interval 12 month) and g.mois_cible
+    group by g.company_id, g.product_id, g.mois_cible
+
+),
+
+previsions as (
+
+    select
+        g.mois_cible,
+        g.company_id,
+        g.product_id,
+        g.company_code,
+        g.company_name,
+        g.product_code,
+        g.product_name,
+        g.statut_vie,
+        g.classe_abc,
+        g.methode_prevision,
+        g.nb_mois_anciennete,
+        r.demande_reelle,
+        r.nb_mois_avec_demande,
+        round(r.demande_fenetre / {{ var('prevision_nb_mois_moyenne', 3) }}, 2)
+            as prevision_moyenne_mobile,
+        round(r.demande_saison_n1_totale / 3, 2) as prevision_saisonniere,
+        round(
+            safe_divide(r.demande_fenetre, greatest(r.nb_mois_avec_demande, 1)), 2
+        ) as prevision_naive
+    from grille as g
+    inner join retropolation as r
+        on
+            g.company_id = r.company_id
+            and g.product_id = r.product_id
+            and g.mois_cible = r.mois_cible
+
+),
+
+final as (
+
+    select
+        *,
+        case
+            when methode_prevision = 'exclu' then 0
+            when methode_prevision = 'reference_saisonniere' then prevision_saisonniere
+            when methode_prevision = 'naif' then prevision_naive
+            else prevision_moyenne_mobile
+        end as prevision_retenue
+    from previsions
+
+)
+
+select
+    mois_cible,
+    company_id,
+    product_id,
+    company_code,
+    company_name,
+    product_code,
+    product_name,
+    statut_vie,
+    classe_abc,
+    methode_prevision,
+    nb_mois_anciennete,
+    nb_mois_avec_demande,
+    demande_reelle,
+    prevision_moyenne_mobile,
+    prevision_saisonniere,
+    prevision_naive,
+    prevision_retenue,
+    round(demande_reelle - prevision_retenue, 2) as erreur,
+    round(abs(demande_reelle - prevision_retenue), 2) as erreur_absolue,
+    current_date('Europe/Paris') as date_calcul
+from final


### PR DESCRIPTION
## Quoi

Nouveau mart **`fct_supply_chain__erreur_prevision_neshu`** — le backtest de la chaîne forecast NESHU, première brique de la feuille de route V2 (doc méthodologie §10).

Pour chaque mois passé (janv. 2024 → dernier mois clos), il rejoue les 3 méthodes de prévision V1 **telles qu'elles auraient été calculées pendant ce mois** — seules les données strictement antérieures au mois cible sont visibles (walk-forward, pas de fuite du futur) — puis les compare à la demande réelle.

## Pourquoi

1. **Mesurer** : erreur et biais du forecast article par article, sur tout l'historique, régénéré chaque nuit (le mois qui se clôt entre automatiquement).
2. **Alimenter V2.1** : l'écart-type de l'erreur remplacera l'écart-type de la demande brute dans le stock de sécurité du point de commande (le levier principal : la sécurité pèse 70-80 % du seuil).
3. **Arbitrer** : les 3 méthodes candidates sont exposées côte à côte (champion-challenger) → chaque évolution V2.2-V2.4 se tranche par une requête, sans re-backtester.

## Comment

- Rejeu déterministe des formules de `fct_supply_chain__prevision_demande_neshu` (`current_date()` → mois de coupure). Fidèle à ③, y compris la fenêtre saisonnière [M-12, M-10].
- Grain : 1 ligne par (mois_cible, company_id, product_id) — ~7 900 lignes, full rebuild.
- `erreur = demande_reelle − prevision_retenue` (positive = sous-prévision).
- Un couple n'entre qu'à partir de son premier mois de demande ; `nb_mois_anciennete` exposé pour filtrer les fenêtres incomplètes.
- **Limite assumée (documentée)** : `prevision_retenue` route selon la classification actuelle, non rejouée à date ; les colonnes candidates compensent, la classif à date s'accumulera via le futur snapshot mensuel de ②.
- `date_calcul` en **Europe/Paris** (nouveau standard ; les marts V1 restent en UTC, alignement ultérieur).

## Validation (dev, 15/07/2026)

- Build + 16 tests : **17/17 PASS** (unicité du grain, invariants exclu/abs, relationships, volumétrie).
- **Match exact** avec les cas de référence du doc méthodologie : LCDP529 Rungis → σ demande 311, biais MA3 +144, σ erreur 150.
- Premiers verdicts champion-challenger (12 derniers mois, ancienneté ≥ 3) : MA3 24 % de WMAPE (biais +54 = sous-prévision en croissance → V2.1) ; routage saisonnier 32,1 % vs 46,5 % si MA3 (Kinder Bueno sept. 2025 : réel 1 710, saisonnière 2 400, MA3 80) ; surveille 80,8 % (→ périmètre Croston V2.3) ; naïf 313 % (→ V2.2) ; 3 relances manquées détectées (NESPINTENSO Lyon 5 700 u → V2.5).

## Impact

Purement additif : ne touche ni ③ ni ④ — aucun chiffre existant ne bouge pendant l'évaluation métier de la V1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)