### PR TITLE
feat(oracle): sources + staging contact_has_device (NESHU + LCDP)

### DIFF
--- a/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__models.yml
@@ -82,6 +82,42 @@ models:
                 to: ref('stg_oracle_lcdp__company')
                 field: idcompany
 
+  # CONTACT_HAS_DEVICE
+  - name: stg_oracle_lcdp__contact_has_device
+    description: >
+      Rattachement d'une machine au membre du personnel interne qui en a la charge
+      (approvisionneur / technicien). Grain : 1 ligne par couple contact × device.
+      Le contact se raccroche à une ressource via son `code` (aucune FK idresources
+      dans la source). Couvre ~27 % du parc actif LCDP, mais la quasi-totalité du
+      périmètre DA FROID Nayax.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - idcontact
+              - iddevice
+    columns:
+      - name: idcontact
+        description: "Identifiant du contact (personnel interne — code aligné sur resources.code)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_oracle_lcdp__contact')
+                field: idcontact
+      - name: iddevice
+        description: "Identifiant du device rattaché"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_oracle_lcdp__device')
+                field: iddevice
+      - name: extracted_at
+        description: "Date d'extraction de la ligne"
+      - name: deleted_at
+        description: "Date de suppression logique de la ligne"
+
   # CONTRACT
   - name: stg_oracle_lcdp__contract
     description: "Contrats transformés et nettoyés depuis la base Oracle LCDP"

--- a/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
+++ b/models/staging/oracle_lcdp/_oracle_lcdp__sources.yml
@@ -172,6 +172,23 @@ sources:
           - name: modification_date
             description: "Date de modification de la ligne"
 
+      # CONTACT_HAS_DEVICE
+      - name: lcdp_contact_has_device
+        description: >
+          Table de jonction contact <-> device : rattachement d'une machine au
+          personnel interne (approvisionneur / technicien) qui en a la charge.
+          Aucune colonne temporelle métier ni code_status_record : seuls les _sdc_*
+          sont disponibles.
+        columns:
+          - name: idcontact
+            tests:
+              - not_null
+            description: "Identifiant du contact (personnel interne — code aligné sur resources.code)"
+          - name: iddevice
+            tests:
+              - not_null
+            description: "Identifiant du device"
+
       # CONTRACT
       - name: lcdp_contract
         description: "Table des contrats"

--- a/models/staging/oracle_lcdp/stg_oracle_lcdp__contact_has_device.sql
+++ b/models/staging/oracle_lcdp/stg_oracle_lcdp__contact_has_device.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        materialized='table',
+        description='contact_has_device nettoyés et enrichis depuis lcdp_contact_has_device — rattachement machine / personnel interne'
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('oracle_lcdp', 'lcdp_contact_has_device') }}
+),
+
+cleaned_data as (
+    select
+        -- IDs convertis en BIGINT
+        cast(idcontact as int64) as idcontact,
+        cast(iddevice as int64) as iddevice,
+
+        -- Timestamps harmonisés
+        -- La source ne porte ni creation_date ni modification_date : pas de
+        -- created_at / updated_at exposables (cf. autres tables de jonction).
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+
+    from source_data
+)
+
+select * from cleaned_data

--- a/models/staging/oracle_neshu/_oracle_neshu__models.yml
+++ b/models/staging/oracle_neshu/_oracle_neshu__models.yml
@@ -89,6 +89,41 @@ models:
                 to: ref('stg_oracle_neshu__company')
                 field: idcompany
 
+  # CONTACT_HAS_DEVICE
+  - name: stg_oracle_neshu__contact_has_device
+    description: >
+      Rattachement d'une machine au membre du personnel interne qui en a la charge
+      (approvisionneur / technicien). Grain : 1 ligne par couple contact × device.
+      Le contact se raccroche à une ressource via son `code` (aucune FK idresources
+      dans la source). Couvre ~29 % du parc actif NESHU.
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns:
+              - idcontact
+              - iddevice
+    columns:
+      - name: idcontact
+        description: "Identifiant du contact (personnel interne — code aligné sur resources.code)"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_oracle_neshu__contact')
+                field: idcontact
+      - name: iddevice
+        description: "Identifiant du device rattaché"
+        tests:
+          - not_null
+          - relationships:
+              arguments:
+                to: ref('stg_oracle_neshu__device')
+                field: iddevice
+      - name: extracted_at
+        description: "Date d'extraction de la ligne"
+      - name: deleted_at
+        description: "Date de suppression logique de la ligne"
+
   # CONTRACT
   - name: stg_oracle_neshu__contract
     description: "Contrats transformés et nettoyés depuis la base Oracle"

--- a/models/staging/oracle_neshu/_oracle_neshu__sources.yml
+++ b/models/staging/oracle_neshu/_oracle_neshu__sources.yml
@@ -160,6 +160,23 @@ sources:
           - name: modification_date
             description: "Date de modification de la ligne"
 
