### PR TITLE
feat(mssql_sage): trois dimensions Sage et leurs relationships

### DIFF
--- a/.claude/skills/check-staging-relationships/SKILL.md
+++ b/.claude/skills/check-staging-relationships/SKILL.md
@@ -35,6 +35,17 @@ $P/.venv/bin/python .claude/skills/discover-sql-source/discover.py $P \
 Ce fichier ne bouge qu'à une montée de version de l'ERP. Le rafraîchir de temps en
 temps, pas à chaque build.
 
+**Il ne décrit QUE la source** — toutes ses tables et vues, leurs clés primaires, toutes
+ses clés étrangères. Il ne sait rien du périmètre répliqué : c'est cette compétence qui
+croise, en lisant les `source()` du manifest. Une table de la source sans modèle staging
+sort simplement de l'univers auditable.
+
+**Les clés composites ont leur propre famille (1b).** Le test `relationships` de dbt ne
+porte que sur UNE colonne : elles ne sont pas couvrables telles quelles. Tester une seule
+de leurs colonnes est une simplification légitime quand les autres ne discriminent pas —
+le rapport le signale par `[testée sur …]`, sans trancher à ta place. Les traiter comme
+des clés simples produisait un « manquant » fantôme et un SQL invalide (`on s.a = c.a,b`).
+
 ## Arguments
 
 `$ARGUMENTS` — le nom de la source dbt, plus les options.

--- a/.claude/skills/check-staging-relationships/audit.py
+++ b/.claude/skills/check-staging-relationships/audit.py
@@ -160,8 +160,13 @@ def main() -> int:
     manifest, contrat = _charger(args.source, relations_path)
 
     modele_de = _modeles_par_table(manifest, args.source)
+    # Le contrat peut décrire le SCHÉMA ENTIER (discover.py --tout) et pas seulement le
+    # périmètre répliqué : les tables hors périmètre y portent `table_raw: null`. On les
+    # écarte ici — une table absente de BigQuery n'a pas de modèle staging, et sans ce
+    # filtre le rapport annoncerait « 404 tables répliquées » pour cinq.
+    tables_repliquees = {t: d for t, d in contrat["tables"].items() if d.get("table_raw")}
     # Le contrat nomme les tables de la SOURCE ; le manifest, les tables BigQuery.
