### PR TITLE
feat(apptech): ingestion des 6 types restants (aguila, astreinte, curative, events, mee, modif_intervention)

### DIFF
--- a/docs/apptech_ingestion.md
+++ b/docs/apptech_ingestion.md
@@ -1,0 +1,123 @@
+# Ingestion apptech — suivi technique (contexte & pattern)
+
+> Doc de référence de la source `apptech` (app interne de suivi technique).
+> Itération 1 (types `pause` + `rw`) : PR #178 + infra `80b6cdd`, appliquée.
+> Itération 2 (2026-07-15) : les 6 types suivants (`aguila`, `astreinte`,
+> `curative`, `events`, `mee`, `modif_intervention`) — tables externes
+> appliquées + staging/tests dans cette PR. **Les 8 types du bucket sont
+> couverts.** Pour un futur type : checklist §4.
+
+## 1. Contexte
+
+L'**app interne de suivi technique** (construite par l'analyste, SA `evs-app-tech`)
+sert aux managers à saisir des **retraitements sur les interventions techniques**
+(overrides de primes, re-mappings d'ids, événements techniciens…). Elle écrit des
+NDJSON dans `gs://evs-datastack-apptech/suivi_tech/`.
+
+### Contrat avec l'app (accordé avec l'analyste, 2026-07)
+
+- Layout : `suivi_tech/ingestion/<type>/<YYYY-MM>/<timestampZ>.ndjson`
+  (ex. `pause/2026-06/20260710T074944Z.ndjson`).
+- Fichiers **immuables** : toute modification = **nouveau fichier horodaté**,
+  jamais d'écrasement.
+- Chaque fichier = **snapshot COMPLET du (type, mois)** → seul le dernier fichier
+  d'un mois fait foi ; une ligne absente du dernier snapshot = retraitement révoqué.
+- `suivi_tech/drafts/` = état applicatif interne : **ne jamais le lire**.
+- Ajout d'un champ par l'app : annoncé, puis répliqué dans le schéma TF
+  (`ignore_unknown_values = true` protège entre-temps).
+
+## 2. Ce qui existe déjà
+
+### Infra (`/mnt/data/infra`, master, appliqué)
+
+- `bigquery_external_tables.tf` : tables externes `prod_raw.ext_gcs_apptech__suivi_tech_pause`
+  et `_rw` — NDJSON, **schéma explicite** (pas d'autodetect), `ignore_unknown_values`,
+  URI glob `.../ingestion/<type>/*.ndjson` (traverse les dossiers mensuels).
+  Naming : `ext_gcs_apptech__suivi_tech_<type>`.
+- `app_data_access.tf` : `locals.apptech_bucket_readers` → grant `storage.objectViewer`
+  sur le bucket pour `dbt_analysts`, `meltano_runner`, `dbt_dev` (BigQuery lit GCS
+  avec les droits du principal requêteur). **Déjà en place — rien à ajouter en IAM
+  pour un nouveau type.**
+
+### dbt (ce repo)
+
+- `models/staging/apptech/` : `_apptech__sources.yml`, `_apptech__models.yml`,
+  `stg_apptech__suivi_tech_pause.sql`, `stg_apptech__suivi_tech_rw.sql`.
+- Tag `apptech` hérité par dossier (`dbt_project.yml`) — un nouveau modèle dans le
+  dossier est taggé automatiquement.
+- Validé : `dbt build --select tag:apptech --target dev` → 15/15 PASS.
+
+### Le pattern staging (à répliquer pour chaque type)
+
+Voir `stg_apptech__suivi_tech_pause.sql` — structure `source_data` → `cleaned_data`
+→ select final avec :
+
+- Métadonnées dérivées de `_file_name` : `periode` (regex sur le dossier
+  `YYYY-MM`), `source_file`, `extracted_at`
+  (`safe.parse_timestamp('%Y%m%dT%H%M%SZ', …)` sur le nom de fichier).
+- **Dedup snapshot** : `qualify extracted_at = max(extracted_at) over (partition by periode)`.
+- Nettoyage léger : `nullif(trim(...), '')` sur les champs libres, `upper`/`lower`
+  sur les codes. Passthrough des noms de colonnes (convention staging).
+- Matérialisation `table` (défaut), pas de partition (volumes minuscules).
+- Tests (syntaxe dbt ≥ 1.11 : `arguments:` + severity sous `config:`) :
+  `unique_combination_of_columns (periode, <clé>)`, `not_null` sur clé/periode/extracted_at,
+  `accepted_values` sur les codes, `expression_is_true` en `warn` pour les
+  cohérences de saisie. **Pas de freshness** (soumissions humaines événementielles).
+
+## 3. Les 6 types de l'itération 2 (intégrés — schémas observés au 2026-07-15)
+
+Schémas profilés sur l'ensemble des fichiers du bucket :
+
+| Type | Clé probable | Champs observés |
+|---|---|---|
+| `aguila` | `intervention_id` | `intervention_id` (str), `convertir_code_5` (OUI/NON), `commentaire` |
+| `astreinte` | `intervention_id` | `intervention_id` (str), `tech_id_reel` (str, ex. `tec-00056`), `tech_yuman_id_reel` (**number**), `commentaire` |
+| `curative` | `intervention_id` | `intervention_id` (str), `delai_tech_force` (str, ex. `J+0`), `delai_partenaire_force` (str), `commentaire` |
+| `events` | `evt_id` (**pas** intervention_id) | `evt_id` (**number**), `evt_tech_yuman_id` (number), `evt_tech_name`, `evt_tech_secteur`, `evt_event_type` (ex. `Conges`), `evt_event_unit` (ex. `Journee`), `evt_event_valeur` (**float**), `evt_event_date` (str `YYYY-MM-DD`), `evt_event_manager_comment`, `mois` (number), `annee` (number) |
+| `mee` | `intervention_id` | `intervention_id` (str), `a_facturer` (OUI/NON), `commentaire` |
+| `modif_intervention` | `intervention_id` | `intervention_id` (str), `a_facturer` (str, **peut être `""`** → nullif), `tech_id_reel` (str), `tech_yuman_id_reel` (number), `commentaire` |
+
+Points d'attention :
+
+- **Types JSON ≠ CSV** : le schéma de la table externe doit matcher le type JSON
+  réel — ids saisis = STRING même si numériques ; `tech_yuman_id_reel`, `evt_id`,
+  `mois`, `annee` = INT64 ; `evt_event_valeur` = **FLOAT64** (5.0 dans le JSON).
+  Vérifier sur plusieurs lignes avant de figer (échantillonner via
+  `gcloud storage cat gs://…/<type>/**/*.ndjson | head`).
+- `events` vit sur un **référentiel différent** (événements techniciens, pas
+  interventions) : clé `evt_id` — confirmer avec l'analyste si `evt_id` est unique
+  globalement ou par mois ; il porte aussi `mois`/`annee` → répliquer le test
+  `expression_is_true` de cohérence avec `periode` (cf. rw).
+- `pause` a maintenant **2 fichiers sur 2026-06** → le dedup snapshot est exercé
+  en réel pour la première fois : après build, vérifier que seules les lignes du
+  fichier `20260715T121911Z` sortent du staging.
+- Étendre la description de `accepted_values` seulement sur les codes confirmés
+  (OUI/NON) ; pour `delai_*_force` demander la liste des valeurs possibles avant
+  de contraindre (sinon `not_null` seul).
+
+## 4. Checklist pour ajouter un type
+
+1. **Infra d'abord** (`/mnt/data/infra`, direct sur master — pas de branche) :
+   ajouter `resource "google_bigquery_table" "ext_gcs_apptech_suivi_tech_<type>"`
+   dans `bigquery_external_tables.tf` (copier le bloc pause, adapter schéma + URI).
+   `terraform validate` → `plan` (ne doit montrer QUE les adds attendus) → `apply`.
+   Sanity : `bq query 'select count(*), count(distinct _file_name) from prod_raw.ext_gcs_apptech__suivi_tech_<type>'`.
+2. **dbt** (branche feature depuis master) : entrée dans `_apptech__sources.yml`,
+   `stg_apptech__suivi_tech_<type>.sql` (pattern §2), doc + tests dans
+   `_apptech__models.yml`. Rien à toucher dans `dbt_project.yml` (tag hérité).
+3. **Valider** : `sqlfluff lint models/staging/apptech/` puis
+   `dbt build --select tag:apptech --target dev` (env : `source dbt_venv/bin/activate`
+   + `set -a && source .env && set +a`).
+4. PR → Slim CI ne build que les nouveaux nœuds → squash merge → CD prod.
+
+Style : guillemets **doubles** pour les strings Jinja contenant des apostrophes
+(pas de `\'`) ; conventions staging dans `docs/conventions/staging.md`.
+
+## 5. Aval (hors scope ingestion, à la main de Cebrail)
+
+- Jointures des `intervention_id` vers les référentiels (formats différents selon
+  les types : ids courts ~5 chiffres vs longs ~7 chiffres — référentiels distincts
+  à confirmer, probablement Yuman workorders vs interventions Nomad/nesp_tech).
+- Tests `relationships` en `warn` vers les staging d'interventions une fois les
+  référentiels confirmés (filet anti-fautes de saisie).
+- Branchement dans les marts (primes, facturation, planning technicien).

--- a/models/staging/apptech/_apptech__models.yml
+++ b/models/staging/apptech/_apptech__models.yml
@@ -42,6 +42,268 @@ models:
         tests:
           - not_null
 
+  - name: stg_apptech__suivi_tech_aguila
+    description: >
+      Overrides Aguila (conversion du code 5) par intervention. Dedup snapshot :
+      seules les lignes du dernier fichier NDJSON de chaque mois sont conservées.
+      Pas de test de freshness (soumissions humaines).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - intervention_id
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: convertir_code_5
+        description: "Décision de conversion du code 5 (normalisé en majuscules)"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['OUI', 'NON']
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
+  - name: stg_apptech__suivi_tech_astreinte
+    description: >
+      Réaffectations d'astreinte : technicien réel ayant effectué l'intervention.
+      Dedup snapshot : seules les lignes du dernier fichier NDJSON de chaque mois
+      sont conservées. Pas de test de freshness (soumissions humaines).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - intervention_id
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: tech_id_reel
+        description: "Identifiant interne du technicien réel (normalisé en minuscules, ex. 'tec-00056')"
+        tests:
+          - not_null:
+              config:
+                severity: warn
+      - name: tech_yuman_id_reel
+        description: "Identifiant Yuman du technicien réel"
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
+  - name: stg_apptech__suivi_tech_curative
+    description: >
+      Délais forcés (technicien/partenaire) sur interventions curatives. Domaine
+      des délais non contraint (valeurs observées J+0/J+1/J+2 — liste complète à
+      confirmer avec l'analyste avant un accepted_values). Dedup snapshot : seules
+      les lignes du dernier fichier NDJSON de chaque mois sont conservées.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - intervention_id
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: delai_tech_force
+        description: "Délai technicien forcé (normalisé en majuscules, ex. 'J+0')"
+      - name: delai_partenaire_force
+        description: "Délai partenaire forcé (normalisé en majuscules, ex. 'J+2')"
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
+  - name: stg_apptech__suivi_tech_events
+    description: >
+      Événements techniciens (congés, maladie, astreinte…) — référentiel distinct
+      des interventions (clé evt_id). Dedup snapshot : seules les lignes du
+      dernier fichier NDJSON de chaque mois sont conservées. Pas de test de
+      freshness (soumissions humaines).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - evt_id
+      # Cohérence saisie : le mois porté par les enregistrements doit matcher
+      # le dossier GCS dans lequel le fichier a été déposé.
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "periode = format('%04d-%02d', annee, mois)"
+          config:
+            severity: warn
+    columns:
+      - name: evt_id
+        description: "Identifiant de l'événement (attribué par l'app)"
+        tests:
+          - not_null
+      - name: evt_tech_yuman_id
+        description: "Identifiant Yuman du technicien concerné"
+        tests:
+          - not_null:
+              config:
+                severity: warn
+      - name: evt_tech_name
+        description: "Nom du technicien (tel que saisi)"
+      - name: evt_tech_secteur
+        description: "Secteur du technicien (normalisé en minuscules, ex. 'evs aura')"
+      - name: evt_event_type
+        description: "Type d'événement (ex. Conges, Maladie, Astreinte — domaine ouvert)"
+        tests:
+          - not_null
+      - name: evt_event_unit
+        description: "Unité de la valeur (Journee / Heure observés)"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['Journee', 'Heure']
+              config:
+                severity: warn
+      - name: evt_event_valeur
+        description: "Valeur de l'événement dans l'unité donnée (FLOAT, ex. 5.0 jours)"
+      - name: evt_event_date
+        description: "Date de l'événement (DATE, parsée depuis YYYY-MM-DD)"
+      - name: evt_event_manager_comment
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: annee
+        description: "Année portée par l'enregistrement source"
+      - name: mois
+        description: "Mois (1-12) porté par l'enregistrement source"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
+  - name: stg_apptech__suivi_tech_mee
+    description: >
+      Décisions de facturation des mises en exploitation (MEE) par intervention.
+      Dedup snapshot : seules les lignes du dernier fichier NDJSON de chaque mois
+      sont conservées. Pas de test de freshness (soumissions humaines).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - intervention_id
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: a_facturer
+        description: "Décision de facturation de la MEE (normalisé en majuscules)"
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['OUI', 'NON']
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
+  - name: stg_apptech__suivi_tech_modif_intervention
+    description: >
+      Modifications d'intervention (décision de facturation éventuelle et/ou
+      technicien réel). a_facturer peut être NULL (modif sans décision de
+      facturation). Dedup snapshot : seules les lignes du dernier fichier NDJSON
+      de chaque mois sont conservées. Pas de test de freshness (soumissions humaines).
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - periode
+              - intervention_id
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        tests:
+          - not_null
+      - name: a_facturer
+        description: "Décision de facturation (normalisé en majuscules, NULL si non renseignée)"
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['OUI', 'NON']
+      - name: tech_id_reel
+        description: "Identifiant interne du technicien réel (normalisé en minuscules, ex. 'tec-01003')"
+      - name: tech_yuman_id_reel
+        description: "Identifiant Yuman du technicien réel"
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)"
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS"
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)"
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour ce mois"
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot (parsé depuis son nom, UTC)"
+        tests:
+          - not_null
+
   - name: stg_apptech__suivi_tech_rw
     description: >
       Re-mappings d'interventions (rework) saisis dans l'app suivi technique :

