### PR TITLE
feat(apptech): ingestion suivi_tech pause + rw (tables externes GCS)

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -37,6 +37,9 @@ models:
       +schema: staging
       +tags: ['staging']
 
+      apptech:
+        +tags: ['staging', 'apptech']
+
       yuman:
         +tags: ['staging', 'yuman']
 

--- a/models/staging/apptech/_apptech__models.yml
+++ b/models/staging/apptech/_apptech__models.yml
@@ -1,0 +1,103 @@
+version: 2
+
+models:
+  - name: stg_apptech__suivi_tech_pause
+    description: >
+      Overrides de prime "pause" saisis dans l'app suivi technique : une ligne =
+      une intervention dont la prime doit être doublée (ou non). Dedup snapshot :
+      seules les lignes du dernier fichier NDJSON de chaque mois sont conservées
+      (une ligne absente du dernier snapshot = override révoqué). Pas de test de
+      freshness : soumissions humaines sans cadence garantie. La jointure vers le
+      référentiel d'interventions est gérée en aval (intermediate).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - intervention_id
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING, non vérifié contre un référentiel à ce stade)"
+        tests:
+          - not_null
+      - name: doubler_prime
+        description: "Décision de doublement de la prime (normalisé en majuscules)"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['OUI', 'NON']
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
+  - name: stg_apptech__suivi_tech_rw
+    description: >
+      Re-mappings d'interventions (rework) saisis dans l'app suivi technique :
+      une ligne = un id d'intervention erroné réaffecté vers le bon id, avec le
+      technicien concerné. Dedup snapshot : seules les lignes du dernier fichier
+      NDJSON de chaque mois sont conservées. Pas de test de freshness :
+      soumissions humaines sans cadence garantie.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - bad_intervention_id
+      # Cohérence saisie : le mois porté par les enregistrements doit matcher
+      # le dossier GCS dans lequel le fichier a été déposé.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "periode = format('%04d-%02d', annee, mois)"
+          config:
+            severity: warn
+      # Un re-mapping d'un id vers lui-même est presque sûrement une erreur de saisie.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "bad_intervention_id != new_intervention_id"
+          config:
+            severity: warn
+    columns:
+      - name: bad_intervention_id
+        description: "Id d'intervention erroné (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: new_intervention_id
+        description: "Id d'intervention corrigé (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: tech_id
+        description: "Identifiant du technicien concerné"
+      - name: tech_nom
+        description: "Nom du technicien (tel que saisi)"
+      - name: tech_secteur
+        description: "Secteur du technicien (normalisé en minuscules, ex. 'evs idf')"
+      - name: annee
+        description: "Année portée par l'enregistrement source"
+      - name: mois
+        description: "Mois (1-12) porté par l'enregistrement source"
+      - name: source
+        description: "Fichier Excel d'origine de la correction (traçabilité amont, ex. 'RW EVS IDF 2026-02.xlsx')"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null

--- a/models/staging/apptech/_apptech__sources.yml
+++ b/models/staging/apptech/_apptech__sources.yml
@@ -1,0 +1,27 @@
+version: 2
+
+sources:
+  - name: apptech
+    description: >
+      Retraitements d'interventions techniques saisis via l'app interne de suivi
+      technique (SA evs-app-tech), déposés en NDJSON dans
+      gs://evs-datastack-apptech/suivi_tech/ingestion/<type>/<YYYY-MM>/<timestampZ>.ndjson
+      et exposés en tables externes BigQuery (cf. infra/bigquery_external_tables.tf).
+      Contrat avec l'app : fichiers immuables (toute modification = nouveau fichier
+      horodaté), chaque fichier = snapshot COMPLET du (type, mois). Le dossier
+      drafts/ du bucket est de l'état applicatif et n'est jamais lu ici.
+      Pas de freshness déclarée : soumissions humaines événementielles, sans
+      cadence garantie (un test de récence flapperait).
+    database: "{{ var('raw_project') }}"
+    schema: "prod_raw"
+    tables:
+      - name: ext_gcs_apptech__suivi_tech_pause
+        description: >
+          Overrides de prime "pause" : une ligne = une intervention dont la prime
+          doit être doublée (ou non), avec commentaire libre du manager.
+      - name: ext_gcs_apptech__suivi_tech_rw
+        description: >
+          Re-mappings d'interventions (rework) : une ligne = un id d'intervention
+          erroné (bad_intervention_id) réaffecté vers le bon id
+          (new_intervention_id), avec le technicien concerné et le fichier Excel
+          d'origine de la correction.

