### PR TITLE
docs: aligner pipeline-schedule.md sur la realite des workflows Oracle

### DIFF
--- a/docs/pipeline-schedule.md
+++ b/docs/pipeline-schedule.md
@@ -27,13 +27,12 @@ marts aval). Le transform n'a plus d'horaire propre : il suit la fin de l'EL de 
 
 ```
 00h ─────────────────────────────────────────────────────────────────────────────
-01:00  EL+T  oracle_neshu, oracle_lcdp(1-6), mssql_sage(1-5), yuman(1-5) → raw+stg+int + marts neshu/lcdp/finance/technique/supply_chain
+01:00  EL+T  oracle_neshu(1-5), oracle_lcdp(1-5), oracle_nayka(1-5), mssql_sage(1-5), yuman(1-5) → raw+stg+int + marts neshu/lcdp/finance/technique/supply_chain
 03:00  EL+T  zoho_desk (1-5)                                          → raw+stg+int (pas de marts à ce jour)
 06:00  EL+T  yuman_gcs (1-6)                                          → + marts supply_chain
 07:30  EL+T  nesp_tech (lundi seulement)                              → + marts technique, commerce
 08:00  EL+T  sftp_evs/gac, nesp_co                                    → + marts services_generaux, commerce
 09:00  SN    transform-snapshots-daily (tous snapshots)
-08,11,15h  EL+T  passages-appro-neshu (fast-lane: tap appro + selector passage_appro_fastlane_neshu) → fct_neshu__passage_appro
 08,15,18h  EL+T  oracle_lcdp (périmètre complet + refresh PBI)             → marts lcdp, supply_chain
 23:00  EL+T  oracle_stock_theorique                                  → + marts supply_chain
 23:15  EL+T  oracle_lcdp_stock_theorique                             → + marts supply_chain (lcdp)
@@ -55,12 +54,12 @@ homonyme dans `workflows/*.yaml`.
 
 | Scheduler | Cron | Jours | Workflow ciblé | Source |
 |---|---|---|---|---|
-| pipeline-oracle-neshu | `0 1 * * *` | tous | pipeline-oracle-neshu.yaml | oracle_neshu |
-| pipeline-oracle-neshu-full-refresh | `0 4 * * 0` | dim | pipeline-oracle-neshu-full-refresh.yaml | oracle_neshu (full) |
-| pipeline-passages-appro-neshu | `0 8,11,15 * * 1-5` | lun-ven | pipeline-passages-appro-neshu.yaml | oracle_neshu (fast-lane appro: EL `tap-oracle-appro-fastlane` + dbt selector `passage_appro_fastlane_neshu` + refresh PBI) |
-| pipeline-oracle-lcdp-dlt | `0 1 * * 1-6` | lun-sam | pipeline-oracle-lcdp-dlt.yaml | oracle_lcdp (EL dlt + dbt + refresh PBI) |
-| pipeline-oracle-lcdp-dlt-intraday | `0 8,15,18 * * 1-5` | lun-ven | *(même workflow)* | oracle_lcdp — second déclencheur du workflow ci-dessus |
-| pipeline-oracle-lcdp-dlt-purge | `0 4 * * 0` | dim | pipeline-oracle-lcdp-dlt-purge.yaml | oracle_lcdp (`--purge-deletes` : supprime les lignes effacées à la source) |
+| pipeline-oracle-neshu | `0 1 * * 1-5` | lun-ven | pipeline-oracle-neshu.yaml | oracle_neshu (EL dlt + dbt + refresh PBI) |
+| pipeline-oracle-neshu-intraday | `0 8,11,15 * * 1-5` | lun-ven | *(même workflow)* | oracle_neshu — second déclencheur du workflow ci-dessus |
+| pipeline-oracle-neshu-purge | `0 4 * * 0` | dim | pipeline-oracle-neshu-purge.yaml | oracle_neshu (`--purge-deletes` : supprime les lignes effacées à la source) |
+| pipeline-oracle-lcdp | `0 1 * * 1-5` | lun-ven | pipeline-oracle-lcdp.yaml | oracle_lcdp (EL dlt + dbt + refresh PBI) |
+| pipeline-oracle-lcdp-intraday | `0 8,15,18 * * 1-5` | lun-ven | *(même workflow)* | oracle_lcdp — second déclencheur du workflow ci-dessus |
+| pipeline-oracle-lcdp-purge | `0 4 * * 0` | dim | pipeline-oracle-lcdp-purge.yaml | oracle_lcdp (`--purge-deletes` : supprime les lignes effacées à la source) |
 | pipeline-mssql-sage | `0 1 * * 1-5` | lun-ven | pipeline-mssql-sage.yaml | mssql_sage |
 | pipeline-yuman | `0 1 * * 1-5` | lun-ven | pipeline-yuman.yaml | yuman |
 | pipeline-zoho-desk | `0 3 * * 1-5` | lun-ven | pipeline-zoho-desk.yaml | zoho_desk |
@@ -69,10 +68,6 @@ homonyme dans `workflows/*.yaml`.
 | pipeline-sftp-evs | `0 8 * * *` | tous | pipeline-sftp-evs.yaml | gac |
 | pipeline-nesp-co | `0 8 * * *` | tous | pipeline-nesp-co.yaml | nesp_co |
 | pipeline-oracle-stock-theorique | `0 23 * * *` | tous | pipeline-oracle-stock-theorique.yaml | oracle_neshu_gcs |
-
-> Le pipeline `pipeline-passages-appro-neshu` est une **voie rapide** (EL partiel +
-> dbt par selector + refresh PBI), pas un EL standard. Détail du design et dépannage :
-> [`docs/architecture/passages-appro-fast-lane.md`](architecture/passages-appro-fast-lane.md).
 
 ### 2.2 Transform (dbt) — embarqué dans les pipelines EL (Option C)
 
@@ -83,7 +78,7 @@ après son extract/load, un `dbt build --select source:<source>+` (étape `run_d
 | Pipeline EL | Sélecteur build | Marts reconstruits (BU aval via lignage) |
 |---|---|---|
 | pipeline-oracle-neshu | `source:oracle_neshu+` | neshu, supply_chain |
-| pipeline-oracle-lcdp-dlt | `source:oracle_lcdp+` | lcdp, supply_chain |
+| pipeline-oracle-lcdp | `source:oracle_lcdp+` | lcdp, supply_chain |
 | pipeline-yuman | `source:yuman_api+` | neshu, technique |
 | pipeline-sftp-gcs-yuman | `source:yuman_gcs+` | supply_chain |
 | pipeline-nesp-tech | `source:nesp_tech+` | technique, commerce |
@@ -94,7 +89,6 @@ après son extract/load, un `dbt build --select source:<source>+` (étape `run_d
 | pipeline-oracle-lcdp-stock-theorique | `source:oracle_lcdp_gcs+` | supply_chain (lcdp) |
 | pipeline-zoho-desk | `source:zoho_desk+` | — (pas de marts à ce jour) |
 
-> `pipeline-oracle-neshu-full-refresh` garde `tag:oracle_neshu` (+`--full-refresh`, staging/int).
 > Snapshots exclus de tout `dbt build` via `--exclude resource_type:snapshot` (entrypoint).
 
 ### 2.3 Snapshots


### PR DESCRIPTION
Documentation seule, aucun modèle touché.

Trois écarts entre le document et l'infrastructure réelle, corrigés :

| Écart | Réalité |
|---|---|
| suffixe `-dlt` sur les jobs et workflows Oracle | retiré — il servait à la coexistence avec les jumeaux Meltano, détruits |
| `pipeline-oracle-neshu-full-refresh` et `pipeline-passages-appro-neshu` listés | supprimés de GCP |
| crons `0 1 * * *` (neshu) et `0 1 * * 1-6` (lcdp) | les trois pipelines Oracle sont désormais en `0 1 * * 1-5` |

Ajoute `pipeline-oracle-neshu-intraday` et `-purge`, absents du tableau, et `oracle_nayka` à la frise de 01:00.