### PR TITLE
feat(yuman): brancher la couche staging sur yuman_evs_* (dlt)

### DIFF
--- a/models/staging/yuman/_yuman__models.yml
+++ b/models/staging/yuman/_yuman__models.yml
@@ -53,8 +53,6 @@ models:
         description: "Date de dernière mise à jour"
       - name: extracted_at
         description: "Date d'extraction depuis la source (Singer/Meltano)"
-      - name: deleted_at
-        description: "Date de suppression (soft delete)"
 
   - name: stg_yuman__sites
     description: "Sites transformés et nettoyés depuis l'API Yuman"
@@ -111,12 +109,12 @@ models:
           - not_null
 
       - name: is_forbidden_article
-        description: "Indique si l'article est interdit. Dérivé du champ personnalisé Yuman booléen 'ARTICLE INTERDIT' (Oui/Non) extrait de `_embed_fields`. false si non renseigné."
+        description: "Indique si l'article est interdit. Dérivé du champ personnalisé Yuman booléen 'ARTICLE INTERDIT' (Oui/Non) extrait de `_embed.fields`. false si non renseigné."
         tests:
           - not_null
 
       - name: is_mandatory_article
-        description: "Indique si l'article est obligatoire. Dérivé du champ personnalisé Yuman booléen 'ARTICLE OBLIGATOIRE' (Oui/Non) extrait de `_embed_fields`. false si non renseigné."
+        description: "Indique si l'article est obligatoire. Dérivé du champ personnalisé Yuman booléen 'ARTICLE OBLIGATOIRE' (Oui/Non) extrait de `_embed.fields`. false si non renseigné."
         tests:
           - not_null
 
@@ -276,8 +274,6 @@ models:
         description: "Date de dernière mise à jour"
       - name: extracted_at
         description: "Date d'extraction depuis la source"
-      - name: deleted_at
-        description: "Date de suppression (soft delete)"
 
   - name: stg_yuman__purchase_orders
     description: "Purchase Orders dépliés : une ligne = une commande + une pièce associée"
@@ -366,12 +362,10 @@ models:
       # --- Métadonnées ---
       - name: extracted_at
         description: "Date d'extraction depuis la source (Singer/Meltano)"
-      - name: sdc_sequence
-        description: "Numéro de séquence pour suivi d'update via Meltano"
 
   # --- Table de faits dépliée des produits utilisés dans les interventions (workorders) ---
   - name: stg_yuman__workorder_products
-    description: "Produits utilisés lors des interventions (workorders). 1 ligne = 1 produit utilisé dans une intervention. Cette table déplie le JSON _embed_products de la table yuman_workorders."
+    description: "Produits utilisés lors des interventions (workorders). 1 ligne = 1 produit utilisé dans une intervention. Cette table déplie `_embed.products` de la table yuman_evs_workorders."
     columns:
       - name: workorder_product_id
         description: "Identifiant unique du produit utilisé dans l'intervention (clé primaire)"

--- a/models/staging/yuman/_yuman__sources.yml
+++ b/models/staging/yuman/_yuman__sources.yml
@@ -12,7 +12,7 @@ sources:
 
       # Freshness: tier Standard — 26h warn / 48h error
       # Cf. docs/freshness.md
-      loaded_at_field: _sdc_extracted_at
+      loaded_at_field: _extracted_at
       freshness:
         warn_after: {count: 26, period: hour}
         error_after: {count: 48, period: hour}
@@ -21,7 +21,7 @@ sources:
       # ═══════════════════════════════════════════════════════════════════
       # FACT-LIKE TABLES (transactions, events) - Use source default
       # ═══════════════════════════════════════════════════════════════════
-      - name: yuman_workorders
+      - name: yuman_evs_workorders
         description: "Table des interventions Yuman - CRITIQUE pour facturation"
         columns:
           - name: id
@@ -42,7 +42,7 @@ sources:
           - name: category_id
             description: "Identifiant de la catégorie de l'intervention"
 
