### PR TITLE
fix(mssql_sage): colonnes techniques dlt au lieu des _sdc_ de Meltano

### DIFF
--- a/models/staging/mssql_sage/_mssql_sage__models.yml
+++ b/models/staging/mssql_sage/_mssql_sage__models.yml
@@ -48,8 +48,6 @@ models:
         description: "Timestamp de dernière modification"
       - name: extracted_at
         description: "Timestamp d'extraction"
-      - name: deleted_at
-        description: "Timestamp de suppression logique"
 
   - name: stg_mssql_sage__f_ecriturec
     description: "Écritures comptables nettoyées issues du système MSSQL Sage. Déduplication staging sur ec_no — clé unique métier Sage — en gardant le cb_marq le plus récent (Sage crée parfois un nouveau cb_marq sur update au lieu de modifier la ligne existante, l'ancien étant supprimé)."
@@ -111,8 +109,6 @@ models:
         description: "Timestamp de dernière modification"
       - name: extracted_at
         description: "Timestamp d'extraction"
-      - name: deleted_at
-        description: "Timestamp de suppression logique"
 
   # TABLE COMPTE NUNSHEN COMMERCE
   - name: stg_mssql_sage__f_comptet
@@ -175,9 +171,7 @@ models:
       - name: updated_at
         description: "Date de dernière modification du compte client (cb_modification)"
       - name: extracted_at
-        description: "Timestamp d'extraction depuis la source (_sdc_extracted_at)"
-      - name: deleted_at
-        description: "Timestamp de suppression logique source (_sdc_deleted_at)"
+        description: "Timestamp du run dlt qui a chargé la ligne (_extracted_at)"
 
   # TABLE COLLABORATEUR NUNSHEN COMMERCE
   - name: stg_mssql_sage__f_collaborateur
@@ -204,9 +198,7 @@ models:
       - name: updated_at
         description: "Date de dernière modification du collaborateur (cb_modification)"
       - name: extracted_at
-        description: "Timestamp d'extraction depuis la source (_sdc_extracted_at)"
-      - name: deleted_at
-        description: "Timestamp de suppression logique source (_sdc_deleted_at)"
+        description: "Timestamp du run dlt qui a chargé la ligne (_extracted_at)"
 
 
   # TABLE DOCLIGNE NUNSHEN COMMERCE
@@ -271,6 +263,4 @@ models:
       - name: updated_at
         description: "Date de dernière modification de la ligne document (cb_modification)"
       - name: extracted_at
-        description: "Timestamp d'extraction depuis la source (_sdc_extracted_at)"
-      - name: deleted_at
-        description: "Timestamp de suppression logique source (_sdc_deleted_at)"
+        description: "Timestamp du run dlt qui a chargé la ligne (_extracted_at)"

--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -11,7 +11,7 @@ sources:
 
       # Freshness: tier Standard — 26h warn / 48h error
       # Cf. docs/freshness.md
-      loaded_at_field: _sdc_extracted_at
+      loaded_at_field: _extracted_at
       freshness:
         warn_after: {count: 26, period: hour}
         error_after: {count: 48, period: hour}
@@ -54,18 +54,10 @@ sources:
             description: "Horodatage de création de la ligne"
           - name: cb_creation_user
             description: "Utilisateur ayant créé la ligne (UUID)"
-          - name: _sdc_received_at
-            description: "Timestamp de réception du flux par Singer/ETL"
-          - name: _sdc_extracted_at
-            description: "Timestamp d’extraction initiale"
-          - name: _sdc_batched_at
-            description: "Timestamp de regroupement du lot"
-          - name: _sdc_deleted_at
-            description: "Timestamp de suppression logique (si applicable)"
-          - name: _sdc_table_version
-            description: "Version de la table dans le flux d’ingestion"
-          - name: _sdc_sequence
-            description: "Numéro de séquence du flux pour suivi d’ordre"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"
 
         # PK testée sur cb_marq (cf. colonne). L'unicité de la clé métier
         # (ec_no, n_analytique, ea_ligne) reste testée au staging après dédup.
@@ -223,18 +215,10 @@ sources:
             description: "Identifiant SAC (non documenté Sage)"
           - name: cb_sac_id
             description: "Identifiant SAC encodé (non documenté Sage)"
-          - name: _sdc_received_at
-            description: "Timestamp d’ingestion du flux par Singer/ETL"
-          - name: _sdc_extracted_at
-            description: "Timestamp d’extraction"
-          - name: _sdc_batched_at
-            description: "Timestamp de batch"
-          - name: _sdc_deleted_at
-            description: "Timestamp de suppression logique"
-          - name: _sdc_table_version
-            description: "Version de la table dans le flux d’ingestion"
-          - name: _sdc_sequence
-            description: "Numéro de séquence du flux"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"
 
 
       # NUNSHEN COMMERCE : TABLE COMPTE (overwrite)
@@ -260,18 +244,10 @@ sources:
             description: "Horodatage de création (TIMESTAMP)"
           - name: cb_modification
             description: "Horodatage de dernière modification (TIMESTAMP)"
-          - name: _sdc_extracted_at
-            description: "Timestamp d'extraction depuis la source"
-          - name: _sdc_received_at
-            description: "Timestamp de réception"
-          - name: _sdc_batched_at
-            description: "Timestamp de traitement du batch"
-          - name: _sdc_deleted_at
-            description: "Timestamp de suppression logique source"
-          - name: _sdc_sequence
-            description: "Identifiant de séquence pour la réplication"
-          - name: _sdc_table_version
-            description: "Version de la table source pour la réplication"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"
 
       # NUNSHEN COMMERCE : TABLE COLLABORATEUR (overwrite)
       - name: dbo_f_collaborateur
