### PR TITLE
feat(apptech): identité interventions + socle retraitements (int_apptech__retraitements)

### DIFF
--- a/models/intermediate/apptech/_apptech__intermediate_models.yml
+++ b/models/intermediate/apptech/_apptech__intermediate_models.yml
@@ -14,12 +14,14 @@ models:
       UNION ALL des 6 modèles staging apptech (astreinte, mee, curative, aguila,
       pause, modif_intervention), chacun apportant une colonne littérale
       type_retraitement et ses colonnes manager propres (NULL pour les autres).
-      Dédoublonnage GLOBAL sur (intervention_id, type_retraitement) — au-delà de
-      la periode, car modif_intervention n'a pas de restriction de mois — en
-      gardant la ligne la plus récente (periode_date desc, extracted_at desc).
+      Dédoublonnage GLOBAL sur (src_inter, intervention_id, type_retraitement) —
+      au-delà de la periode, car modif_intervention n'a pas de restriction de mois
+      — en gardant la ligne la plus récente (periode_date desc, extracted_at desc).
+      key_inter = concat(src_inter, '_', intervention_id) reconstruit la PK de
+      fct_technique__intervention pour la jointure aval.
 
       [GRAIN]
-      1 ligne par (intervention_id, type_retraitement). PK composite.
+      1 ligne par (key_inter, type_retraitement). PK composite.
 
       [NOTES]
       RW (Repair Warranty) et events sont exclus : RW = clawback de prime imputé
@@ -27,19 +29,30 @@ models:
       référentiel technicien distinct. Le cas rare d'une intervention touchée par
       2 types (ex. curative + modif_intervention) reste ici en 2 lignes :
       l'arbitrage inter-types est fait en aval (mart Facturation retraitée).
-      Colonne type_modif (Annulation/Réattribution/…) attendue côté app mais pas
-      encore émise dans le staging — à intégrer quand disponible.
+      src_inter/numero_pu proviennent du NDJSON (contrat identité 2026-07) : NULL
+      tant que l'app ne les émet pas → key_inter NULL, jointure aval vide, sans
+      casser le build. type_modif n'est renseigné que par modif_intervention.
     tests:
       - dbt_utils.unique_combination_of_columns:
           arguments:
             combination_of_columns:
+              - src_inter
               - intervention_id
               - type_retraitement
     columns:
+      - name: key_inter
+        description: >
+          Clé de jointure vers fct_technique__intervention =
+          concat(src_inter, '_', intervention_id). NULL tant que src_inter n'est
+          pas émis par l'app (phase de bascule).
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)."
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP). Opaque — le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL en phase de bascule."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour audit/relecture. NULL en phase de bascule."
       - name: type_retraitement
         description: "Type de retraitement à l'origine de la ligne."
         tests:
@@ -61,6 +74,8 @@ models:
         description: "Décision de doublement de la prime pause (OUI/NON). Alimenté par pause uniquement (NULL sinon)."
       - name: convertir_code_5
         description: "Décision de conversion du code 5 Aguila (OUI/NON). Alimenté par aguila uniquement (NULL sinon)."
+      - name: type_modif
+        description: "Nature de la modification (Annulation / Réattribution / Annulation + Réattribution / Autre). Alimenté par modif_intervention uniquement (NULL sinon)."
       - name: commentaire
         description: "Commentaire libre du manager (NULL si vide)."
       - name: periode