-    raw_de_table = {t: d["table_raw"] for t, d in contrat["tables"].items()}
+    raw_de_table = {t: d["table_raw"] for t, d in tables_repliquees.items()}
     table_de_raw = {v: k for k, v in raw_de_table.items()}
     modele_par_table = {
         table_de_raw[raw]: modele for raw, modele in modele_de.items() if raw in table_de_raw
@@ -176,8 +181,14 @@ def main() -> int:
         print(f"\n{'=' * 78}")
         print(f"AUDIT DES RELATIONSHIPS — source {args.source}")
         print(f"{'=' * 78}")
-        print(f"  {len(contrat['tables'])} tables répliquées, {len(modelisees)} modélisées.")
-        print(f"  {len(contrat['relations'])} clés étrangères déclarées par la source.")
+        print(f"  {len(tables_repliquees)} tables répliquées, {len(modelisees)} modélisées.")
+        if len(tables_repliquees) < len(contrat["tables"]):
+            print(
+                f"  (contrat du schéma ENTIER : {len(contrat['tables'])} tables, "
+                f"{len(contrat['relations'])} clés étrangères)"
+            )
+        else:
+            print(f"  {len(contrat['relations'])} clés étrangères déclarées par la source.")
 
     # Univers : les deux extrémités modélisées.
     univers, hors = [], []

--- a/.claude/skills/check-staging-relationships/audit.py
+++ b/.claude/skills/check-staging-relationships/audit.py
@@ -160,13 +160,14 @@ def main() -> int:
     manifest, contrat = _charger(args.source, relations_path)
 
     modele_de = _modeles_par_table(manifest, args.source)
-    # Le contrat peut décrire le SCHÉMA ENTIER (discover.py --tout) et pas seulement le
-    # périmètre répliqué : les tables hors périmètre y portent `table_raw: null`. On les
-    # écarte ici — une table absente de BigQuery n'a pas de modèle staging, et sans ce
-    # filtre le rapport annoncerait « 404 tables répliquées » pour cinq.
-    tables_repliquees = {t: d for t, d in contrat["tables"].items() if d.get("table_raw")}
+    # Le contrat décrit la SOURCE ENTIÈRE et ne sait RIEN de ce qu'on réplique : c'est
+    # voulu, le périmètre bouge à chaque décision de scope et n'a pas à faire churner un
+    # artefact de contrat. La table d'atterrissage se déduit du préfixe, et c'est le
+    # manifest dbt qui tranche ce qui est réellement modélisé — une table de la source
+    # sans modèle staging sort simplement de l'univers auditable.
+    prefixe = contrat["prefixe_bigquery"]
     # Le contrat nomme les tables de la SOURCE ; le manifest, les tables BigQuery.
-    raw_de_table = {t: d["table_raw"] for t, d in tables_repliquees.items()}
+    raw_de_table = {t: f"{prefixe}_{t}" for t in contrat["tables"]}
     table_de_raw = {v: k for k, v in raw_de_table.items()}
     modele_par_table = {
         table_de_raw[raw]: modele for raw, modele in modele_de.items() if raw in table_de_raw
@@ -181,24 +182,30 @@ def main() -> int:
         print(f"\n{'=' * 78}")
         print(f"AUDIT DES RELATIONSHIPS — source {args.source}")
         print(f"{'=' * 78}")
-        print(f"  {len(tables_repliquees)} tables répliquées, {len(modelisees)} modélisées.")
-        if len(tables_repliquees) < len(contrat["tables"]):
-            print(
-                f"  (contrat du schéma ENTIER : {len(contrat['tables'])} tables, "
-                f"{len(contrat['relations'])} clés étrangères)"
-            )
-        else:
-            print(f"  {len(contrat['relations'])} clés étrangères déclarées par la source.")
+        print(
+            f"  {len(contrat['tables'])} tables à la source, dont {len(modelisees)} "
+            f"modélisées en staging."
+        )
+        print(f"  {len(contrat['relations'])} clés étrangères déclarées par la source.")
 
-    # Univers : les deux extrémités modélisées.
-    univers, hors = [], []
+    # Univers : les deux extrémités modélisées. Les FK COMPOSITES en sortent — le test
+    # `relationships` de dbt ne porte QUE sur une colonne. Les laisser dans l'univers
+    # produisait deux erreurs : un « manquant » fantôme sur leur première colonne, et un
+    # SQL invalide (`on s.a = c.a,b`). Elles ont leur propre famille, pour être décidées
+    # à la main. Mesuré sur Sage : 23 des 499 FK sont composites.
+    univers, composites, hors = [], [], []
     for r in contrat["relations"]:
-        if r["source"] in modelisees and r["cible"] in modelisees:
-            univers.append(r)
-        else:
+        if r["source"] not in modelisees or r["cible"] not in modelisees:
             hors.append(r)
+        elif len(r["colonnes"]) > 1:
+            composites.append(r)
+        else:
+            univers.append(r)
     if entete:
-        print(f"  {len(univers)} auditables (deux tables modélisées), {len(hors)} hors univers.\n")
+        print(
+            f"  {len(univers)} auditables (deux tables modélisées, clé simple), "
+            f"{len(composites)} composites, {len(hors)} hors univers.\n"
+        )
 
     # Rapprochement à la COLONNE, pas seulement à la paire de tables. `column_name` est
     # toujours présent dans le manifest, documenté ou non : c'est une clé fiable. Cela
@@ -208,8 +215,15 @@ def main() -> int:
         (modele_par_table[r["source"]], r["colonnes"][0], modele_par_table[r["cible"]]): r
         for r in univers
     }
+    # Un test posé sur UNE colonne d'une FK composite n'est ni conforme ni aberrant :
+    # c'est une simplification, légitime quand les autres colonnes ne discriminent pas.
+    colonnes_composites = {
+        (modele_par_table[r["source"]], c, modele_par_table[r["cible"]]): r
+        for r in composites
+        for c in r["colonnes"]
+    }
 
-    conformes, colonne_inattendue, a_confirmer = [], [], []
+    conformes, colonne_inattendue, a_confirmer, partiels = [], [], [], []
     couverts = set()
     for porteur, liste in sorted(tests.items()):
         if porteur not in modele_vers_table:
@@ -219,6 +233,8 @@ def main() -> int:
             if cle in attendus:
                 conformes.append((cle, attendus[cle], t))
                 couverts.add(cle)
+            elif cle in colonnes_composites:
+                partiels.append((cle, colonnes_composites[cle]))
             elif any(k[0] == porteur and k[2] == t["modele_cible"] for k in attendus):
                 colonne_inattendue.append((porteur, t))
             else:
@@ -262,6 +278,20 @@ def main() -> int:
     print("  À documenter comme connaissance métier, ou à corriger.\n")
     for porteur, t in a_confirmer:
         print(f"  {porteur}.{t['colonne']} -> {t['modele_cible']}.{t['champ_cible']} [{t['severity']}]")
+
+    if composites:
+        print(f"\n{'-' * 78}\n1b. CLÉS COMPOSITES — {len(composites)} FK")
+        print(f"{'-' * 78}")
+        print("  Le test `relationships` de dbt ne porte que sur UNE colonne : ces FK ne")
+        print("  sont pas couvrables telles quelles. Tester une seule de leurs colonnes")
+        print("  est une simplification légitime QUAND les autres ne discriminent pas —")
+        print("  à vérifier au cas par cas, pas à supposer.\n")
+        for r in sorted(composites, key=lambda x: (x["source"], x["colonnes"])):
+            porteur = modele_par_table[r["source"]]
+            cible = modele_par_table[r["cible"]]
+            couvert = [c for c in r["colonnes"] if (porteur, c, cible) in {k for k, _ in partiels}]
+            marque = f"   [testée sur {','.join(couvert)}]" if couvert else "   [non testée]"
+            print(f"  {porteur}.({','.join(r['colonnes'])}) -> {cible}.({','.join(r['colonnes_cible'])}){marque}")
 
     if colonne_inattendue:
         print(f"\n{'-' * 78}\n2b. COLONNE INATTENDUE — {len(colonne_inattendue)} tests")

--- a/models/staging/mssql_sage/_mssql_sage__models.yml
+++ b/models/staging/mssql_sage/_mssql_sage__models.yml
@@ -33,7 +33,12 @@ models:
         tests:
           - not_null
       - name: ca_num
-        description: "Code analytique"
+        description: "Code de la section analytique. FK déclarée par Sage vers F_COMPTEA."
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_mssql_sage__f_comptea')
+                field: ca_num
       - name: ea_montant
         description: "Montant de l'écriture analytique"
       - name: ea_quantite
@@ -67,7 +72,12 @@ models:
       - name: jo_num
         description: "Code du journal"
       - name: cg_num
-        description: "Compte général"
+        description: "Numéro de compte général. FK déclarée par Sage vers F_COMPTEG."
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_mssql_sage__f_compteg')
+                field: cg_num
       - name: ct_num
         description: "Compte tiers (nullable pour les écritures sans tiers)"
         tests:
@@ -247,7 +257,12 @@ models:
       - name: dl_design
         description: "Désignation produit de la ventes"
       - name: ar_ref
-        description: "Référence article de la ventes"
+        description: "Référence article de la vente. FK déclarée par Sage vers F_ARTICLE. Nullable : 39 695 lignes sur 337 572 n'en portent pas (de vrais NULL, que le test relationships ignore)."
+        tests:
+          - relationships:
+              arguments:
+                to: ref('stg_mssql_sage__f_article')
+                field: ar_ref
       - name: do_date
         description: "Date de la vente"
       - name: dl_qte
@@ -264,3 +279,92 @@ models:
         description: "Date de dernière modification de la ligne document (cb_modification)"
       - name: extracted_at
         description: "Timestamp du run dlt qui a chargé la ligne (_extracted_at)"
+
+  # ---------------------------------------------------------------------------
+  # DIMENSIONS COMPTABLES ET ARTICLES
+  #
+  # Ajoutées le 2026-08-01 pour porter les trois relationships que Sage déclare
+  # depuis une colonne exposée. Orphelins mesurés à la source avant ajout : ZÉRO
+  # sur les trois liens.
+  # ---------------------------------------------------------------------------
+  - name: stg_mssql_sage__f_compteg
+    description: "Plan comptable général — dimension des écritures comptables."
+    columns:
+      - name: cb_marq
+        description: "Identifiant technique Sage (PK ligne)"
+        tests:
+          - unique
+          - not_null
+      - name: cg_num
+        description: "Numéro de compte général — clé métier"
+        tests:
+          - unique
+          - not_null
+      - name: cg_intitule
+        description: "Libellé du compte général. C'est la source de vérité du champ designation_compte, aujourd'hui saisi à la main dans le seed ref_mssql_sage__code_comptable_bu."
+      - name: cg_type
+        description: "Type de compte (détail, total, centralisateur…)"
+      - name: cg_sommeil
+        description: "Compte mis en sommeil (inactif)"
+      - name: ta_code
+        description: "Code taxe rattaché au compte"
+      - name: created_at
+        description: "Date de création de la ligne dans Sage"
+      - name: updated_at
+        description: "Date de dernière modification dans Sage"
+      - name: extracted_at
+        description: "Horodatage du run dlt qui a chargé la ligne"
+
+  - name: stg_mssql_sage__f_comptea
+    description: "Sections analytiques — dimension des écritures analytiques."
+    columns:
+      - name: cb_marq
+        description: "Identifiant technique Sage (PK ligne)"
+        tests:
+          - unique
+          - not_null
+      - name: ca_num
+        description: "Code de la section analytique — clé métier"
+        tests:
+          - unique
+          - not_null
+      - name: n_analytique
+        description: "Numéro de plan analytique. Ne porte qu'UNE valeur : il n'existe qu'un plan, d'où l'unicité de ca_num seul."
+      - name: ca_intitule
+        description: "Libellé de la section analytique"
+      - name: ca_statut
+        description: "Statut de l'affaire"
+      - name: ca_sommeil
+        description: "Section mise en sommeil (inactive)"
+      - name: created_at
+        description: "Date de création de la ligne dans Sage"
+      - name: updated_at
+        description: "Date de dernière modification dans Sage"
+      - name: extracted_at
+        description: "Horodatage du run dlt qui a chargé la ligne"
+
+  - name: stg_mssql_sage__f_article
+    description: "Référentiel articles — dimension des lignes de documents commerciaux."
+    columns:
+      - name: cb_marq
+        description: "Identifiant technique Sage (PK ligne)"
+        tests:
+          - unique
+          - not_null
+      - name: ar_ref
+        description: "Référence article — clé métier"
+        tests:
+          - unique
+          - not_null
+      - name: ar_design
+        description: "Désignation de l'article"
+      - name: fa_code_famille
+        description: "Code de la famille d'articles"
+      - name: ar_sommeil
+        description: "Article mis en sommeil (inactif)"
+      - name: created_at
+        description: "Date de création de la ligne dans Sage"
+      - name: updated_at
+        description: "Date de dernière modification dans Sage"
+      - name: extracted_at
+        description: "Horodatage du run dlt qui a chargé la ligne"

--- a/models/staging/mssql_sage/_mssql_sage__sources.yml
+++ b/models/staging/mssql_sage/_mssql_sage__sources.yml
@@ -308,3 +308,102 @@ sources:
             description: "Horodatage du run dlt qui a chargé la ligne"
           - name: _dlt_load_id
             description: "Identifiant du paquet de chargement dlt — sert à l’audit"
+
+      # ---------------------------------------------------------------------
+      # DIMENSIONS COMPTABLES ET ARTICLES (overwrite)
+      #
+      # Ajoutées le 2026-08-01. Les trois SEULES tables hors périmètre vers
+      # lesquelles une clé étrangère de Sage part d'une colonne réellement
+      # exposée en staging — les neuf autres cibles ne sont référencées que par
+      # des colonnes techniques `cb*` que dbt ne sélectionne pas.
+      # ---------------------------------------------------------------------
+      - name: dbo_f_compteg
+        description: "Plan comptable général (f_compteg) — un compte général par ligne avec son intitulé. 544 lignes."
+
+        columns:
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne)"
+            tests:
+              - unique
+              - not_null
+          - name: cg_num
+            description: "Numéro de compte général. Clé métier, unique (contrainte UKA_F_COMPTEG_CG_Num)."
+            tests:
+              - unique
+              - not_null
+          - name: cg_intitule
+            description: "Libellé du compte général"
+          - name: cg_type
+            description: "Type de compte (détail, total, centralisateur…)"
+          - name: cg_sommeil
+            description: "Compte mis en sommeil (inactif)"
+          - name: ta_code
+            description: "Code taxe rattaché au compte"
+          - name: cb_creation
+            description: "Horodatage de création de la ligne"
+          - name: cb_modification
+            description: "Horodatage de dernière modification"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"
+
+      - name: dbo_f_comptea
+        description: "Sections analytiques (f_comptea) — une affaire / section par ligne avec son intitulé. 309 lignes."
+
+        columns:
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne)"
+            tests:
+              - unique
+              - not_null
+          - name: n_analytique
+            description: "Numéro de plan analytique. Sage déclare l'unicité sur (n_analytique, ca_num), mais cette colonne ne porte qu'UNE valeur : il n'y a qu'un seul plan."
+          - name: ca_num
+            description: "Code de la section analytique. Unique à lui seul ici — 309 valeurs pour 309 lignes."
+            tests:
+              - unique
+              - not_null
+          - name: ca_intitule
+            description: "Libellé de la section analytique"
+          - name: ca_statut
+            description: "Statut de l'affaire"
+          - name: ca_sommeil
+            description: "Section mise en sommeil (inactive)"
+          - name: cb_creation
+            description: "Horodatage de création de la ligne"
+          - name: cb_modification
+            description: "Horodatage de dernière modification"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"
+
+      - name: dbo_f_article
+        description: "Référentiel articles (f_article) — une référence par ligne avec sa désignation. 3 589 lignes, 134 colonnes à la source dont seul un socle est exposé en staging."
+
+        columns:
+          - name: cb_marq
+            description: "Identifiant technique Sage (PK ligne)"
+            tests:
+              - unique
+              - not_null
+          - name: ar_ref
+            description: "Référence article. Clé métier, unique (contrainte UKA_F_ARTICLE_AR_Ref)."
+            tests:
+              - unique
+              - not_null
+          - name: ar_design
+            description: "Désignation de l'article"
+          - name: fa_code_famille
+            description: "Code de la famille d'articles"
+          - name: ar_sommeil
+            description: "Article mis en sommeil (inactif)"
+          - name: cb_creation
+            description: "Horodatage de création de la ligne"
+          - name: cb_modification
+            description: "Horodatage de dernière modification"
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne"
+          - name: _dlt_load_id
+            description: "Identifiant du paquet de chargement dlt — sert à l’audit"