@@ -294,18 +270,10 @@ sources:
             description: "Horodatage de création (TIMESTAMP)"
           - name: cb_modification
             description: "Horodatage de dernière modification (TIMESTAMP)"
-          - name: _sdc_extracted_at
-            description: "Timestamp d'extraction depuis la source"
-          - name: _sdc_received_at
-            description: "Timestamp de réception"
-          - name: _sdc_batched_at
-            description: "Timestamp de traitement du batch"
-          - name: _sdc_deleted_at
-            description: "Timestamp de suppression logique source"
-          - name: _sdc_sequence
-            description: "Identifiant de séquence pour la réplication"
-          - name: _sdc_table_version
-            description: "Version de la table source pour la réplication"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"
 
       # NUNSHEN COMMERCE : TABLE DOCLIGNE (incrémental)
       - name: dbo_f_docligne
@@ -336,15 +304,7 @@ sources:
             description: "Horodatage de création (TIMESTAMP)"
           - name: cb_modification
             description: "Horodatage de dernière modification (TIMESTAMP)"
-          - name: _sdc_extracted_at
-            description: "Timestamp d'extraction depuis la source"
-          - name: _sdc_received_at
-            description: "Timestamp de réception"
-          - name: _sdc_batched_at
-            description: "Timestamp de traitement du batch"
-          - name: _sdc_deleted_at
-            description: "Timestamp de suppression logique source"
-          - name: _sdc_sequence
-            description: "Identifiant de séquence pour la réplication"
-          - name: _sdc_table_version
-            description: "Version de la table source pour la réplication"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"

--- a/models/staging/mssql_sage/stg_mssql_sage__f_collaborateur.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_collaborateur.sql
@@ -24,8 +24,7 @@ cleaned_data as (
         -- Metadata
         cb_creation as created_at,
         coalesce(cb_modification, cb_creation) as updated_at,
-        _sdc_extracted_at as extracted_at,
-        _sdc_deleted_at as deleted_at
+        _extracted_at as extracted_at
 
     from source_data
 )

--- a/models/staging/mssql_sage/stg_mssql_sage__f_comptet.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_comptet.sql
@@ -43,8 +43,7 @@ cleaned_data as (
         -- Metadata
         cb_creation as created_at,
         coalesce(cb_modification, cb_creation) as updated_at,
-        _sdc_extracted_at as extracted_at,
-        _sdc_deleted_at as deleted_at
+        _extracted_at as extracted_at
 
     from source_data
 )

--- a/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_docligne.sql
@@ -46,8 +46,7 @@ cleaned_data as (
         -- Metadata
         cb_creation as created_at,
         coalesce(cb_modification, cb_creation) as updated_at,
-        _sdc_extracted_at as extracted_at,
-        _sdc_deleted_at as deleted_at
+        _extracted_at as extracted_at
     from source_data
 )
 

--- a/models/staging/mssql_sage/stg_mssql_sage__f_ecriturea.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_ecriturea.sql
@@ -38,8 +38,7 @@ cleaned_data as (
         cb_creation as created_at,
         -- Fallback to cb_creation when cb_modification is null
         coalesce(cb_modification, cb_creation) as updated_at,
-        _sdc_extracted_at as extracted_at,
-        _sdc_deleted_at as deleted_at
+        _extracted_at as extracted_at
 
     from source_data
 )

--- a/models/staging/mssql_sage/stg_mssql_sage__f_ecriturec.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_ecriturec.sql
@@ -50,8 +50,7 @@ cleaned_data as (
         cb_creation_user,
         cb_creation as created_at,
         coalesce(cb_modification, cb_creation) as updated_at,
-        _sdc_extracted_at as extracted_at,
-        _sdc_deleted_at as deleted_at
+        _extracted_at as extracted_at
 
     from source_data
 )


### PR DESCRIPTION
Accompagne la migration de `elt_mssql_sage` de Meltano vers dlt
([ingestion#1](https://github.com/CebrailEVS/ingestion/pull/1)). `prod_raw.dbo_f_*` ne
porte plus les colonnes `_sdc_*` de Singer.

## Changements

- `_sdc_extracted_at as extracted_at` → `_extracted_at as extracted_at` (5 modèles)
- `_sdc_deleted_at as deleted_at` retiré : dlt ne fait pas de suppression logique, et
  la colonne était NULL partout
- `loaded_at_field` des sources : `_sdc_extracted_at` → `_extracted_at`
- 60 lignes de documentation de colonnes `_sdc_*` retirées, remplacées par les 5 blocs
  décrivant les colonnes techniques dlt

## Validation

`dbt build --target dev --select source:mssql_sage+` contre le **vrai** `prod_raw`
rechargé par dlt : **PASS=60, WARN=0, ERROR=0**.

Contrôle métier — P&L reconstruit sur dlt contre celui en production :

| Année | Écart |
|---|---|
| 2024 | **0,00 €** (996 lignes de part et d'autre) |
| 2025 | **0,00 €** (1068 lignes) |
| 2026 | +299 439 € sur les KPI de base, 660 lignes de part et d'autre |

Deux années closes qui se reproduisent au centime : les 39 colonnes passées de
`FLOAT64` à `NUMERIC` ne changent aucune valeur. L'écart 2026 tient à la fraîcheur —
le mart de production a été construit le 30/07 à 23:08, la source a bougé jusqu'au
31/07 à 17:04 (99 360 € de `ea_montant` modifiés depuis) — et au retrait de 52 lignes
fantômes présentes dans BigQuery mais absentes de la source. Il n'a pas été décomposé
à l'euro près.

Aucun modèle en aval n'est incrémental : le changement de type ne peut pas déclencher
l'erreur « BigQuery n'altère pas une colonne ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUokh8wiTL3F4jgZjYqRnL