--- a/models/intermediate/apptech/_apptech__intermediate_models.yml
+++ b/models/intermediate/apptech/_apptech__intermediate_models.yml
@@ -1,0 +1,77 @@
+version: 2
+
+models:
+  - name: int_apptech__retraitements
+    description: >
+      [QUOI MÉTIER]
+      Compilation des retraitements manuels saisis par les managers dans l'app
+      Suivi Tech : réaffectations d'astreinte, décisions de facturation (MEE et
+      modif d'intervention), délais forcés (curative/aguila), doublement de prime
+      pause. Brique de construction du mart Facturation retraitée — pas consommée
+      directement en BI.
+
+      [COMMENT CONSTRUITE]
+      UNION ALL des 6 modèles staging apptech (astreinte, mee, curative, aguila,
+      pause, modif_intervention), chacun apportant une colonne littérale
+      type_retraitement et ses colonnes manager propres (NULL pour les autres).
+      Dédoublonnage GLOBAL sur (intervention_id, type_retraitement) — au-delà de
+      la periode, car modif_intervention n'a pas de restriction de mois — en
+      gardant la ligne la plus récente (periode_date desc, extracted_at desc).
+
+      [GRAIN]
+      1 ligne par (intervention_id, type_retraitement). PK composite.
+
+      [NOTES]
+      RW (Repair Warranty) et events sont exclus : RW = clawback de prime imputé
+      au technicien d'une AUTRE intervention (relève des marts Primes), events =
+      référentiel technicien distinct. Le cas rare d'une intervention touchée par
+      2 types (ex. curative + modif_intervention) reste ici en 2 lignes :
+      l'arbitrage inter-types est fait en aval (mart Facturation retraitée).
+      Colonne type_modif (Annulation/Réattribution/…) attendue côté app mais pas
+      encore émise dans le staging — à intégrer quand disponible.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - intervention_id
+              - type_retraitement
+    columns:
+      - name: intervention_id
+        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)."
+        tests:
+          - not_null
+      - name: type_retraitement
+        description: "Type de retraitement à l'origine de la ligne."
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['astreinte', 'mee', 'curative', 'aguila', 'pause', 'modif_intervention']
+      - name: a_facturer
+        description: "Décision de facturation (OUI/NON). Alimenté par mee et modif_intervention uniquement (NULL sinon)."
+      - name: tech_id_reel
+        description: "Identifiant interne du technicien réel. Alimenté par astreinte et modif_intervention (NULL sinon)."
+      - name: tech_yuman_id_reel
+        description: "Identifiant Yuman du technicien réel. Alimenté par astreinte et modif_intervention (NULL sinon)."
+      - name: delai_tech_force
+        description: "Délai technicien forcé (ex. J+0). Alimenté par curative uniquement (NULL sinon)."
+      - name: delai_partenaire_force
+        description: "Délai partenaire forcé (ex. J+2). Alimenté par curative uniquement (NULL sinon)."
+      - name: doubler_prime
+        description: "Décision de doublement de la prime pause (OUI/NON). Alimenté par pause uniquement (NULL sinon)."
+      - name: convertir_code_5
+        description: "Décision de conversion du code 5 Aguila (OUI/NON). Alimenté par aguila uniquement (NULL sinon)."
+      - name: commentaire
+        description: "Commentaire libre du manager (NULL si vide)."
+      - name: periode
+        description: "Mois concerné au format YYYY-MM, dérivé du dossier GCS du flux source."
+        tests:
+          - not_null
+      - name: periode_date
+        description: "Premier jour du mois concerné (DATE)."
+      - name: source_file
+        description: "Nom du fichier NDJSON snapshot retenu pour cette ligne."
+      - name: extracted_at
+        description: "Timestamp du fichier snapshot retenu (UTC)."
+        tests:
+          - not_null

--- a/models/intermediate/apptech/int_apptech__retraitements.sql
+++ b/models/intermediate/apptech/int_apptech__retraitements.sql
@@ -1,16 +1,24 @@
 {{ config(materialized='table') }}
 
 -- Compilation des 6 flux de retraitement de l'app Suivi Tech en un modèle unique,
--- une ligne par (intervention_id, type_retraitement). RW et events sont exclus
+-- une ligne par (key_inter, type_retraitement). RW et events sont exclus
 -- (RW = clawback de prime, cf. §2.3 note_context ; events = référentiel technicien).
 -- Chaque flux apporte ses colonnes manager propres ; NULL pour celles qui ne le
 -- concernent pas. L'arbitrage entre types touchant une même intervention est
 -- volontairement repoussé au mart Facturation retraitée (modèle 1).