-      - name: yuman_workorder_demands
+      - name: yuman_evs_workorder_demands
         description: "Table des demandes d'intervention Yuman"
         columns:
           - name: id
@@ -67,7 +67,7 @@ sources:
           - name: status
             description: "Statut de la demande"
 
-      - name: yuman_purchase_orders
+      - name: yuman_evs_purchase_orders
         description: "Table des commandes d'achat Yuman"
         columns:
           - name: id
@@ -79,7 +79,7 @@ sources:
       # ═══════════════════════════════════════════════════════════════════
       # DIMENSION TABLES (entities) - Use source default
       # ═══════════════════════════════════════════════════════════════════
-      - name: yuman_clients
+      - name: yuman_evs_clients
         description: "Table des clients Yuman"
         columns:
           - name: id
@@ -88,7 +88,7 @@ sources:
               - not_null
             description: "Identifiant unique du client"
 
-      - name: yuman_contacts
+      - name: yuman_evs_contacts
         description: "Table des contacts Yuman"
         columns:
           - name: id
@@ -119,7 +119,7 @@ sources:
           - name: updated_at
             description: "Date de dernière mise à jour"
 
-      - name: yuman_sites
+      - name: yuman_evs_sites
         description: "Table des sites Yuman"
         columns:
           - name: id
@@ -132,7 +132,7 @@ sources:
               - not_null
             description: "Référence vers le client propriétaire"
 
-      - name: yuman_materials
+      - name: yuman_evs_materials
         description: "Table des machines Yuman"
         columns:
           - name: id
@@ -145,7 +145,7 @@ sources:
               - not_null
             description: "Référence vers le site propriétaire"
 
-      - name: yuman_users
+      - name: yuman_evs_users
         description: "Table des users Yuman"
         columns:
           - name: id
@@ -157,7 +157,7 @@ sources:
       # ═══════════════════════════════════════════════════════════════════
       # REFERENCE TABLES (rarely change) - Freshness disabled
       # ═══════════════════════════════════════════════════════════════════
-      - name: yuman_products
+      - name: yuman_evs_products
         description: "Table des produits Yuman - référentiel, rarement modifié"
         config:
           freshness: null
@@ -168,7 +168,7 @@ sources:
               - not_null
             description: "Identifiant unique du produit/articles"
 
-      - name: yuman_material_categories
+      - name: yuman_evs_materials_categories
         description: "Table des catégories de machines Yuman - référentiel stable"
         config:
           freshness: null
@@ -179,7 +179,7 @@ sources:
               - not_null
             description: "Identifiant unique de la catégorie machine"
 
-      - name: yuman_workorder_categories
+      - name: yuman_evs_workorders_categories
         description: "Table des catégories d'intervention Yuman - référentiel stable"
         config:
           freshness: null
@@ -190,7 +190,7 @@ sources:
               - not_null
             description: "Identifiant unique de la catégorie de demande"
 
-      - name: yuman_workorder_demands_categories
+      - name: yuman_evs_workorder_demands_categories
         description: "Table des catégories de demandes d'intervention Yuman - référentiel stable"
         config:
           freshness: null
@@ -201,7 +201,7 @@ sources:
               - not_null
             description: "Identifiant unique de la catégorie de demande"
 
-      - name: yuman_storehouses
+      - name: yuman_evs_products_storehouses
         description: "Table des storehouses Yuman - référentiel stable"
         config:
           freshness: null

--- a/models/staging/yuman/stg_yuman__clients.sql
+++ b/models/staging/yuman/stg_yuman__clients.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_clients') }}
+    from {{ source('yuman_api', 'yuman_evs_clients') }}
 
 ),
 