--- a/models/staging/mssql_sage/stg_mssql_sage__f_article.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_article.sql
@@ -1,0 +1,57 @@
+{{
+    config(
+        materialized='table',
+        description="Référentiel articles de Sage (dbo_f_article) : une référence par ligne, avec sa désignation. Sert de dimension aux lignes de documents commerciaux. La table source porte 134 colonnes, dont des champs métier propres à EVS (provenance, note olfactive, certifications) volontairement non exposés ici — à ajouter au besoin, un par un."
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('mssql_sage', 'dbo_f_article') }}
+),
+
+cleaned_data as (
+    select
+        -- Identifiant technique Sage (PK)
+        cb_marq,
+
+        -- Clé métier : unique dans Sage (contrainte UKA_F_ARTICLE_AR_Ref)
+        ar_ref,
+        ar_design,
+
+        -- Classement
+        fa_code_famille,
+        ar_type,
+        ar_nature,
+        ar_code_barre,
+        ar_substitut,
+
+        -- Valorisation
+        ar_prix_ach,
+        ar_prix_ven,
+        ar_prix_ttc,
+        ar_coef,
+        ar_cout_std,
+
+        -- Gestion
+        ar_suivi_stock,
+        ar_sommeil,
+        ar_publie,
+        ar_nomencl,
+        co_no,
+
+        -- Metadata
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _extracted_at as extracted_at
+
+    from source_data
+)
+
+select *
+from cleaned_data
+-- Défensif : le raw est un snapshot complet, donc ar_ref y est déjà unique.
+qualify row_number() over (
+    partition by ar_ref
+    order by updated_at desc, cb_marq desc
+) = 1

