### PR TITLE
refactor(neshu): parser le XML de CONTRACT dans dbt, supprimer evs_contract_parsed

### DIFF
--- a/macros/neshu/decoder_entites_xml.sql
+++ b/macros/neshu/decoder_entites_xml.sql
@@ -1,0 +1,16 @@
+{#
+    Décode les entités XML d'une chaîne extraite par regexp.
+
+    Nécessaire depuis que le parsing du XML de CONTRACT est fait en SQL plutôt que
+    par un script Python : ElementTree décodait les entités, une expression
+    régulière non. Sur les 306 contrats de NESHU, un seul contient `&apos;`, et
+    sans ce décodage la valeur différait de celle produite par l'ancien script.
+
+    `&amp;` est traité EN DERNIER, sinon `&amp;apos;` deviendrait `'` au lieu de
+    `&apos;` — l'esperluette doit être la dernière entité restaurée.
+#}
+{% macro decoder_entites_xml(colonne) %}
+    replace(replace(replace(replace(replace(
+        {{ colonne }},
+        '&apos;', "'"), '&quot;', '"'), '&lt;', '<'), '&gt;', '>'), '&amp;', '&')
+{% endmacro %}

--- a/models/staging/oracle_neshu/_oracle_neshu__sources.yml
+++ b/models/staging/oracle_neshu/_oracle_neshu__sources.yml
@@ -199,23 +199,6 @@ sources:
           - name: CURRENT_END_DATE
             description: "Date de fin courant du contrat"
 
-      - name: evs_contract_parsed
-        description: "Contrats parsés (extraction Python custom)"
-        config:
-          freshness: null
-        columns:
-          - name: idcontract
-            tests:
-              - unique
-              - not_null
-            description: "Identifiant unique du contrat"
-          - name: nombre_collab
-            description: "Nombre collab du contrat"
-          - name: engagement
-            description: "Engagement consommation du contrat"
-          - name: extracted_at
-            description: "Meta donnée d'extraction script python"
-
       # DEVICE
       - name: evs_device
         description: "Table des machines/équipements parc"

--- a/models/staging/oracle_neshu/stg_oracle_neshu__contract.sql
+++ b/models/staging/oracle_neshu/stg_oracle_neshu__contract.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        description='Contrats nettoyés et enrichis depuis evs_contract et evs_contract_parsed (XML parsé).'
+        description='Contrats nettoyés depuis evs_contract, colonne XML parsée ici même.'
     )
 }}
 
@@ -28,28 +28,50 @@ with source_data as (
     from {{ source('oracle_neshu', 'evs_contract') }}
 ),
 
