### PR TITLE
fix(neshu): rattacher machine_appro_intervention au client courant

### DIFF
--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1276,8 +1276,11 @@ models:
 
       [COMMENT CONSTRUITE]
       Joint `int_oracle_neshu__appro_machine_context` (intermediate
-      factorisé, grain device) avec `dim_neshu__device` et
-      `dim_neshu__company` (attributs display). Côté Yuman, filtre
+      factorisé, grain device) avec `dim_neshu__device`. La company
+      (company_id / company_code) = propriétaire COURANT issu de
+      `dim_neshu__device` (ERP idcompany_customer), et NON le client
+      historique dérivé des tâches d'appro (qui reste figé sur l'ancien
+      emplacement après un déménagement de machine). Côté Yuman, filtre
       `int_yuman__demands_workorders_enriched` sur partenaire NESHU et
       catégorie CURATIVE*, puis dispatch en 3 buckets selon le statut
       (logique statut-d'abord, buckets mutuellement exclusifs) :
@@ -1286,9 +1289,12 @@ models:
         - future  : workorder_status='Scheduled'    + demand Accepted (toute date, planifié à venir OU en retard)
       Chaque workorder a un statut unique → au plus un bucket, pas de doublon
       (ex. une In progress avec date_done renseignée reste en 'current', pas en 'past').
-      Cross-source join sur
-      `UPPER(TRIM(device_code))` = `serial_clean` (normalisation Yuman :
-      strip 'NESH_' prefix).
+      Cross-source join sur `UPPER(TRIM(device_code))` = `serial_clean`
+      (normalisation Yuman : strip 'NESH_' prefix) ET sur le client
+      COURANT `UPPER(TRIM(company_code))` = `yuman_company_code`
+      (client_code Yuman 'NESH_' stripé). Le double critère garantit
+      qu'on ne rattache que les interventions de l'emplacement actuel de
+      la machine, jamais celles d'un ancien client.
 
       [GRAIN]
       1 ligne par device_id Neshu (ayant ≥ 1 passage appro).
@@ -1302,17 +1308,17 @@ models:
       (pause historique, déjà reprise) mais ne sont pas "en cours".
       Les déplacements sans réparation (is_workorder_not_done) sont exclus.
 
-      ⚠️ Jointure cross-source actuellement fragile (string match
-      device_code ↔ serial). Une table de mapping device Yuman ↔ device
-      Oracle Neshu pourrait remplacer ce match string si besoin futur.
-      Diagnostic effectué (2026-05-24) : 94 % des devices avec workorders
-      curative ont un match 1-1 propre (1175/1250). 6 % (75 devices) ont
-      2 materials Yuman par device — pour ces cas, les attributs détaillés
-      `past_/current_/future_*` ne reflètent qu'un seul material (choisi
-      par row_number partition sur serial_clean order by date_done desc).
-      Les compteurs (`nb_interventions_15j`) restent justes car comptent
-      tous les workorders distincts du serial. ROI bridge faible — pas
-      prioritaire tant que le DA ne signale pas de pain métier.
+      ⚠️ Jointure cross-source par string match device_code ↔ serial,
+      désambiguïsée par le client courant. Un même serial peut porter
+      plusieurs materials Yuman (historique des déplacements de la machine
+      chez différents clients) ; le double critère serial + client courant
+      isole le bon material. Conséquence voulue : une machine passée en
+      atelier / remise en état / dépôt rebut (dont le client Yuman interne
+      'NESH_EVS' ne mappe pas aux codes internes Neshu) n'affiche plus
+      d'intervention curative client — c'est cohérent avec l'objectif
+      "suivi appro + curatif du client courant". Une table de mapping
+      device Yuman ↔ device Oracle Neshu reste envisageable si le string
+      match sur le serial devient insuffisant.
 
       Replace l'ancienne PR #77 (Rim) qui plaçait ce mart à tort dans
       `marts/technique/` avec un nom au pluriel et une logique appro
@@ -1334,7 +1340,7 @@ models:
                 to: ref('dim_neshu__device')
                 field: device_id
       - name: company_id