+--
+-- Identité : key_inter = concat(src_inter, '_', intervention_id) reconstruit la PK
+-- de fct_technique__intervention (workorder_id/n_planning chevauchent → src_inter
+-- requis). src_inter/numero_pu proviennent du NDJSON (contrat identité 2026-07) ;
+-- ils sont NULL tant que l'app ne les émet pas — key_inter est alors NULL et la
+-- jointure au fait est vide, sans casser le build (bascule sûre).
 
 with unioned as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         'astreinte' as type_retraitement,
         cast(null as string) as a_facturer,
         tech_id_reel,
@@ -19,6 +27,7 @@ with unioned as (
         cast(null as string) as delai_partenaire_force,
         cast(null as string) as doubler_prime,
         cast(null as string) as convertir_code_5,
+        cast(null as string) as type_modif,
         commentaire,
         periode,
         periode_date,
@@ -30,6 +39,8 @@ with unioned as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         'mee' as type_retraitement,
         a_facturer,
         cast(null as string) as tech_id_reel,
@@ -38,6 +49,7 @@ with unioned as (
         cast(null as string) as delai_partenaire_force,
         cast(null as string) as doubler_prime,
         cast(null as string) as convertir_code_5,
+        cast(null as string) as type_modif,
         commentaire,
         periode,
         periode_date,
@@ -49,6 +61,8 @@ with unioned as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         'curative' as type_retraitement,
         cast(null as string) as a_facturer,
         cast(null as string) as tech_id_reel,
@@ -57,6 +71,7 @@ with unioned as (
         delai_partenaire_force,
         cast(null as string) as doubler_prime,
         cast(null as string) as convertir_code_5,
+        cast(null as string) as type_modif,
         commentaire,
         periode,
         periode_date,
@@ -68,6 +83,8 @@ with unioned as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         'aguila' as type_retraitement,
         cast(null as string) as a_facturer,
         cast(null as string) as tech_id_reel,
@@ -76,6 +93,7 @@ with unioned as (
         cast(null as string) as delai_partenaire_force,
         cast(null as string) as doubler_prime,
         convertir_code_5,
+        cast(null as string) as type_modif,
         commentaire,
         periode,
         periode_date,
@@ -87,6 +105,8 @@ with unioned as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         'pause' as type_retraitement,
         cast(null as string) as a_facturer,
         cast(null as string) as tech_id_reel,
@@ -95,6 +115,7 @@ with unioned as (
         cast(null as string) as delai_partenaire_force,
         doubler_prime,
         cast(null as string) as convertir_code_5,
+        cast(null as string) as type_modif,
         commentaire,
         periode,
         periode_date,
@@ -106,6 +127,8 @@ with unioned as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         'modif_intervention' as type_retraitement,
         a_facturer,
         tech_id_reel,
@@ -114,6 +137,7 @@ with unioned as (
         cast(null as string) as delai_partenaire_force,
         cast(null as string) as doubler_prime,
         cast(null as string) as convertir_code_5,
+        type_modif,
         commentaire,
         periode,
         periode_date,
@@ -121,14 +145,37 @@ with unioned as (
         extracted_at
     from {{ ref('stg_apptech__suivi_tech_modif_intervention') }}
 
+),
+
+-- Dedup GLOBAL sur (src_inter, intervention_id, type_retraitement) = (key_inter,
+-- type) : au-delà de la periode, car modif_intervention n'a pas de restriction de
+-- mois. On garde la ligne dont (periode, extracted_at) est la plus récente. La
+-- clé inclut src_inter (partition tolérante à src_inter NULL pendant la bascule).
+deduped as (
+    select * from unioned
+    qualify row_number() over (
+        partition by src_inter, intervention_id, type_retraitement
+        order by periode_date desc, extracted_at desc
+    ) = 1
 )
 
--- Dedup GLOBAL sur (intervention_id, type_retraitement) : au-delà de la periode,
--- car modif_intervention n'a pas de restriction de mois (une même intervention
--- peut être re-modifiée dans une periode ultérieure). On garde la ligne dont
--- (periode, extracted_at) est la plus récente.
-select * from unioned
-qualify row_number() over (
-    partition by intervention_id, type_retraitement
-    order by periode_date desc, extracted_at desc
-) = 1
+select
+    concat(src_inter, '_', intervention_id) as key_inter,
+    intervention_id,
+    src_inter,
+    numero_pu,
+    type_retraitement,
+    a_facturer,
+    tech_id_reel,
+    tech_yuman_id_reel,
+    delai_tech_force,
+    delai_partenaire_force,
+    doubler_prime,
+    convertir_code_5,
+    type_modif,
+    commentaire,
+    periode,
+    periode_date,
+    source_file,
+    extracted_at
+from deduped

--- a/models/intermediate/apptech/int_apptech__retraitements.sql
+++ b/models/intermediate/apptech/int_apptech__retraitements.sql
@@ -1,0 +1,134 @@
+{{ config(materialized='table') }}
+
+-- Compilation des 6 flux de retraitement de l'app Suivi Tech en un modèle unique,
+-- une ligne par (intervention_id, type_retraitement). RW et events sont exclus
+-- (RW = clawback de prime, cf. §2.3 note_context ; events = référentiel technicien).
+-- Chaque flux apporte ses colonnes manager propres ; NULL pour celles qui ne le
+-- concernent pas. L'arbitrage entre types touchant une même intervention est
+-- volontairement repoussé au mart Facturation retraitée (modèle 1).
+
+with unioned as (
+
+    select
+        intervention_id,
+        'astreinte' as type_retraitement,
+        cast(null as string) as a_facturer,
+        tech_id_reel,
+        tech_yuman_id_reel,
+        cast(null as string) as delai_tech_force,
+        cast(null as string) as delai_partenaire_force,
+        cast(null as string) as doubler_prime,
+        cast(null as string) as convertir_code_5,
+        commentaire,
+        periode,
+        periode_date,
+        source_file,
+        extracted_at
+    from {{ ref('stg_apptech__suivi_tech_astreinte') }}
+
+    union all
+
+    select
+        intervention_id,
+        'mee' as type_retraitement,
+        a_facturer,
+        cast(null as string) as tech_id_reel,
+        cast(null as int64) as tech_yuman_id_reel,
+        cast(null as string) as delai_tech_force,
+        cast(null as string) as delai_partenaire_force,
+        cast(null as string) as doubler_prime,
+        cast(null as string) as convertir_code_5,
+        commentaire,
+        periode,
+        periode_date,
+        source_file,
+        extracted_at
+    from {{ ref('stg_apptech__suivi_tech_mee') }}
+
+    union all
+
+    select
+        intervention_id,
+        'curative' as type_retraitement,
+        cast(null as string) as a_facturer,
+        cast(null as string) as tech_id_reel,
+        cast(null as int64) as tech_yuman_id_reel,
+        delai_tech_force,
+        delai_partenaire_force,
+        cast(null as string) as doubler_prime,
+        cast(null as string) as convertir_code_5,
+        commentaire,
+        periode,
+        periode_date,
+        source_file,
+        extracted_at
+    from {{ ref('stg_apptech__suivi_tech_curative') }}
+
+    union all
+
+    select
+        intervention_id,
+        'aguila' as type_retraitement,
+        cast(null as string) as a_facturer,
+        cast(null as string) as tech_id_reel,
+        cast(null as int64) as tech_yuman_id_reel,
+        cast(null as string) as delai_tech_force,
+        cast(null as string) as delai_partenaire_force,
+        cast(null as string) as doubler_prime,
+        convertir_code_5,
+        commentaire,
+        periode,
+        periode_date,
+        source_file,
+        extracted_at
+    from {{ ref('stg_apptech__suivi_tech_aguila') }}
+
+    union all
+
+    select
+        intervention_id,
+        'pause' as type_retraitement,
+        cast(null as string) as a_facturer,
+        cast(null as string) as tech_id_reel,
+        cast(null as int64) as tech_yuman_id_reel,
+        cast(null as string) as delai_tech_force,
+        cast(null as string) as delai_partenaire_force,
+        doubler_prime,
+        cast(null as string) as convertir_code_5,
+        commentaire,
+        periode,
+        periode_date,
+        source_file,
+        extracted_at
+    from {{ ref('stg_apptech__suivi_tech_pause') }}
+
+    union all
+
+    select
+        intervention_id,
+        'modif_intervention' as type_retraitement,
+        a_facturer,
+        tech_id_reel,
+        tech_yuman_id_reel,
+        cast(null as string) as delai_tech_force,
+        cast(null as string) as delai_partenaire_force,
+        cast(null as string) as doubler_prime,
+        cast(null as string) as convertir_code_5,
+        commentaire,
+        periode,
+        periode_date,
+        source_file,
+        extracted_at
+    from {{ ref('stg_apptech__suivi_tech_modif_intervention') }}
+
+)
+
+-- Dedup GLOBAL sur (intervention_id, type_retraitement) : au-delà de la periode,
+-- car modif_intervention n'a pas de restriction de mois (une même intervention
+-- peut être re-modifiée dans une periode ultérieure). On garde la ligne dont
+-- (periode, extracted_at) est la plus récente.
+select * from unioned
+qualify row_number() over (
+    partition by intervention_id, type_retraitement
+    order by periode_date desc, extracted_at desc
+) = 1

--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -30,7 +30,7 @@ models:
       seed `ref_nesp_tech__cps_montagne_primes`.
 
       [GRAIN]
-      1 ligne par intervention. PK = `key_inter` = `intervention_id` + '_' + `partenaire`.
+      1 ligne par intervention. PK = `key_inter` = `src_inter` + '_' + `intervention_id`.
 
       [NOTES]
       - Filtres répartis sur 3 niveaux (intermediate → CTE du fait → jointures
@@ -56,15 +56,29 @@ models:
       - name: key_inter
         description: >
           PK — identifiant unique de l'intervention =
-          `intervention_id` + '_' + `partenaire`.
+          `src_inter` + '_' + `intervention_id`. Discriminant `src_inter` requis :
+          `workorder_id` (YUMAN) et `n_planning` (NESP) se chevauchent sur ~785
+          valeurs (mêmes plages numériques), donc `intervention_id` seul n'est pas
+          unique au global.
         tests:
           - not_null
           - unique
 
       - name: intervention_id
         description: >
-          Identifiant de l'intervention dans le système source : `n_planning`
-          côté NESP, `workorder_number` côté YUMAN.
+          PK de l'intervention dans son système source : `n_planning` côté NESP,
+          `workorder_id` (identifiant interne Yuman, PK réelle) côté YUMAN. Unique
+          par source, PAS au global (cf. `key_inter`). Le numéro visible (n° PU)
+          est porté par `numero_pu`.
+        tests:
+          - not_null
+
+      - name: numero_pu
+        description: >
+          Numéro d'intervention visible (« n° PU »), tel que recherché par les
+          managers : `workorder_number` côté YUMAN, `n_planning` côté NESP. Peut
+          être ré-employé entre partenaires côté YUMAN (non unique) — ne pas
+          l'utiliser comme clé de jointure, réservé à l'affichage/recherche.
         tests:
           - not_null
 

--- a/models/marts/technique/fct_technique__intervention.sql
+++ b/models/marts/technique/fct_technique__intervention.sql
@@ -16,6 +16,7 @@ with nesp_interventions as (
         'NESP' as src_inter,
         'NESPRESSO' as partenaire,
         cast(dedup.n_planning as string) as intervention_id,
+        cast(dedup.n_planning as string) as numero_pu,
         dedup.n_tech as tech_id,
         cast(dedup.n_client as string) as client_id,
         initcap(dedup.raison_sociale_client) as client_nom,
@@ -64,7 +65,8 @@ yuman_interventions as (
     select
         'YUMAN' as src_inter,
         inter_yuman.partner_name as partenaire,
-        inter_yuman.workorder_number as intervention_id,
+        cast(inter_yuman.workorder_id as string) as intervention_id,
+        inter_yuman.workorder_number as numero_pu,
         cast(inter_yuman.technician_id as string) as tech_id,
         inter_yuman.client_code as client_id,
         initcap(inter_yuman.client_name) as client_nom,
@@ -106,10 +108,11 @@ interventions as (
 -- CTE 4 : Enrichissement métier (durée + flags + mapping techniciens)
 interventions_enrichies as (
     select
-        concat(i.intervention_id, '_', i.partenaire) as key_inter,
+        concat(i.src_inter, '_', i.intervention_id) as key_inter,
         i.src_inter,
         i.partenaire,
         i.intervention_id,
+        i.numero_pu,
         i.intervention_statut,
         i.statut_facturation,
         i.categorie_machine,
@@ -188,6 +191,7 @@ select
     src_inter,
     partenaire,
     intervention_id,
+    numero_pu,
     intervention_statut,
     statut_facturation,
     coalesce(categorie_machine, 'UNDEFINED') as categorie_machine,

--- a/models/staging/apptech/_apptech__models.yml
+++ b/models/staging/apptech/_apptech__models.yml
@@ -17,9 +17,13 @@ models:
               - intervention_id
     columns:
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING, non vérifié contre un référentiel à ce stade)"
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP, telle qu'exposée par fct_technique__intervention). Le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL tant que l'app ne l'émet pas (bascule contrat identité 2026-07)."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: doubler_prime
         description: "Décision de doublement de la prime (normalisé en majuscules)"
         tests:
@@ -55,9 +59,13 @@ models:
               - intervention_id
     columns:
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP, telle qu'exposée par fct_technique__intervention). Le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL tant que l'app ne l'émet pas (bascule contrat identité 2026-07)."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: convertir_code_5
         description: "Décision de conversion du code 5 (normalisé en majuscules)"
         tests:
@@ -93,9 +101,13 @@ models:
               - intervention_id
     columns:
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP, telle qu'exposée par fct_technique__intervention). Le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL tant que l'app ne l'émet pas (bascule contrat identité 2026-07)."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: tech_id_reel
         description: "Identifiant interne du technicien réel (normalisé en minuscules, ex. 'tec-00056')"
         tests:
@@ -133,9 +145,13 @@ models:
               - intervention_id
     columns:
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP, telle qu'exposée par fct_technique__intervention). Le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL tant que l'app ne l'émet pas (bascule contrat identité 2026-07)."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: delai_tech_force
         description: "Délai technicien forcé (normalisé en majuscules, ex. 'J+0')"
       - name: delai_partenaire_force
@@ -237,9 +253,13 @@ models:
               - intervention_id
     columns:
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP, telle qu'exposée par fct_technique__intervention). Le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL tant que l'app ne l'émet pas (bascule contrat identité 2026-07)."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: a_facturer
         description: "Décision de facturation de la MEE (normalisé en majuscules)"
         tests:
@@ -276,9 +296,13 @@ models:
               - intervention_id
     columns:
       - name: intervention_id
-        description: "Identifiant de l'intervention concernée (saisie humaine — STRING)"
+        description: "PK source de l'intervention (workorder_id YUMAN / n_planning NESP, telle qu'exposée par fct_technique__intervention). Le n° visible est numero_pu."
         tests:
           - not_null
+      - name: src_inter
+        description: "Système source de l'intervention (NESP / YUMAN), émis par l'app. NULL tant que l'app ne l'émet pas (bascule contrat identité 2026-07)."
+      - name: numero_pu
+        description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: a_facturer
         description: "Décision de facturation (normalisé en majuscules, NULL si non renseignée)"
         tests:
@@ -289,6 +313,8 @@ models:
         description: "Identifiant interne du technicien réel (normalisé en minuscules, ex. 'tec-01003')"
       - name: tech_yuman_id_reel
         description: "Identifiant Yuman du technicien réel"
+      - name: type_modif
+        description: "Nature de la modification, calculée côté app (Annulation / Réattribution / Annulation + Réattribution / Autre). NULL tant que l'app ne l'émet pas."
       - name: commentaire
         description: "Commentaire libre du manager (NULL si vide)"
       - name: periode

--- a/models/staging/apptech/stg_apptech__suivi_tech_aguila.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_aguila.sql
@@ -9,6 +9,8 @@ with source_data as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         convertir_code_5,
         commentaire,
         _file_name as gcs_uri
@@ -20,6 +22,8 @@ cleaned_data as (
 
     select
         intervention_id,
+        upper(trim(src_inter)) as src_inter,
+        nullif(trim(numero_pu), '') as numero_pu,
         upper(trim(convertir_code_5)) as convertir_code_5,
         nullif(trim(commentaire), '') as commentaire,
 
@@ -38,6 +42,8 @@ cleaned_data as (
 -- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
 select
     intervention_id,
+    src_inter,
+    numero_pu,
     convertir_code_5,
     commentaire,
     periode,

--- a/models/staging/apptech/stg_apptech__suivi_tech_astreinte.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_astreinte.sql
@@ -9,6 +9,8 @@ with source_data as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         tech_id_reel,
         tech_yuman_id_reel,
         commentaire,
@@ -21,6 +23,8 @@ cleaned_data as (
 
     select
         intervention_id,
+        upper(trim(src_inter)) as src_inter,
+        nullif(trim(numero_pu), '') as numero_pu,
         lower(trim(tech_id_reel)) as tech_id_reel,
         tech_yuman_id_reel,
         nullif(trim(commentaire), '') as commentaire,
@@ -40,6 +44,8 @@ cleaned_data as (
 -- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
 select
     intervention_id,
+    src_inter,
+    numero_pu,
     tech_id_reel,
     tech_yuman_id_reel,
     commentaire,

--- a/models/staging/apptech/stg_apptech__suivi_tech_curative.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_curative.sql
@@ -9,6 +9,8 @@ with source_data as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         delai_tech_force,
         delai_partenaire_force,
         commentaire,
@@ -21,6 +23,8 @@ cleaned_data as (
 
     select
         intervention_id,
+        upper(trim(src_inter)) as src_inter,
+        nullif(trim(numero_pu), '') as numero_pu,
         upper(trim(delai_tech_force)) as delai_tech_force,
         upper(trim(delai_partenaire_force)) as delai_partenaire_force,
         nullif(trim(commentaire), '') as commentaire,
@@ -40,6 +44,8 @@ cleaned_data as (
 -- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
 select
     intervention_id,
+    src_inter,
+    numero_pu,
     delai_tech_force,
     delai_partenaire_force,
     commentaire,

--- a/models/staging/apptech/stg_apptech__suivi_tech_mee.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_mee.sql
@@ -9,6 +9,8 @@ with source_data as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         a_facturer,
         commentaire,
         _file_name as gcs_uri
@@ -20,6 +22,8 @@ cleaned_data as (
 
     select
         intervention_id,
+        upper(trim(src_inter)) as src_inter,
+        nullif(trim(numero_pu), '') as numero_pu,
         upper(trim(a_facturer)) as a_facturer,
         nullif(trim(commentaire), '') as commentaire,
 
@@ -38,6 +42,8 @@ cleaned_data as (
 -- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
 select
     intervention_id,
+    src_inter,
+    numero_pu,
     a_facturer,
     commentaire,
     periode,

--- a/models/staging/apptech/stg_apptech__suivi_tech_modif_intervention.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_modif_intervention.sql
@@ -9,9 +9,12 @@ with source_data as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         a_facturer,
         tech_id_reel,
         tech_yuman_id_reel,
+        type_modif,
         commentaire,
         _file_name as gcs_uri
     from {{ source('apptech', 'ext_gcs_apptech__suivi_tech_modif_intervention') }}
@@ -22,10 +25,13 @@ cleaned_data as (
 
     select
         intervention_id,
+        upper(trim(src_inter)) as src_inter,
+        nullif(trim(numero_pu), '') as numero_pu,
         -- a_facturer peut être vide dans la source (modif sans décision de facturation)
         upper(nullif(trim(a_facturer), '')) as a_facturer,
         lower(trim(tech_id_reel)) as tech_id_reel,
         tech_yuman_id_reel,
+        nullif(trim(type_modif), '') as type_modif,
         nullif(trim(commentaire), '') as commentaire,
 
         -- Métadonnées dérivées du chemin GCS ingestion/modif_intervention/<YYYY-MM>/<timestampZ>.ndjson
@@ -43,9 +49,12 @@ cleaned_data as (
 -- (cf. stg_apptech__suivi_tech_pause pour le détail du contrat).
 select
     intervention_id,
+    src_inter,
+    numero_pu,
     a_facturer,
     tech_id_reel,
     tech_yuman_id_reel,
+    type_modif,
     commentaire,
     periode,
     parse_date('%Y-%m', periode) as periode_date,

--- a/models/staging/apptech/stg_apptech__suivi_tech_pause.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_pause.sql
@@ -9,6 +9,8 @@ with source_data as (
 
     select
         intervention_id,
+        src_inter,
+        numero_pu,
         doubler_prime,
         commentaire,
         _file_name as gcs_uri
@@ -20,6 +22,8 @@ cleaned_data as (
 
     select
         intervention_id,
+        upper(trim(src_inter)) as src_inter,
+        nullif(trim(numero_pu), '') as numero_pu,
         upper(trim(doubler_prime)) as doubler_prime,
         nullif(trim(commentaire), '') as commentaire,
 
@@ -39,6 +43,8 @@ cleaned_data as (
 -- dernier snapshot = override révoqué). L'historique complet reste dans GCS.
 select
     intervention_id,
+    src_inter,
+    numero_pu,
     doubler_prime,
     commentaire,
     periode,


### PR DESCRIPTION
## Contexte
Premier jalon du chantier « Facturation retraitée » (app Suivi Tech). On pose le socle : compilation des retraitements + fiabilisation de l'identité des interventions.

## Changements

### 1. Fix PK `fct_technique__intervention`
- `intervention_id` passe du numéro visible (`workorder_number`, **non unique** : réemployé entre partenaires — ex. `09706` en NESHU *et* AUUM) à la **vraie PK source** : `workorder_id` (YUMAN) / `n_planning` (NESP).
- `workorder_id` et `n_planning` se chevauchent (~785 cas) → `intervention_id` seul n'est pas unique au global → `key_inter` reconstruit sur **`src_inter` + `intervention_id`** (unique 92,6k/92,6k, test `unique` OK).
- Nouvelle colonne **`numero_pu`** = n° visible (recherche managers / affichage).
- ⚠️ **Impact BI** : le rapport « Pilotage Technique » (exposure `pilotage_technique`) doit repointer l'affichage du n° d'intervention sur `numero_pu`.

### 2. `int_apptech__retraitements` (nouveau)
- UNION ALL des 6 flux staging apptech (astreinte, mee, curative, aguila, pause, modif_intervention). RW + events exclus.
- Grain `(key_inter, type_retraitement)`, dedup global (au-delà de la periode, pour `modif_intervention` sans restriction de mois).

### 3. Staging apptech + tables externes
- Les 6 staging portent `src_inter` + `numero_pu` ; `modif_intervention` porte `type_modif`.
- Tables externes (repo infra, **déjà mergé/appliqué** sur `prod_raw`) mises à jour (additif, `NULLABLE` + `ignore_unknown_values`).

## Bascule progressive
`src_inter`/`numero_pu`/`key_inter` sont **NULL tant que l'app n'émet pas** ces champs (contrat identité 2026-07 transmis au DA). Jointures retraitement vides jusque-là, **sans casser le build** — conçu tolérant.

## Validation
- `dbt build` en dev : **45/45 PASS** (fait + chaîne apptech + tests). `unique(key_inter)` OK.
- SQLFluff clean, `dbt parse` OK.

## Hors périmètre (à suivre)
- Mart `fct_technique__interventions_retraitees` (cœur étape 2) : design-first à la prochaine étape.
- RW + marts Primes : plus tard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)