--- a/models/staging/mssql_sage/stg_mssql_sage__f_comptea.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_comptea.sql
@@ -1,0 +1,54 @@
+{{
+    config(
+        materialized='table',
+        description="Sections analytiques de Sage (dbo_f_comptea) : une affaire / section par ligne, avec son intitulé. Sert de dimension aux écritures analytiques et de référence au seed ref_mssql_sage__code_analytique_bu, qui mappe les sections vers les BU."
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('mssql_sage', 'dbo_f_comptea') }}
+),
+
+cleaned_data as (
+    select
+        -- Identifiant technique Sage (PK)
+        cb_marq,
+
+        -- Clé métier. Sage déclare l'unicité sur (N_Analytique, CA_Num), mais
+        -- n_analytique ne porte qu'UNE valeur ici — il n'y a qu'un plan analytique.
+        -- ca_num est donc unique à lui seul : mesuré 309 valeurs pour 309 lignes.
+        n_analytique,
+        ca_num,
+        ca_intitule,
+
+        -- Caractérisation de la section
+        ca_type,
+        ca_classement,
+        ca_statut,
+        ca_sommeil,
+        ca_domaine,
+        ca_mode_facturation,
+        co_no,
+
+        -- Cycle de vie de l'affaire
+        ca_date_creation_affaire,
+        ca_date_accept_affaire,
+        ca_date_debut_affaire,
+        ca_date_fin_affaire,
+
+        -- Metadata
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _extracted_at as extracted_at
+
+    from source_data
+)
+
+select *
+from cleaned_data
+-- Défensif : le raw est un snapshot complet, donc ca_num y est déjà unique.
+qualify row_number() over (
+    partition by ca_num
+    order by updated_at desc, cb_marq desc
+) = 1

