### PR TITLE
fix(neshu): comparer code_status_record a un entier dans dim_neshu__device

### DIFF
--- a/models/marts/neshu/dim_neshu__device.sql
+++ b/models/marts/neshu/dim_neshu__device.sql
@@ -30,7 +30,7 @@ with device_labels as (
         on d.idlocation = lo.idlocation
     where
         d.idcompany_customer is not null
-        and d.code_status_record <> '-1'  -- exclude ERP ghost-deletes
+        and d.code_status_record <> -1  -- exclude ERP ghost-deletes
 ),
 
 aggregated_labels as (


### PR DESCRIPTION
## Contexte

La CD de prod a échoué après la migration de `oracle_neshu` vers dlt, avec deux erreurs.

Le `meltano.yml` avait `use_singer_decimal: true`, qui faisait remonter **tous les nombres en chaînes**. dlt les type correctement : **340 colonnes** de `prod_raw.evs_*` ont changé de type, dont 274 de `STRING` vers `FLOAT64`.

## Erreur 1 — corrigée ici, une ligne

```
No matching signature for operator != for argument types: FLOAT64, STRING
```

`dim_neshu__device` lit `stg_oracle_neshu__device`, qui n'a jamais casté `code_status_record` : la colonne suit donc le type du raw et devient numérique. La comparaison à `'-1'` ne passait que par coercition implicite.

Confirmé par ses quatre modèles frères — `dim_neshu__product`, `__company`, `__contract`, `__resource` — qui comparent **déjà** à `-1`. `device` était l'intrus.

**Les 14 comparaisons `t.code_status_record = '1'` des modèles `intermediate` ne sont PAS touchées** : elles lisent `stg_oracle_neshu__task`, qui fait `cast(code_status_record as string)`, exactement comme `stg_oracle_lcdp__task` déjà migré et en production.

## Erreur 2 — aucun changement de code

```
Value of type FLOAT64 cannot be assigned to spantime, which has type STRING
```

Le modèle fait déjà `cast(spantime as float64)`. C'est la table de prod qui portait encore `STRING`, et BigQuery n'altère pas une colonne.

Résolu par un **`--full-refresh` en prod déjà appliqué** sur les 5 modèles incrémentaux : `PASS=346 ERROR=0`.

## Validation

| Environnement | Résultat |
|---|---|
| `dbt build --target dev --select tag:oracle_neshu --full-refresh` | `PASS=346 WARN=0 ERROR=0 SKIP=0` |
| `dbt build --target prod --select tag:oracle_neshu --full-refresh` | `PASS=346 WARN=0 ERROR=0 SKIP=0` |

Le scheduler `pipeline-oracle-neshu-dlt-intraday` est suspendu le temps de l'opération, à réactiver après le merge.