+      # CONTACT_HAS_DEVICE
+      - name: evs_contact_has_device
+        description: >
+          Table de jonction contact <-> device : rattachement d'une machine au
+          personnel interne (approvisionneur / technicien) qui en a la charge.
+          Aucune colonne temporelle métier ni code_status_record : seuls les _sdc_*
+          sont disponibles.
+        columns:
+          - name: idcontact
+            tests:
+              - not_null
+            description: "Identifiant du contact (personnel interne — code aligné sur resources.code)"
+          - name: iddevice
+            tests:
+              - not_null
+            description: "Identifiant du device"
+
       # CONTRACT
       - name: evs_contract
         description: "Table des contrats"

--- a/models/staging/oracle_neshu/stg_oracle_neshu__contact_has_device.sql
+++ b/models/staging/oracle_neshu/stg_oracle_neshu__contact_has_device.sql
@@ -1,0 +1,28 @@
+{{
+    config(
+        materialized='table',
+        description='contact_has_device nettoyés et enrichis depuis evs_contact_has_device — rattachement machine / personnel interne'
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('oracle_neshu', 'evs_contact_has_device') }}
+),
+
+cleaned_data as (
+    select
+        -- IDs convertis en BIGINT
+        cast(idcontact as int64) as idcontact,
+        cast(iddevice as int64) as iddevice,
+
+        -- Timestamps harmonisés
+        -- La source ne porte ni creation_date ni modification_date : pas de
+        -- created_at / updated_at exposables (cf. autres tables de jonction).
+        timestamp(_sdc_extracted_at) as extracted_at,
+        timestamp(_sdc_deleted_at) as deleted_at
+
+    from source_data
+)
+
+select * from cleaned_data


### PR DESCRIPTION
## Contexte

Deux tables de jonction `contact_has_device` ont été ajoutées à `prod_raw` (extract déjà en place dans les deux `meltano.yml`). Cette PR les déclare en source et crée leur staging.

**Ce que contient réellement la table** : le rattachement d'une machine au membre du **personnel interne** qui en a la charge (approvisionneur / technicien) — et non des contacts clients. Les codes contact sont alignés sur `resources.code` (`APPRO01`…`APPRO13`, `APPROEXTERIEUR` côté LCDP ; `AKONE`, `FSAHBI`, `XLELU`… côté NESHU), tous rattachés à la société interne.

## Analyse préalable (BigQuery)

| | LCDP | NESHU |
|---|---|---|
| Lignes / devices / contacts | 732 / 730 / 14 | 1 425 / 1 425 / 34 |
| Devices à plusieurs contacts | 2 | 0 |
| Contacts résolus vers `dim__resource` par le code | 14/14 | 34/34 |
| Couverture parc actif | 26,7 % | 29,4 % |
| Concordance avec le roadman observé sur le terrain (90 j) | 90,9 % | 84,1 % |

Couverture du périmètre du dashboard LCDP : **107/108** machines de `fct_lcdp__chargement_sortie`, **168/169** de `fct_lcdp__ca_mensuel`.

## Contenu

- **Sources** — `lcdp_contact_has_device` + `evs_contact_has_device`, insérées entre `contact` et `contract`, `not_null` sur les deux clés. La source ne porte ni `creation_date`, ni `modification_date`, ni `code_status_record` : acté dans la description.
- **Staging** — `stg_oracle_lcdp__contact_has_device` + `stg_oracle_neshu__contact_has_device`, calqués sur `stg_*__label_has_device` : cast `int64` des IDs, `extracted_at` / `deleted_at` depuis les `_sdc_*`, `description` dans le config block. Pas de `created_at` / `updated_at` — c'est le pattern des autres tables de jonction.
- **Tests** — `not_null` + `relationships` vers `contact` et `device` sur chaque clé, `dbt_utils.unique_combination_of_columns` sur `(idcontact, iddevice)` (PK réelle, vérifiée unique sur les deux sources).

## Validation

`sqlfluff` clean, `dbt build --target dev` OK sur les deux modèles, **10/10 tests au vert**.

Note : le test `relationships` sur `iddevice` échouait initialement côté NESHU parce que `dev_staging.stg_oracle_neshu__device` datait du 4 juillet (6 167 lignes vs 6 183 en prod) — **zéro orphelin contre prod**. Résolu en reconstruisant la table en dev. En CI, `pr-check` tourne avec `--defer --state state/`, donc les refs non construites pointent sur prod.

## Points d'attention pour la revue

- La jointure `contact` → `resources` se fait par le **code**, il n'y a aucune FK `idresources` dans la source. `contact.code` n'est pas unique globalement (38 doublons LCDP, 52 NESHU) mais **aucun ne touche les contacts utilisés ici** (tous internes) — jointure vérifiée sans fan-out (732 → 732, 1 425 → 1 425). À border au moment de l'intégration dans les dims.
- 2 machines LCDP portent 2 contacts (`M7077`, `M5114` — machines à café, hors périmètre DA FROID). Nécessitera une règle déterministe côté dim.
- 5 affectations NESHU pointent vers un roadman inactif.

## Hors périmètre de cette PR

L'exposition de la ressource affectée dans `dim_lcdp__device` / `dim_neshu__device` (nommage `assigned_resource_*` à valider), qui permettra de répondre à la demande roadman du dashboard LCDP sans toucher au grain des faits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dhqo6RaZ6ee5V1tatatrDM