--- a/models/staging/mssql_sage/stg_mssql_sage__f_compteg.sql
+++ b/models/staging/mssql_sage/stg_mssql_sage__f_compteg.sql
@@ -1,0 +1,47 @@
+{{
+    config(
+        materialized='table',
+        description="Plan comptable général de Sage (dbo_f_compteg) : un compte général par ligne, avec son intitulé. Sert de dimension aux écritures comptables et de référence au seed ref_mssql_sage__code_comptable_bu, qui n'en couvre que les comptes de classes 6 et 7."
+    )
+}}
+
+with source_data as (
+    select *
+    from {{ source('mssql_sage', 'dbo_f_compteg') }}
+),
+
+cleaned_data as (
+    select
+        -- Identifiant technique Sage (PK)
+        cb_marq,
+
+        -- Clé métier : unique dans Sage (contrainte UKA_F_COMPTEG_CG_Num)
+        cg_num,
+        cg_intitule,
+
+        -- Caractérisation du compte
+        cg_type,
+        cg_classement,
+        n_nature,
+        ta_code,
+        cg_sommeil,
+        cg_analytique,
+        cg_lettrage,
+        cg_tiers,
+
+        -- Metadata
+        cb_creation as created_at,
+        coalesce(cb_modification, cb_creation) as updated_at,
+        _extracted_at as extracted_at
+
+    from source_data
+)
+
+select *
+from cleaned_data
+-- Défensif : le raw est un snapshot complet, donc cg_num y est déjà unique. Le
+-- qualify protège d'un passage futur en merge, comme sur les autres référentiels.
+qualify row_number() over (
+    partition by cg_num
+    order by updated_at desc, cb_marq desc
+) = 1