+-- Le XML de CONTRACT etait parse par un script Python separe
+-- (ingest_oracle_evs_contract -> prod_raw.evs_contract_parsed), parce que le tap
+-- Meltano ne savait pas lire une colonne XMLTYPE et la laissait NULL. dlt la charge
+-- en texte, donc le parsing revient ici : un job, une table et une image en moins.
+--
+-- Les entites XML doivent etre decodees : ElementTree le faisait, une regex non.
+-- Sur les 306 contrats, un seul contient `&apos;` — sans ce decodage la valeur
+-- differait de celle du script. `&amp;` est traite EN DERNIER, sinon `&amp;apos;`
+-- deviendrait `'` au lieu de `&apos;`.
+--
+-- Equivalence verifiee le 2026-08-01 contre evs_contract_parsed : 306/306 lignes
+-- identiques sur nombre_collab ET engagement.
+extraction_xml as (
+    select
+        idcontract,
+        regexp_extract(xml, r'<NOMBRE_COLLAB>([^<]*)</NOMBRE_COLLAB>') as nombre_collab_brut,
+        regexp_extract(xml, r'<ENGAGEMENT>([^<]*)</ENGAGEMENT>')       as engagement_brut
+    from source_data
+),
+
 parsed_data as (
     select
-        cast(idcontract as int64) as idcontract,
+        idcontract,
 
         -- nombre_collab → conversion en entier
-        cast(nullif(trim(nombre_collab), '') as int64) as nombre_collab,
+        cast(nullif(trim({{ decoder_entites_xml('nombre_collab_brut') }}), '') as int64) as nombre_collab,
 
         -- garder la valeur brute telle quelle
-        trim(engagement) as engagement_raw,
+        trim({{ decoder_entites_xml('engagement_brut') }}) as engagement_raw,
 
         -- version nettoyée numérique
         -- nullif protège le cast quand l'extraction ne contient aucun chiffre
         -- (ex. saisie texte libre « PAS D'ENGAGEMENT ») → NULL au lieu de Bad int64
         case
-            when upper(trim(engagement)) = 'AUCUN' then 0
+            when upper(trim({{ decoder_entites_xml('engagement_brut') }})) = 'AUCUN' then 0
             else cast(
-                nullif(regexp_replace(regexp_extract(engagement, r'[\d\s]+'), r'\s+', ''), '') as int64
+                nullif(
+                    regexp_replace(regexp_extract({{ decoder_entites_xml('engagement_brut') }}, r'[\d\s]+'), r'\s+', ''),
+                    ''
+                ) as int64
             )
-        end as engagement_clean,
+        end as engagement_clean
 
-        timestamp(extracted_at) as parsed_extracted_at
-    from {{ source('oracle_neshu', 'evs_contract_parsed') }}
+    from extraction_xml
 ),
 
 cleaned_data as (
@@ -66,7 +88,7 @@ cleaned_data as (
         c.code,
         c.name,
         c.code_status_record,
-        -- Colonnes enrichies depuis evs_contract_parsed
+        -- Colonnes extraites du XML (cf. CTE extraction_xml)
         p.nombre_collab,
         p.engagement_raw,
         p.engagement_clean,
@@ -76,7 +98,6 @@ cleaned_data as (
         timestamp(c.current_end_date) as current_end_date,
         timestamp(c.termination_date) as termination_date,
 
-        timestamp(p.parsed_extracted_at) as parsed_extracted_at,
         timestamp(c.creation_date) as created_at,
         timestamp(coalesce(c.modification_date, c.creation_date)) as updated_at,
         timestamp(c._extracted_at) as extracted_at

--- a/models/staging/oracle_neshu/stg_oracle_neshu__contract.sql
+++ b/models/staging/oracle_neshu/stg_oracle_neshu__contract.sql
@@ -44,8 +44,16 @@ extraction_xml as (
     select
         idcontract,
         regexp_extract(xml, r'<NOMBRE_COLLAB>([^<]*)</NOMBRE_COLLAB>') as nombre_collab_brut,
-        regexp_extract(xml, r'<ENGAGEMENT>([^<]*)</ENGAGEMENT>')       as engagement_brut
+        regexp_extract(xml, r'<ENGAGEMENT>([^<]*)</ENGAGEMENT>') as engagement_brut
     from source_data
+),
+
+decode_xml as (
+    select
+        idcontract,
+        {{ decoder_entites_xml('nombre_collab_brut') }} as nombre_collab,
+        {{ decoder_entites_xml('engagement_brut') }} as engagement
+    from extraction_xml
 ),
 
 parsed_data as (
@@ -53,25 +61,22 @@ parsed_data as (
         idcontract,
 
         -- nombre_collab → conversion en entier
-        cast(nullif(trim({{ decoder_entites_xml('nombre_collab_brut') }}), '') as int64) as nombre_collab,
+        cast(nullif(trim(nombre_collab), '') as int64) as nombre_collab,
 
         -- garder la valeur brute telle quelle
-        trim({{ decoder_entites_xml('engagement_brut') }}) as engagement_raw,
+        trim(engagement) as engagement_raw,
 
         -- version nettoyée numérique
         -- nullif protège le cast quand l'extraction ne contient aucun chiffre
         -- (ex. saisie texte libre « PAS D'ENGAGEMENT ») → NULL au lieu de Bad int64
         case
-            when upper(trim({{ decoder_entites_xml('engagement_brut') }})) = 'AUCUN' then 0
+            when upper(trim(engagement)) = 'AUCUN' then 0
             else cast(
-                nullif(
-                    regexp_replace(regexp_extract({{ decoder_entites_xml('engagement_brut') }}, r'[\d\s]+'), r'\s+', ''),
-                    ''
-                ) as int64
+                nullif(regexp_replace(regexp_extract(engagement, r'[\d\s]+'), r'\s+', ''), '') as int64
             )
         end as engagement_clean
 
-    from extraction_xml
+    from decode_xml
 ),
 
 cleaned_data as (


### PR DESCRIPTION
Premier volet du démantèlement Meltano sur `oracle_neshu`.

## Pourquoi

`ingest_oracle_evs_contract` était un script Python séparé qui lisait `EVS.CONTRACT`, parsait sa colonne `XMLTYPE` avec ElementTree, et écrivait `prod_raw.evs_contract_parsed`. Il n'existait que parce que **le tap Meltano ne savait pas lire une colonne XMLTYPE** et la laissait NULL.

dlt la charge en texte. Le parsing revient donc dans dbt — un job Cloud Run, une image et une table BigQuery en moins.

## La subtilité

`ElementTree` décode les entités XML, une expression régulière non. Sur les 306 contrats, **un seul** contient `&apos;` :

```
sans décodage : "PAS D&apos;ENGAMEMENT"
avec décodage : "PAS D'ENGAMEMENT"     <- ce que le script produisait
```

D'où la macro `decoder_entites_xml`, qui traite `&amp;` **en dernier** : sinon `&amp;apos;` deviendrait `'` au lieu de `&apos;`.

## Équivalence prouvée

| Comparaison | Résultat |
|---|---|
| contre `prod_raw.evs_contract_parsed` (source du script) | **306/306** sur `nombre_collab` et `engagement` |
| contre `prod_staging.stg_oracle_neshu__contract` (ce que la prod produit) | **306/306** sur les trois colonnes |

Les trois colonnes lues par `dim_neshu__contract` — `nombre_collab`, `engagement_raw`, `engagement_clean` — sont préservées à l'identique. `parsed_extracted_at` est supprimée : horodatage du script disparu, aucun consommateur.

## Suite

Une fois mergé : suppression du job `ingest-oracle-evs-contract`, de son image, de la table `evs_contract_parsed` et du projet dans `extract_load/`.