### PR TITLE
feat(yuman): expose is_active sur le parc machine (materials + dims technique)

### DIFF
--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -383,6 +383,11 @@ models:
       - name: material_in_service_date
         description: "Date de mise en service de la machine"
 
+      - name: material_is_active
+        description: "Indique si la machine est active dans Yuman (champ source `active`). false = machine désactivée/retirée du parc."
+        tests:
+          - not_null
+
       - name: created_at
         description: "Date de création de l'enregistrement"
 

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -439,6 +439,11 @@ models:
       - name: material_in_service_date
         description: "Date de mise en service de la machine"
 
+      - name: material_is_active
+        description: "Indique si la machine est active dans Yuman (champ source `active`). false = machine désactivée/sortie du parc. Attribut de filtre : le parc total inclut les inactives, filtrer sur true pour le parc actif."
+        tests:
+          - not_null
+
       # Informations Client
       - name: client_id
         description: "Id du client associé à la machine"

--- a/models/marts/technique/dim_technique__material.sql
+++ b/models/marts/technique/dim_technique__material.sql
@@ -11,6 +11,7 @@ select
     ym.material_serial_number,
     ycat.category_name,
     ym.material_in_service_date,
+    ym.is_active as material_is_active,
     ym.created_at,
     ym.updated_at
 

--- a/models/marts/technique/dim_technique__parc_machine.sql
+++ b/models/marts/technique/dim_technique__parc_machine.sql
@@ -11,6 +11,7 @@ select
     ym.material_serial_number,
     ycat.category_name,
     ym.material_in_service_date,
+    ym.is_active as material_is_active,
 
     -- Informations Client
     yc.client_id,

--- a/models/staging/yuman/_yuman__models.yml
+++ b/models/staging/yuman/_yuman__models.yml
@@ -96,6 +96,10 @@ models:
               arguments:
                 to: ref('stg_yuman__materials_categories')
                 field: category_id
+      - name: is_active
+        description: "Indique si la machine est active dans Yuman (champ source `active`). false = machine désactivée/retirée du parc."
+        tests:
+          - not_null
 
   - name: stg_yuman__products
     description: "Produits transformés et nettoyés depuis l'API Yuman"

--- a/models/staging/yuman/stg_yuman__materials.sql
+++ b/models/staging/yuman/stg_yuman__materials.sql
@@ -23,6 +23,7 @@ cleaned_materials as (
         brand as material_brand,
         description as material_description,
         in_service_date as material_in_service_date,
+        active as is_active,
 
         (
             select json_value(elem, '$.value')


### PR DESCRIPTION
## Contexte

`active` (BOOL) de l'API Yuman n'était pas repris pour les machines : `yuman_clients` et `yuman_products` exposaient déjà `is_active`, mais **`yuman_materials` non**, ni en staging ni en mart. Cette PR comble ce trou.

## Changements

- `stg_yuman__materials` : ajout de `active as is_active` (passthrough) + test `not_null`.
- `dim_technique__material` : propagation en `material_is_active` + test `not_null`.
- `dim_technique__parc_machine` : idem `material_is_active`, pour cohérence entre les 2 dims de parc.

## Analyse d'impact (technique)

Ajout **purement additif**. Les 5 consommateurs de `stg_yuman__materials` projettent tous des colonnes **explicites** (jamais `select *`), donc aucun ne récupère la nouvelle colonne par effet de bord. Pas de changement de grain, pas de collision de nom, pas de risque incrémental (`materialized='table'`).

## Analyse métier

`active=false` = machine **sortie du parc** (modèles réels, pas des génériques), qui **conserve son historique** : 195 inactives (~1,9 % du parc) avec 324 interventions passées mais **0 demande ouverte**.

- **Faits transactionnels** (interventions, suivi partenaire, conso, facturation) : pas de filtre — l'historique reste valide, et 0 demande ouverte ⇒ aucune alerte active générée.
- **Maintenance préventive** : déjà propre (population pilotée par `dim_neshu__device.is_active` Oracle ; 100 % des machines matchées sont actives).
- **Dimensions de parc** : seul endroit où le flag compte. Exposé pour permettre de distinguer parc actif / parc total en BI. **Aucun filtre imposé** — décision de périmètre laissée au métier/DA.

## Validation

- SQLFluff lint OK
- `dbt parse` OK
- `dbt build --target dev` OK : tous tests PASS, dont les `not_null` sur `is_active` / `material_is_active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)