### PR DESCRIPTION
Accompagne l'ajout de `F_COMPTEG`, `F_COMPTEA` et `F_ARTICLE` au périmètre du pipeline
`mssql_sage` (déjà en production côté `ingestion`).

Ce sont les **trois seules** tables hors périmètre vers lesquelles une clé étrangère de
Sage part d'une colonne réellement exposée en staging. Les neuf autres cibles ne sont
référencées que par des colonnes techniques `cb*` que dbt ne sélectionne pas : les
répliquer n'aurait apporté aucun test.

## Trois modèles, trois tests

| Test | Orphelins mesurés à la source **avant** ajout |
|---|---|
| `f_ecriturec.cg_num` → `f_compteg.cg_num` | **0** sur 317 615 |
| `f_ecriturea.ca_num` → `f_comptea.ca_num` | **0** sur 192 382 |
| `f_docligne.ar_ref` → `f_article.ar_ref` | **0** sur 297 877 renseignées |

Les 39 695 `ar_ref` restantes sont de **vrais NULL** — vérifié, zéro chaîne vide — que le
test `relationships` de dbt ignore.

Sur `ca_num` : la FK déclarée est composite `(n_analytique, ca_num)`, mais `n_analytique`
ne porte qu'**une** valeur (il n'existe qu'un plan analytique) et `ca_num` est unique dans
`F_COMPTEA` (309 pour 309). Joindre sur `ca_num` seul suffit et n'explose pas.