--- a/models/staging/apptech/_apptech__sources.yml
+++ b/models/staging/apptech/_apptech__sources.yml
@@ -25,3 +25,30 @@ sources:
           erroné (bad_intervention_id) réaffecté vers le bon id
           (new_intervention_id), avec le technicien concerné et le fichier Excel
           d'origine de la correction.
+      - name: ext_gcs_apptech__suivi_tech_aguila
+        description: >
+          Overrides Aguila : une ligne = une intervention dont le code 5 doit
+          être converti (ou non), avec commentaire du manager.
+      - name: ext_gcs_apptech__suivi_tech_astreinte
+        description: >
+          Réaffectations d'astreinte : une ligne = une intervention dont le
+          technicien réel diffère de celui planifié (tech_id_reel +
+          tech_yuman_id_reel).
+      - name: ext_gcs_apptech__suivi_tech_curative
+        description: >
+          Délais forcés sur interventions curatives : une ligne = une
+          intervention dont les délais technicien/partenaire sont surchargés
+          manuellement (ex. J+0, J+2).
+      - name: ext_gcs_apptech__suivi_tech_events
+        description: >
+          Événements techniciens (congés, maladie, astreinte…) — référentiel
+          distinct des interventions : clé evt_id, avec type/unité/valeur et
+          date de l'événement.
+      - name: ext_gcs_apptech__suivi_tech_mee
+        description: >
+          Mises en exploitation (MEE) : une ligne = une intervention avec la
+          décision de facturation (a_facturer OUI/NON).
+      - name: ext_gcs_apptech__suivi_tech_modif_intervention
+        description: >
+          Modifications d'intervention : une ligne = une intervention corrigée
+          (décision de facturation éventuelle et/ou technicien réel).