-        description: FK vers dim_neshu__company (client de la machine).
+        description: FK vers dim_neshu__company (propriétaire COURANT de la machine, issu de dim_neshu__device / ERP — pas le client historique d'appro).
         tests:
           - not_null
           - relationships:
@@ -1342,9 +1348,9 @@ models:
                 to: ref('dim_neshu__company')
                 field: company_id
       - name: device_code
-        description: Code interne machine — utilisé pour la jointure cross-source vers Yuman.
+        description: Code interne machine — utilisé pour la jointure cross-source vers Yuman (serial).
       - name: company_code
-        description: Code client (display) — issu de dim_neshu__company.
+        description: Code client (display) du propriétaire courant — issu de dim_neshu__device ; sert aussi de clé de rattachement au client courant côté Yuman.
 
       # === Contexte appro ===
       - name: last_appro_date

--- a/models/marts/neshu/_neshu__marts_models.yml
+++ b/models/marts/neshu/_neshu__marts_models.yml
@@ -1281,7 +1281,7 @@ models:
       `int_yuman__demands_workorders_enriched` sur partenaire NESHU et
       catégorie CURATIVE*, puis dispatch en 3 buckets selon le statut
       (logique statut-d'abord, buckets mutuellement exclusifs) :
-        - past    : workorder_status='Closed'      + demand Accepted + date_done dans [J-15 ; aujourd'hui]
+        - past    : workorder_status='Closed'      + demand Closed   + date_done dans [J-15 ; aujourd'hui]
         - current : workorder_status='In progress'  + demand Accepted (toute date)
         - future  : workorder_status='Scheduled'    + demand Accepted (toute date, planifié à venir OU en retard)
       Chaque workorder a un statut unique → au plus un bucket, pas de doublon

--- a/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
+++ b/models/marts/neshu/fct_neshu__machine_appro_intervention.sql
@@ -12,26 +12,37 @@
 --
 -- Sources :
 --   - int_oracle_neshu__appro_machine_context (grain device, factorisé)
---   - dim_neshu__device, dim_neshu__company (attributs display)
+--   - dim_neshu__device (device_code + company du propriétaire COURANT)
 --   - int_yuman__demands_workorders_enriched (interventions Yuman)
 --
--- ⚠️ Jointure cross-source fragile : device_code Neshu = serial Yuman
--- (UPPER + TRIM + strip 'NESH_'). À remplacer par une table de mapping
--- device Yuman ↔ device Oracle Neshu dans un suivant PR.
+-- ⚠️ Jointure cross-source device_code Neshu = serial Yuman
+-- (UPPER + TRIM + strip 'NESH_'), DÉSAMBIGUÏSÉE par le client courant :
+-- un même serial peut porter plusieurs materials Yuman (historique des
+-- déplacements de la machine chez différents clients). On ne rattache
+-- que les interventions du client COURANT de la machine, via
+-- client_code Yuman ('NESH_' + code client) = company_code Neshu.
+-- Conséquence : company_code affiché et interventions montrées désignent
+-- toujours le même emplacement (cohérence par construction). Les
+-- interventions faites en atelier / remise en état (client Yuman interne
+-- 'NESH_EVS', non mappable aux codes atelier Neshu) ne remontent pas.
 -- ============================================================
 
 -- ============================================================
 -- CTE 1 : Contexte appro machine + attributs display Neshu
+-- company_id / company_code = propriétaire COURANT (dim_neshu__device,
+-- issu de l'ERP idcompany_customer), et NON le client historique dérivé
+-- des tâches d'appro (qui reste figé sur l'ancien emplacement après un
+-- déménagement de machine).
 -- ============================================================
 with appro_context as (
 
     select
         ctx.device_id,
-        ctx.company_id,
 
-        -- Display attributes via conformed dims
+        -- Company du propriétaire courant (dim device, pas l'historique appro)
+        d.company_id,
         d.device_code,
-        c.company_code,
+        d.company_code,
 
         -- Appro context (depuis l'intermediate)
         ctx.last_appro_task_id,
@@ -55,8 +66,6 @@ with appro_context as (
     from {{ ref('int_oracle_neshu__appro_machine_context') }} as ctx
     left join {{ ref('dim_neshu__device') }} as d
         on ctx.device_id = d.device_id
-    left join {{ ref('dim_neshu__company') }} as c
-        on ctx.company_id = c.company_id
 
 ),
 
@@ -64,6 +73,8 @@ with appro_context as (
 -- CTE 2 : Interventions Yuman NESHU curatives, normalisées
 -- Grain : 1 ligne par (material, workorder).
 -- ⚠️ serial_clean = jointure fragile vers Neshu device_code.
+-- yuman_company_code = client Yuman normalisé ('NESH_' stripé) ; sert à
+-- ne rattacher que les interventions du client COURANT de la machine.
 --
 -- Périmètre métier : uniquement les "vraies" interventions.
 --   - is_workorder_not_done = true (motif/detail de non-intervention
@@ -88,6 +99,8 @@ yuman_workorders as (
         material_serial_number,
         upper(trim(replace(material_serial_number, 'NESH_', '')))
             as serial_clean,
+        replace(upper(trim(any_value(client_code))), 'NESH_', '')
+            as yuman_company_code,
         workorder_id as intervention_id,
 
         -- Champs métier essentiels
@@ -155,26 +168,28 @@ yuman_workorders as (
 ),
 
 -- ============================================================
--- CTE 3 : Compteur 15j par machine
+-- CTE 3 : Compteur 15j par machine + client courant
 -- ============================================================
 past_count_15d as (
 
     select
         serial_clean,
+        yuman_company_code,
         count(distinct intervention_id) as nb_interventions_15j
     from yuman_workorders
     where is_past_intervention_15d = 1
-    group by serial_clean
+    group by serial_clean, yuman_company_code
 
 ),
 
 -- ============================================================
--- CTE 4 : Dernière intervention 15j par machine (row_number)
+-- CTE 4 : Dernière intervention 15j par (machine, client) (row_number)
 -- ============================================================
 past_15d_ranked as (
 
     select
         serial_clean,
+        yuman_company_code,
         material_id,
         technician_id,
         intervention_id,
@@ -188,7 +203,7 @@ past_15d_ranked as (
         intervention_title,
         intervention_report,
         row_number() over (
-            partition by serial_clean
+            partition by serial_clean, yuman_company_code
             order by date_done desc
         ) as rn
     from yuman_workorders
@@ -199,6 +214,7 @@ past_15d_ranked as (
 past_15d as (
     select
         serial_clean,
+        yuman_company_code,
         material_id as past_material_id,
         technician_id as past_technician_id,
         intervention_id as past_intervention_id,
@@ -216,12 +232,13 @@ past_15d as (
 ),
 
 -- ============================================================
--- CTE 5 : Intervention en cours par machine
+-- CTE 5 : Intervention en cours par (machine, client)
 -- ============================================================
 current_ranked as (
 
     select
         serial_clean,
+        yuman_company_code,
         material_id,
         technician_id,
         intervention_id,
@@ -238,7 +255,7 @@ current_ranked as (
         workorder_raison_mise_en_pause,
         workorder_explication_mise_en_pause,
         row_number() over (
-            partition by serial_clean
+            partition by serial_clean, yuman_company_code
             order by demand_created_at desc
         ) as rn
     from yuman_workorders
@@ -249,6 +266,7 @@ current_ranked as (
 current_inter as (
     select
         serial_clean,
+        yuman_company_code,
         material_id as current_material_id,
         technician_id as current_technician_id,
         intervention_id as current_intervention_id,
@@ -270,12 +288,13 @@ current_inter as (
 ),
 
 -- ============================================================
--- CTE 6 : Prochaine intervention planifiée par machine
+-- CTE 6 : Prochaine intervention planifiée par (machine, client)
 -- ============================================================
 future_ranked as (
 
     select
         serial_clean,
+        yuman_company_code,
         material_id,
         technician_id,
         intervention_id,
@@ -289,7 +308,7 @@ future_ranked as (
         intervention_title,
         intervention_report,
         row_number() over (
-            partition by serial_clean
+            partition by serial_clean, yuman_company_code
             order by date_planned asc
         ) as rn
     from yuman_workorders
@@ -300,6 +319,7 @@ future_ranked as (
 future_inter as (
     select
         serial_clean,
+        yuman_company_code,
         material_id as future_material_id,
         technician_id as future_technician_id,
         intervention_id as future_intervention_id,
@@ -318,6 +338,9 @@ future_inter as (
 
 -- ============================================================
 -- Assemblage final
+-- Jointure Yuman = serial (device_code) ET client courant (company_code).
+-- Le double critère garantit qu'on ne rattache que les interventions
+-- de l'emplacement actuel de la machine (pas les clients historiques).
 -- ============================================================
 select
     -- IDs (FKs vers dim_neshu__device, dim_neshu__company)
@@ -388,13 +411,20 @@ select
     fi.future_intervention_title,
     fi.future_intervention_report
 from appro_context as ac
--- ⚠️ Jointure cross-source fragile sur string normalisée
--- À remplacer par une table de mapping device dans un suivant PR
+-- Jointure cross-source sur serial normalisé ET client courant
 left join past_15d as p15
-    on upper(trim(ac.device_code)) = p15.serial_clean
+    on
+        upper(trim(ac.device_code)) = p15.serial_clean
+        and upper(trim(ac.company_code)) = p15.yuman_company_code
 left join past_count_15d as pc15
-    on upper(trim(ac.device_code)) = pc15.serial_clean
+    on
+        upper(trim(ac.device_code)) = pc15.serial_clean
+        and upper(trim(ac.company_code)) = pc15.yuman_company_code
 left join current_inter as ci
-    on upper(trim(ac.device_code)) = ci.serial_clean
+    on
+        upper(trim(ac.device_code)) = ci.serial_clean
+        and upper(trim(ac.company_code)) = ci.yuman_company_code
 left join future_inter as fi
-    on upper(trim(ac.device_code)) = fi.serial_clean
+    on
+        upper(trim(ac.device_code)) = fi.serial_clean
+        and upper(trim(ac.company_code)) = fi.yuman_company_code


### PR DESCRIPTION
## Contexte

Incohérence remontée par le métier via la BI parc machines : le `company_code` affiché pouvait être un **ancien** client alors que la machine est aujourd'hui chez un autre client — avec, dans la même ligne, une intervention curative en cours chez ce nouveau client.

Exemple : `MA00103` affichée chez EPEXSPOT (CN1001) alors qu'elle est chez RATP (CN1046), avec l'intervention RATP en cours dans la même ligne.

## Cause

- `company_id`/`company_code` étaient dérivés de **l'historique des tâches d'appro** (`any_value`), figé sur l'ancien emplacement après un déménagement de machine.
- Les interventions Yuman étaient rattachées au **serial seul**, sans tenir compte du client → une ligne pouvait mélanger ancien client + intervention chez le nouveau.

L'ERP (`dim_neshu__device.idcompany_customer`) connaissait le bon propriétaire courant ; le mart lisait le mauvais champ.

## Fix (approche B — ancrage sur le client courant)

1. `company_id`/`company_code` ← `dim_neshu__device` (propriétaire courant / ERP). Suppression de la jointure `dim_neshu__company`.
2. Rattachement Yuman sur **serial ET client courant** (`client_code` Yuman `NESH_` stripé = `company_code`) ; ranking + compteurs partitionnés par `(serial, client)`. Cohérence company ↔ interventions **garantie par construction**.
3. Doc YAML mise à jour (construction, notes, `company_id`/`company_code`) + fix du libellé bucket `past` (`demand Closed`, pas `Accepted`).

## Validation (prod, read-only, ancienne vs nouvelle logique à date identique)

- **Grain intact** : 1872 lignes = 1872 devices, 0 ajout parasite.
- **491 companies** corrigées vers le propriétaire courant.
- **3 interventions décrochées**, toutes légitimes (machines passées en atelier / dépôt rebut → plus de client Yuman correspondant).
- `MA00103` → CN1046 avec son intervention RATP conservée.

## Suivi (hors PR)

- ~431 machines (23 %) du mart sont en localisation interne (dont 320 au rebut) ; question de périmètre laissée au DA/métier (filtrage en BI via `company_code` / `is_active` de `dim_neshu__device`).
- Signal ops : quelques machines rebut/atelier côté ERP avec intervention Yuman encore ouverte (désync ERP ↔ Yuman).

🤖 Generated with [Claude Code](https://claude.com/claude-code)