`dbt build --select source:mssql_sage+` → **PASS=90, WARN=0, ERROR=0** (contre 60 avant).

## Correctif de la compétence `check-staging-relationships`

**1. Le contrat ne porte plus `dans_perimetre` / `table_raw`.** Il décrit la source
entière. Le périmètre bouge à chaque décision de scope : l'inscrire dans un artefact de
contrat le faisait churner pour des raisons étrangères à la source. La compétence calcule
elle-même `<prefixe>_<table>` et laisse le manifest dbt trancher ce qui est modélisé.

**2. Les clés composites ont leur propre famille (1b).** Le test `relationships` de dbt ne
porte que sur **une** colonne. Les traiter comme des clés simples produisait un
« manquant » fantôme sur leur première colonne **et un SQL invalide** :
`on s.n_analytique = c.n_analytique,ca_num`. 23 des 499 FK de Sage sont composites.

## Non-régression

| Source | Auditables | Conformes |
|---|---|---|
| `oracle_lcdp` | 78 | 57 |
| `oracle_neshu` | 82 | 37 |

Identiques à la référence d'avant le changement de format.

Un fait à connaître : `oracle_nayka` sort à **0 modélisée** — c'est exact, ce pipeline n'a
aucun modèle staging dans dbt.

## Ce que ça débloque, au-delà des tests

`cg_intitule` est la source de vérité du champ `designation_compte`, aujourd'hui saisi à
la main dans `ref_mssql_sage__code_comptable_bu.csv` (248 libellés). Quatre comptes de
classe 6/7 ouverts dans Sage n'y figurent pas — `606320`, `607016`, `641201`, `708802` —
et alimentent les 28 lignes non mappées de 2026 (+81 169 €) contre 3 à 4 par an
auparavant. Un test de couverture du seed contre `stg_mssql_sage__f_compteg` rendrait ça
détectable automatiquement ; il serait **rouge aujourd'hui**, donc il n'est pas dans cette
PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUokh8wiTL3F4jgZjYqRnL