--- a/models/staging/apptech/stg_apptech__suivi_tech_pause.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_pause.sql
@@ -1,0 +1,49 @@
+{{
+    config(
+        materialized='table',
+        description="Overrides de prime pause par intervention, depuis les snapshots NDJSON de l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        intervention_id,
+        doubler_prime,
+        commentaire,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_pause') }}
+
+),
+
+cleaned_data as (
+
+    select
+        intervention_id,
+        upper(trim(doubler_prime)) as doubler_prime,
+        nullif(trim(commentaire), '') as commentaire,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/pause/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/pause/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : chaque fichier ré-émet l'état complet du mois pour son
+-- type ; seul le dernier fichier de chaque mois fait foi (une ligne absente du
+-- dernier snapshot = override révoqué). L'historique complet reste dans GCS.
+select
+    intervention_id,
+    doubler_prime,
+    commentaire,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)

--- a/models/staging/apptech/stg_apptech__suivi_tech_rw.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_rw.sql
@@ -1,0 +1,63 @@
+{{
+    config(
+        materialized='table',
+        description="Re-mappings d'interventions (rework) par technicien, depuis les snapshots NDJSON de l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        bad_intervention_id,
+        new_intervention_id,
+        tech_id,
+        tech_nom,
+        tech_secteur,
+        annee,
+        mois,
+        source,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_rw') }}
+
+),
+
+cleaned_data as (
+
+    select
+        bad_intervention_id,
+        new_intervention_id,
+        tech_id,
+        tech_nom,
+        lower(trim(tech_secteur)) as tech_secteur,
+        annee,
+        mois,
+        source,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/rw/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/rw/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    bad_intervention_id,
+    new_intervention_id,
+    tech_id,
+    tech_nom,
+    tech_secteur,
+    annee,
+    mois,
+    source,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)


### PR DESCRIPTION
## Quoi

Nouvelle source `apptech` : retraitements d'interventions techniques saisis via l'app interne (bucket `evs-datastack-apptech`), exposés en tables externes BigQuery et stagés avec dedup snapshot.

- `stg_apptech__suivi_tech_pause` — overrides de prime pause (7 lignes en prod aujourd'hui)
- `stg_apptech__suivi_tech_rw` — re-mappings d'interventions (48 lignes, 2 mois)

## Design

- **Contrat app** (accordé avec l'analyste) : fichiers NDJSON immuables `ingestion/<type>/<YYYY-MM>/<timestampZ>.ndjson`, chaque fichier = snapshot complet du (type, mois). `drafts/` jamais lu.
- **Dedup snapshot** : seul le dernier fichier de chaque mois fait foi (`qualify extracted_at = max(...) over (partition by periode)`) ; une ligne absente du dernier snapshot = override révoqué. Historique complet conservé dans GCS.
- **Pas de freshness** : soumissions humaines événementielles, un test de récence flapperait.
- Jointures vers les référentiels d'interventions : gérées en aval (hors scope PR).

## Infra (déjà appliquée — terraform master 80b6cdd)

Tables externes `prod_raw.ext_gcs_apptech__suivi_tech_{pause,rw}` (schéma explicite, `ignore_unknown_values`) + grants `objectViewer` bucket pour dbt_analysts / meltano_runner / dbt_dev. Plan appliqué : 5 add, 0 change, 0 destroy.

## Validation

- `dbt build --select tag:apptech --target dev` : **15/15 PASS** (2 modèles, 13 tests), 0 warn
- SQLFluff clean, `dbt parse` sans warning
- Regex chemin GCS + parse timestamp validés par requête BigQuery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMJfTsVK7UCaGheg4kvAj2