@@ -21,11 +21,10 @@ base_clients as (
         name as client_name,
         address as client_address,
         active as is_active,
-        safe.parse_json(_embed_fields) as embed_fields,
+        json_query(_embed, '$.fields') as embed_fields,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
     where id is not null
 
@@ -77,8 +76,7 @@ pivoted as (
         bc.is_active,
         bc.created_at,
         bc.updated_at,
-        bc.extracted_at,
-        bc.deleted_at
+        bc.extracted_at
     from base_clients as bc
     left join extracted_fields as ef
         on bc.client_id = ef.client_id
@@ -91,8 +89,7 @@ pivoted as (
         bc.is_active,
         bc.created_at,
         bc.updated_at,
-        bc.extracted_at,
-        bc.deleted_at
+        bc.extracted_at
 
 ),
 
@@ -127,6 +124,5 @@ select
     is_active,
     created_at,
     updated_at,
-    extracted_at,
-    deleted_at
+    extracted_at
 from final

--- a/models/staging/yuman/stg_yuman__contacts.sql
+++ b/models/staging/yuman/stg_yuman__contacts.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_contacts') }}
+    from {{ source('yuman_api', 'yuman_evs_contacts') }}
 
 ),
 
@@ -27,8 +27,7 @@ cleaned as (
         external_reference_vendor,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
     where id is not null
 

--- a/models/staging/yuman/stg_yuman__materials.sql
+++ b/models/staging/yuman/stg_yuman__materials.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_materials') }}
+    from {{ source('yuman_api', 'yuman_evs_materials') }}
 
 ),
 
@@ -27,14 +27,13 @@ cleaned_materials as (
 
         (
             select json_value(elem, '$.value')
-            from unnest(json_query_array(_embed_fields)) as elem
+            from unnest(json_query_array(_embed, '$.fields')) as elem
             where json_value(elem, '$.name') = 'LOCALISATION'
         ) as material_localisation,
 
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
     where id is not null
 

--- a/models/staging/yuman/stg_yuman__materials_categories.sql
+++ b/models/staging/yuman/stg_yuman__materials_categories.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_material_categories') }}
+    from {{ source('yuman_api', 'yuman_evs_materials_categories') }}
 
 ),
 
@@ -19,8 +19,7 @@ cleaned_material_categories as (
         name as category_name,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
     where id is not null
 

--- a/models/staging/yuman/stg_yuman__products.sql
+++ b/models/staging/yuman/stg_yuman__products.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_products') }}
+    from {{ source('yuman_api', 'yuman_evs_products') }}
 
 ),
 
@@ -26,18 +26,17 @@ cleaned_products as (
         active as is_active,
         coalesce(lower((
             select json_value(field, '$.value')
-            from unnest(json_query_array(_embed_fields)) as field
+            from unnest(json_query_array(_embed, '$.fields')) as field
             where json_value(field, '$.name') = 'ARTICLE INTERDIT'
         )) in ('oui', 'yes', 'true'), false) as is_forbidden_article,
         coalesce(lower((
             select json_value(field, '$.value')
-            from unnest(json_query_array(_embed_fields)) as field
+            from unnest(json_query_array(_embed, '$.fields')) as field
             where json_value(field, '$.name') = 'ARTICLE OBLIGATOIRE'
         )) in ('oui', 'yes', 'true'), false) as is_mandatory_article,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
     where id is not null
 

--- a/models/staging/yuman/stg_yuman__purchase_orders.sql
+++ b/models/staging/yuman/stg_yuman__purchase_orders.sql
@@ -8,7 +8,7 @@
 with src as (
 
     select *
-    from {{ source('yuman_api', 'yuman_purchase_orders') }}
+    from {{ source('yuman_api', 'yuman_evs_purchase_orders') }}
 
 ),
 
@@ -33,8 +33,7 @@ po_base as (
         safe_cast(quote_id as int64) as quote_id,
         safe_cast(supplier_id as int64) as supplier_id,
         delivery_address,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        safe_cast(_sdc_sequence as int64) as sdc_sequence,
+        _extracted_at as extracted_at,
         lines
     from src
     where id is not null
@@ -49,8 +48,9 @@ lines_exploded as (
         item
     from po_base as pb
     cross join unnest(
-        -- json_extract_array ne supporte pas les nulls ; safe.parse_json évite les erreurs
-        coalesce(json_extract_array(safe.parse_json(lines)), [])
+        -- `lines` est une colonne JSON NATIVE depuis dlt (Meltano rendait une
+        -- chaîne, d'où le parse_json d'avant). json_query_array gère le NULL.
+        coalesce(json_query_array(lines), [])
     ) as item
 
 ),
@@ -77,7 +77,6 @@ line_parsed as (
         supplier_id,
         delivery_address,
         extracted_at,
-        sdc_sequence,
 
         -- champs ligne
         safe_cast(json_extract_scalar(item, '$.id') as int64) as purchase_order_line_id,
@@ -138,7 +137,6 @@ select
     line_updated_at,
 
     -- métadonnées
-    extracted_at,
-    sdc_sequence
+    extracted_at
 from line_parsed
 where purchase_order_line_id is not null

--- a/models/staging/yuman/stg_yuman__sites.sql
+++ b/models/staging/yuman/stg_yuman__sites.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_sites') }}
+    from {{ source('yuman_api', 'yuman_evs_sites') }}
 
 ),
 
@@ -18,7 +18,7 @@ extracted_postal_code as (
         sd.*,
         (
             select json_extract_scalar(elem, '$.value')
-            from unnest(json_extract_array(sd._embed_fields)) as elem
+            from unnest(json_query_array(sd._embed, '$.fields')) as elem
             where json_extract_scalar(elem, '$.name') = 'CODE POSTAL'
         ) as raw_code_postal
     from source_data as sd
@@ -38,8 +38,7 @@ cleaned as (
         regexp_replace(raw_code_postal, r'\.0$', '') as site_postal_code,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from extracted_postal_code
 
 )

--- a/models/staging/yuman/stg_yuman__storehouses.sql
+++ b/models/staging/yuman/stg_yuman__storehouses.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_storehouses') }}
+    from {{ source('yuman_api', 'yuman_evs_products_storehouses') }}
 
 ),
 
@@ -18,7 +18,7 @@ cleaned_storehouses as (
         id as storehouses_id,
         name as storehouses_name,
         address as storehouses_address,
-        timestamp(_sdc_extracted_at) as extracted_at
+        _extracted_at as extracted_at
     from source_data
 
 )

--- a/models/staging/yuman/stg_yuman__users.sql
+++ b/models/staging/yuman/stg_yuman__users.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_users') }}
+    from {{ source('yuman_api', 'yuman_evs_users') }}
 
 ),
 
@@ -19,17 +19,17 @@ cleaned_users as (
         manager_id,
         nullif((
             select json_value(field, '$.value')
-            from unnest(json_query_array(_embed_fields)) as field
+            from unnest(json_query_array(_embed, '$.fields')) as field
             where json_value(field, '$.name') = 'ID NOMAD'
         ), '') as nomad_id,
         nullif((
             select json_value(field, '$.value')
-            from unnest(json_query_array(_embed_fields)) as field
+            from unnest(json_query_array(_embed, '$.fields')) as field
             where json_value(field, '$.name') = 'SECTEUR'
         ), '') as user_secteur,
         nullif((
             select json_value(field, '$.value')
-            from unnest(json_query_array(_embed_fields)) as field
+            from unnest(json_query_array(_embed, '$.fields')) as field
             where json_value(field, '$.name') = 'ENTREPOT RATTACHEMENT'
         ), '') as entrepot_rattachement,
         name as user_name,
@@ -39,13 +39,12 @@ cleaned_users as (
         manager_as_technician as is_manager_as_technician,
         (
             select json_value(field, '$.value')
-            from unnest(json_query_array(_embed_fields)) as field
+            from unnest(json_query_array(_embed, '$.fields')) as field
             where json_value(field, '$.name') = 'INACTIF'
         ) as user_inactif,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
 
     from source_data
 
@@ -67,8 +66,7 @@ final as (
         lower(user_inactif) not in ('oui', 'sì', 'si', 'yes', 'true') as is_active,
         created_at,
         updated_at,
-        extracted_at,
-        deleted_at
+        extracted_at
 
     from cleaned_users
 

--- a/models/staging/yuman/stg_yuman__workorder_demands.sql
+++ b/models/staging/yuman/stg_yuman__workorder_demands.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_workorder_demands') }}
+    from {{ source('yuman_api', 'yuman_evs_workorder_demands') }}
 
 ),
 
@@ -28,8 +28,7 @@ cleaned_workorder_demands as (
         reject_comment as demand_reject_comment,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
     where id is not null
 

--- a/models/staging/yuman/stg_yuman__workorder_demands_categories.sql
+++ b/models/staging/yuman/stg_yuman__workorder_demands_categories.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_workorder_demands_categories') }}
+    from {{ source('yuman_api', 'yuman_evs_workorder_demands_categories') }}
 
 ),
 
@@ -19,8 +19,7 @@ cleaned_categories as (
         name as demand_category_name,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
 
 )

--- a/models/staging/yuman/stg_yuman__workorder_products.sql
+++ b/models/staging/yuman/stg_yuman__workorder_products.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_workorders') }}
+    from {{ source('yuman_api', 'yuman_evs_workorders') }}
 
 ),
 
@@ -24,7 +24,7 @@ workorder_products_unnested as (
         timestamp(json_extract_scalar(product, '$.created_at')) as product_created_at,
         timestamp(json_extract_scalar(product, '$.updated_at')) as product_updated_at
     from source_data as wo
-    cross join unnest(json_extract_array(wo._embed_products)) as product
+    cross join unnest(json_query_array(wo._embed, '$.products')) as product
 
 ),
 

--- a/models/staging/yuman/stg_yuman__workorders.sql
+++ b/models/staging/yuman/stg_yuman__workorders.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_workorders') }}
+    from {{ source('yuman_api', 'yuman_evs_workorders') }}
 
 ),
 
@@ -26,23 +26,22 @@ base_workorders as (
         -- Workorder details
         number as workorder_number,
         workorder_type,
-        _embed_category_name as workorder_category,
+        json_value(_embed, '$.category.name') as workorder_category,
         status as workorder_status,
         title as workorder_title,
         description as workorder_description,
         report as workorder_report,
-        _embed_technician_name as workorder_technician_name,
+        json_value(_embed, '$.technician.name') as workorder_technician_name,
         time_taken as workorder_time_taken,
         -- JSON
-        safe.parse_json(_embed_fields) as embed_fields,
+        json_query(_embed, '$.fields') as embed_fields,
         -- Dates
         timestamp(date_planned) as date_planned,
         timestamp(date_started) as date_started,
         timestamp(date_done) as date_done,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
 
 ),
@@ -128,8 +127,7 @@ final as (
         date_done,
         created_at,
         updated_at,
-        extracted_at,
-        deleted_at
+        extracted_at
     from json_parsed
 
 )

--- a/models/staging/yuman/stg_yuman__workorders_categories.sql
+++ b/models/staging/yuman/stg_yuman__workorders_categories.sql
@@ -8,7 +8,7 @@
 with source_data as (
 
     select *
-    from {{ source('yuman_api', 'yuman_workorder_categories') }}
+    from {{ source('yuman_api', 'yuman_evs_workorders_categories') }}
 
 ),
 
@@ -19,8 +19,7 @@ cleaned_categories as (
         name as category_name,
         timestamp(created_at) as created_at,
         timestamp(updated_at) as updated_at,
-        timestamp(_sdc_extracted_at) as extracted_at,
-        timestamp(_sdc_deleted_at) as deleted_at
+        _extracted_at as extracted_at
     from source_data
 
 )


### PR DESCRIPTION
Accompagne la migration de l'API Yuman (compte EVS) de Meltano vers dlt, côté
`ingestion`. **26 modèles en aval** : 15 staging, 2 intermediate, 9 marts.

⚠ **À merger seulement une fois `prod_raw.yuman_evs_*` chargé** — c'est déjà fait
(27 tables, run du 2026-08-01).

## Renommage des 13 tables sources

Le nom dérive désormais du chemin d'API. **Quatre changent de structure**, pas
seulement de préfixe :

| Avant | Après |
|---|---|
| `yuman_material_categories` | `yuman_evs_materials_categories` |
| `yuman_workorder_categories` | `yuman_evs_workorders_categories` |
| `yuman_storehouses` | `yuman_evs_products_storehouses` |
| `yuman_workorder_demands_categories` | `yuman_evs_workorder_demands_categories` |

## `_embed` change de forme

Meltano rendait des colonnes séparées — des chaînes JSON (`_embed_fields`,
`_embed_products`) **et** des objets aplatis (`_embed_category_name`). dlt rend
**une** colonne JSON native. 13 références réécrites :

```sql
json_query_array(_embed_fields)        →  json_query_array(_embed, '$.fields')
json_extract_array(wo._embed_products) →  json_query_array(wo._embed, '$.products')
safe.parse_json(_embed_fields)         →  json_query(_embed, '$.fields')
_embed_category_name                   →  json_value(_embed, '$.category.name')
_embed_technician_name                 →  json_value(_embed, '$.technician.name')
```

`purchase_orders.lines` est aussi du JSON natif : `json_extract_array(safe.parse_json(lines))`
devient `json_query_array(lines)`. Sans ça, `PARSE_JSON` échoue — il n'accepte pas
un argument déjà JSON.

## Résidus Singer retirés

`_sdc_extracted_at` → `_extracted_at` (déjà typée `TIMESTAMP`, plus de cast).
`deleted_at` et `sdc_sequence` disparaissent : mesuré, `_sdc_deleted_at` est NULL
sur **100 %** des lignes des trois tables testées, et `sdc_sequence` n'était
transporté que pour être réexposé. Aucun consommateur en intermediate ni en marts.

## Un piège structurel, résolu côté ingestion

dlt crée ses colonnes depuis la **donnée**, Singer depuis le **schéma JSON**. Sept
colonnes NULL à 100 % n'existaient plus, et deux modèles échouaient sur
`Unrecognized name`. Corrigé par le hint `columns` de dlt
([ingestion@61f1755](https://github.com/CebrailEVS/ingestion/commit/61f1755)) plutôt
que par un `cast(null as ...)` ici, qui aurait figé la colonne et masqué les vraies
valeurs le jour où l'API en renverrait.

## Validation

`dbt build --select source:yuman_api+` → **PASS=241, ERROR=0**.

La comparaison des volumes montrait d'abord des écarts négatifs, dont **-8 888** sur
`rupture_depot_yuman`. Ils venaient **entièrement de dépendances non-Yuman périmées
dans dev** (`stg_nesp_tech__articles` au 20/07, `stock_theorique` au 12/07). Après
reconstruction de la lignée complète en amont (212 nœuds, PASS=212) :

| Mart | prod (Meltano) | dev (dlt) | |
|---|---|---|---|
| `fct_supply_chain__rupture_depot_yuman` | 98 887 | **98 887** | identique |
| `fct_technique__consommation_article_nespresso` | 170 276 | **170 276** | identique |
| `fct_technique__intervention` | 93 392 | 93 437 | +45, fraîcheur |
| `stg_yuman__workorders` | 19 481 | 19 515 | +34, le compte actuel de l'API |

Tous les écarts restants sont positifs et correspondent aux données plus récentes.

## Après le merge

Basculer l'`args_override` du workflow `pipeline-yuman` vers `["--target=prod"]` et
le job vers `elt-yuman-evs`, puis supprimer les 13 anciennes tables `yuman_*`.
**La branche SFTP continue de tourner sur `elt-yuman`** : le projet Meltano ne peut
pas être archivé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RUokh8wiTL3F4jgZjYqRnL