--- a/models/staging/apptech/stg_apptech__suivi_tech_aguila.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_aguila.sql
@@ -1,0 +1,48 @@
+{{
+    config(
+        materialized='table',
+        description="Overrides Aguila (conversion code 5) par intervention, depuis les snapshots NDJSON de l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        intervention_id,
+        convertir_code_5,
+        commentaire,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_aguila') }}
+
+),
+
+cleaned_data as (
+
+    select
+        intervention_id,
+        upper(trim(convertir_code_5)) as convertir_code_5,
+        nullif(trim(commentaire), '') as commentaire,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/aguila/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/aguila/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    intervention_id,
+    convertir_code_5,
+    commentaire,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)

--- a/models/staging/apptech/stg_apptech__suivi_tech_astreinte.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_astreinte.sql
@@ -1,0 +1,51 @@
+{{
+    config(
+        materialized='table',
+        description="Réaffectations d'astreinte (technicien réel) par intervention, depuis les snapshots NDJSON de l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        intervention_id,
+        tech_id_reel,
+        tech_yuman_id_reel,
+        commentaire,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_astreinte') }}
+
+),
+
+cleaned_data as (
+
+    select
+        intervention_id,
+        lower(trim(tech_id_reel)) as tech_id_reel,
+        tech_yuman_id_reel,
+        nullif(trim(commentaire), '') as commentaire,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/astreinte/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/astreinte/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    intervention_id,
+    tech_id_reel,
+    tech_yuman_id_reel,
+    commentaire,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)

--- a/models/staging/apptech/stg_apptech__suivi_tech_curative.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_curative.sql
@@ -1,0 +1,51 @@
+{{
+    config(
+        materialized='table',
+        description="Délais forcés (technicien/partenaire) par intervention curative, depuis les snapshots NDJSON de l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        intervention_id,
+        delai_tech_force,
+        delai_partenaire_force,
+        commentaire,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_curative') }}
+
+),
+
+cleaned_data as (
+
+    select
+        intervention_id,
+        upper(trim(delai_tech_force)) as delai_tech_force,
+        upper(trim(delai_partenaire_force)) as delai_partenaire_force,
+        nullif(trim(commentaire), '') as commentaire,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/curative/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/curative/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    intervention_id,
+    delai_tech_force,
+    delai_partenaire_force,
+    commentaire,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)

--- a/models/staging/apptech/stg_apptech__suivi_tech_events.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_events.sql
@@ -1,0 +1,72 @@
+{{
+    config(
+        materialized='table',
+        description="Événements techniciens (congés, maladie, astreinte…) saisis dans l'app suivi technique — référentiel distinct des interventions"
+    )
+}}
+
+with source_data as (
+
+    select
+        evt_id,
+        evt_tech_yuman_id,
+        evt_tech_name,
+        evt_tech_secteur,
+        evt_event_type,
+        evt_event_unit,
+        evt_event_valeur,
+        evt_event_date,
+        evt_event_manager_comment,
+        annee,
+        mois,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_events') }}
+
+),
+
+cleaned_data as (
+
+    select
+        evt_id,
+        evt_tech_yuman_id,
+        evt_tech_name,
+        lower(trim(evt_tech_secteur)) as evt_tech_secteur,
+        evt_event_type,
+        evt_event_unit,
+        evt_event_valeur,
+        safe.parse_date('%F', evt_event_date) as evt_event_date,
+        nullif(trim(evt_event_manager_comment), '') as evt_event_manager_comment,
+        annee,
+        mois,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/events/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/events/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    evt_id,
+    evt_tech_yuman_id,
+    evt_tech_name,
+    evt_tech_secteur,
+    evt_event_type,
+    evt_event_unit,
+    evt_event_valeur,
+    evt_event_date,
+    evt_event_manager_comment,
+    annee,
+    mois,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)

--- a/models/staging/apptech/stg_apptech__suivi_tech_mee.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_mee.sql
@@ -1,0 +1,48 @@
+{{
+    config(
+        materialized='table',
+        description="Décisions de facturation des mises en exploitation (MEE) par intervention, depuis les snapshots NDJSON de l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        intervention_id,
+        a_facturer,
+        commentaire,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_mee') }}
+
+),
+
+cleaned_data as (
+
+    select
+        intervention_id,
+        upper(trim(a_facturer)) as a_facturer,
+        nullif(trim(commentaire), '') as commentaire,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/mee/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/mee/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    intervention_id,
+    a_facturer,
+    commentaire,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)

--- a/models/staging/apptech/stg_apptech__suivi_tech_modif_intervention.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_modif_intervention.sql
@@ -1,0 +1,55 @@
+{{
+    config(
+        materialized='table',
+        description="Modifications d'intervention (facturation, technicien réel) saisies dans l'app suivi technique"
+    )
+}}
+
+with source_data as (
+
+    select
+        intervention_id,
+        a_facturer,
+        tech_id_reel,
+        tech_yuman_id_reel,
+        commentaire,
+        _file_name as gcs_uri
+    from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_modif_intervention') }}
+
+),
+
+cleaned_data as (
+
+    select
+        intervention_id,
+        -- a_facturer peut être vide dans la source (modif sans décision de facturation)
+        upper(nullif(trim(a_facturer), '')) as a_facturer,
+        lower(trim(tech_id_reel)) as tech_id_reel,
+        tech_yuman_id_reel,
+        nullif(trim(commentaire), '') as commentaire,
+
+        -- Métadonnées dérivées du chemin GCS ingestion/modif_intervention/<YYYY-MM>/<timestampZ>.ndjson
+        regexp_extract(gcs_uri, r'/ingestion/modif_intervention/(\d{4}-\d{2})/') as periode,
+        regexp_extract(gcs_uri, r'([^/]+\.ndjson)$') as source_file,
+        safe.parse_timestamp(
+            '%Y%m%dT%H%M%SZ', regexp_extract(gcs_uri, r'/([^/.]+)\.ndjson$')
+        ) as extracted_at
+
+    from source_data
+
+)
+
+-- Sémantique SNAPSHOT : seul le dernier fichier de chaque mois fait foi
+-- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
+select
+    intervention_id,
+    a_facturer,
+    tech_id_reel,
+    tech_yuman_id_reel,
+    commentaire,
+    periode,
+    parse_date('%Y-%m', periode) as periode_date,
+    source_file,
+    extracted_at
+from cleaned_data
+qualify extracted_at = max(extracted_at) over (partition by periode)


### PR DESCRIPTION
## Quoi

Complète la source `apptech` (PR #178) avec les 6 types déposés par l'analyste le 15/07 : `aguila`, `astreinte`, `curative`, `events`, `mee`, `modif_intervention`. Les 8 types du bucket sont maintenant couverts. Inclut la doc de la source (`docs/apptech_ingestion.md` : contrat app, pattern, checklist pour un futur type).

## Design

- Même pattern que pause/rw : dedup snapshot par (type, mois), métadonnées dérivées du chemin GCS, pas de freshness.
- Schémas **profilés sur l'ensemble des NDJSON** du bucket (pas 1 ligne) : ids saisie humaine = STRING, `tech_yuman_id_reel`/`evt_id` = INT64, `evt_event_valeur` = FLOAT64.
- `events` = référentiel distinct (événements techniciens, clé `evt_id`) avec test de cohérence `periode` vs `annee`/`mois` (warn) et `accepted_values` warn sur l'unité (Journee/Heure — domaine à confirmer).
- `modif_intervention.a_facturer` nullable (chaîne vide en source → `nullif`).
- `curative` : pas d'`accepted_values` sur les délais forcés (domaine J+x non confirmé).

## Infra (déjà appliquée — terraform master 6bd4afa)

6 tables externes `prod_raw.ext_gcs_apptech__suivi_tech_*`. Plan : 6 add, 0 change, 0 destroy. IAM inchangé.

## Validation

- `dbt build --select tag:apptech --target dev` : **55/55 PASS** (8 modèles, 47 tests), 0 warn
- **Dedup snapshot exercé en réel** pour la première fois (chaque type a ≥2 fichiers re-soumis) : aguila 8→4 lignes, astreinte 10→5, events 5→2, mee 14→7 — seul le dernier fichier de chaque mois est retenu ✓
- SQLFluff clean, `dbt parse` sans warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BMJfTsVK7UCaGheg4kvAj2