### PR TITLE
feat(gac, nesp_co): brancher les 3 sources SFTP sur le pipeline dlt

### DIFF
--- a/models/staging/gac/_gac__models.yml
+++ b/models/staging/gac/_gac__models.yml
@@ -50,6 +50,4 @@ models:
       - name: date_de_saisie
         description: "Date de saisie du contrat (horodatée)"
       - name: extracted_at
-        description: "Timestamp d'extraction Meltano (_sdc_extracted_at)"
-      - name: deleted_at
-        description: "Timestamp de suppression Meltano (_sdc_deleted_at), NULL si actif"
+        description: "Horodatage du run dlt (_extracted_at)"

--- a/models/staging/gac/_gac__sources.yml
+++ b/models/staging/gac/_gac__sources.yml
@@ -9,7 +9,10 @@ sources:
       tags: ['gac', 'source']
       # Freshness: tier Relaxe — 7j warn / 14j error
       # Cf. docs/freshness.md
-      loaded_at_field: _sdc_batched_at
+      # `_sdc_batched_at` n'existe plus : le pipeline dlt pose `_extracted_at`,
+      # qui remplace le `_sdc_extracted_at` de Singer — lequel était NULL sur
+      # 100 % des lignes des trois tables.
+      loaded_at_field: _extracted_at
       freshness:
         warn_after: {count: 7, period: day}
         error_after: {count: 14, period: day}
@@ -42,11 +45,11 @@ sources:
           - name: date_de_saisie
             description: "Date de saisie du contrat (horodatée)"
       - name: gac_sinistre
-        description: "Snapshots quotidiens cumulatifs des sinistres véhicules (GAC → SFTP SG). Chargé en append immuable : 1 ligne = 1 sinistre dans 1 snapshot daté. L'état courant est dérivé par dédup dans stg_gac__sinistres."
+        description: "Snapshots quotidiens cumulatifs des sinistres véhicules (GAC → SFTP EVS). 1 ligne = 1 sinistre dans 1 snapshot daté. Chargé en merge/delete-insert sur snapshot_date : une journée relue écrase la sienne. L'état courant est dérivé par dédup dans stg_gac__sinistres."
         columns:
           - name: date
             description: "Date du sinistre"
-          - name: immat_
+          - name: immatx
             description: "Immatriculation du véhicule"
           - name: statut_actuel
             description: "Statut actuel du sinistre"
@@ -58,7 +61,7 @@ sources:
             description: "Circonstances du sinistre"
           - name: tiers
             description: "Présence d'un tiers impliqué"
-          - name: resp_
+          - name: respx
             description: "Responsabilité (0-100)"
           - name: matricule
             description: "Matricule du collaborateur"
@@ -76,7 +79,7 @@ sources:
             description: "Montant de la franchise"
           - name: co_t_global
             description: "Coût global du sinistre"
-          - name: cl_tur_
+          - name: cl_turx
             description: "Indicateur de clôture du sinistre"
           - name: description
             description: "Description du sinistre"
@@ -140,7 +143,12 @@ sources:
             description: "Entité 3"
           - name: entit_entit_4
             description: "Entité 4"
-          - name: _sdc_source_file
-            description: "Nom du fichier source (Singer/Airbyte)"
-          - name: _sdc_source_lineno
-            description: "Numéro de ligne dans le fichier source"
+          - name: snapshot_date
+            description: >
+              Date du snapshot, dérivée du nom du fichier
+              (suivi_sinistres_EB_YYYYMMDD_*.csv) par le pipeline dlt, qui s'en
+              sert comme CLÉ DE MERGE. Un fichier relu réécrit sa journée au
+              lieu de s'empiler — sous Meltano, en append sans protection, 95
+              des 133 fichiers avaient été rechargés.
+          - name: _extracted_at
+            description: "Horodatage du run dlt"

--- a/models/staging/gac/stg_gac__sinistres.sql
+++ b/models/staging/gac/stg_gac__sinistres.sql
@@ -1,4 +1,3 @@
--- TEST SELECTIVE RUN, test de fdp
 {{
   config(
     materialized='table',
@@ -17,12 +16,12 @@ cleaned as (
         nullif(trim(n_de_sinistre), '') as n_de_sinistre,
         nullif(trim(type), '') as type_sinistre,
         nullif(trim(r_f_rence_gac), '') as reference_gac,
-        nullif(trim(immat_), '') as immat,
+        nullif(trim(immatx), '') as immat,
         nullif(trim(circonstance), '') as circonstance,
-        nullif(trim(cl_tur_), '') as cloture,
+        nullif(trim(cl_turx), '') as cloture,
         nullif(trim(description), '') as description,
         nullif(trim(tiers), '') as tiers,
-        nullif(trim(resp_), '') as resp,
+        nullif(trim(respx), '') as resp,
         nullif(trim(matricule), '') as matricule,
         nullif(trim(nom), '') as nom,
         nullif(trim(pr_nom), '') as prenom,
@@ -71,18 +70,15 @@ cleaned as (
             '%d/%m/%Y', nullif(trim(date_de_cl_ture_du_sinistre), '')
         ) as date_cloture_sinistre,
 
-        -- Date métier du snapshot, dérivée du nom de fichier daté
-        -- (suivi_sinistres_EB_YYYYMMDD_*.csv). ≠ heure de chargement : c'est
-        -- elle qui doit arbitrer la dédup (un ré-append d'un vieux fichier ne
-        -- doit pas pouvoir se faire passer pour l'état courant).
-        parse_date('%Y%m%d', regexp_extract(_sdc_source_file, r'_(\d{8})_')) as snapshot_date,
+        -- Date métier du snapshot. Le pipeline dlt la FOURNIT désormais : elle
+        -- est sa clé de merge, dérivée du nom du fichier daté
+        -- (suivi_sinistres_EB_YYYYMMDD_*.csv). Le `regexp_extract` qui vivait
+        -- ici a simplement descendu d'un étage, là où il sert de clé.
+        snapshot_date,
 
-        -- Métadonnées Meltano
-        _sdc_source_file,
-        _sdc_source_lineno,
-        _sdc_received_at,
-        _sdc_batched_at,
-        _sdc_sequence
+        -- Horodatage du run dlt. Remplace `_sdc_received_at` : la colonne
+        -- Singer `_sdc_extracted_at` était NULL à 100 %, celle-ci est remplie.
+        _extracted_at
 
     from source
 ),
@@ -104,9 +100,11 @@ deduplicated as (
                     end
 
                 -- Tri par date métier du snapshot (et non l'heure de chargement) :
-                -- garantit qu'on garde la version la plus récente du sinistre,
-                -- robuste aux ré-appends de fichiers antérieurs.
-                order by snapshot_date desc, _sdc_received_at desc
+                -- garantit qu'on garde la version la plus récente du sinistre.
+                -- Le pipeline dlt merge désormais sur `snapshot_date`, donc un
+                -- fichier relu écrase sa journée au lieu de s'empiler : ce tri
+                -- arbitre entre snapshots DIFFÉRENTS, plus entre ré-appends.
+                order by snapshot_date desc, _extracted_at desc
 
             ) as rn
 

--- a/models/staging/gac/stg_gac__vehicule.sql
+++ b/models/staging/gac/stg_gac__vehicule.sql
@@ -34,9 +34,10 @@ cleaned as (
         safe.parse_date('%d/%m/%Y', nullif(trim(dernier_v_nement_date_d_effet), '')) as dernier_evenement_date_d_effet,
         safe.parse_date('%d/%m/%Y', nullif(trim(dernier_v_nement_date_de_fin), '')) as dernier_evenement_date_de_fin,
 
-        -- Métadonnées Meltano
-        _sdc_extracted_at as extracted_at,
-        _sdc_deleted_at as deleted_at
+        -- Horodatage du run dlt. `_sdc_deleted_at` a disparu : la colonne
+        -- Singer était NULL sur 100 % des lignes, et `replace` ne marque pas
+        -- les suppressions — le fichier écrasé EST l'état courant.
+        _extracted_at as extracted_at
 
     from source
 )

--- a/models/staging/nesp_co/_nesp_co__sources.yml
+++ b/models/staging/nesp_co/_nesp_co__sources.yml
@@ -146,7 +146,10 @@ sources:
         # Freshness: tier Manuel — 60j warn / 90j error
         # Livraison manuelle uniquement (pipeline-sftp-nesp-client). Cf. docs/freshness.md
         config:
-          loaded_at_field: _sdc_extracted_at
+          # ÉTAIT NULL À 100 % sous Meltano : le tap-spreadsheets-anywhere ne
+          # l'émettait pas, donc ce test n'a JAMAIS pu se déclencher — et quatre
+          # mois de retard sont passés inaperçus. `_extracted_at` est rempli.
+          loaded_at_field: _extracted_at
           freshness:
             warn_after: {count: 60, period: day}
             error_after: {count: 90, period: day}

--- a/models/staging/nesp_co/stg_nesp_co__client.sql
+++ b/models/staging/nesp_co/stg_nesp_co__client.sql
@@ -19,7 +19,11 @@ deduped as (
         *,
         row_number() over (
             partition by third
-            order by _sdc_received_at desc
+            -- Date de MODIFICATION du classeur, et non l'heure de chargement :
+            -- plusieurs dépôts arrivent souvent dans un même run (le pipeline
+            -- est manuel), et 8 916 clients diffèrent entre deux versions
+            -- consécutives. C'est aussi le `dedup_sort` du merge côté dlt.
+            order by _fichier_modifie_le desc
         ) as rn
     from source_data
 
@@ -57,28 +61,31 @@ base_client as (
         safe_cast(club_dt_disp as timestamp) as club_dt_disp,
         safe_cast(last_caps_ord_dt_disp as timestamp) as last_caps_ord_dt_disp,
 
-        -- mesures
-        ns,
-        ns_n1,
-        ns_n_ytd,
-        ns_n1_ytd,
+        -- mesures. Le classeur atterrit ENTIÈREMENT EN TEXTE côté dlt : laisser
+        -- dlt inférer les types d'un Excel lui fait créer des colonnes variantes
+        -- selon l'ordre des lignes du fichier — 61 % des valeurs de `ns_n_1_ytd`
+        -- étaient parties dans `ns_n_1_ytd__v_double` au premier essai. D'où les
+        -- casts, y compris sur les quatre montants qui arrivaient typés avant.
+        safe_cast(ns as float64) as ns,
+        safe_cast(ns_n_1 as float64) as ns_n1,
+        safe_cast(ns_n_ytd as float64) as ns_n_ytd,
+        safe_cast(ns_n_1_ytd as float64) as ns_n1_ytd,
         cast(caps as int64) as caps,
-        cast(caps_n1 as int64) as caps_n1,
-        cast(_caps_n_ytd as int64) as caps_n_ytd,
-        cast(caps_n1_ytd as int64) as caps_n1_ytd,
-        cast(caps_b2b as int64) as caps_b2b,
-        cast(caps_b2c as int64) as caps_b2c,
-        cast(caps_b2c_ytd_ as int64) as caps_b2c_ytd,
+        cast(caps_n_1 as int64) as caps_n1,
+        cast(caps_n_ytd as int64) as caps_n_ytd,
+        cast(caps_n_1_ytd as int64) as caps_n1_ytd,
+        cast(caps_b2_b as int64) as caps_b2b,
+        cast(caps_b2_c as int64) as caps_b2c,
+        cast(caps_b2_c_ytd as int64) as caps_b2c_ytd,
         cast(ez as int64) as ez,
         cast(ez_n_ytd as int64) as ez_n_ytd,
-        cast(ez_n1 as int64) as ez_n1,
+        cast(ez_n_1 as int64) as ez_n1,
 
-        -- metadata
-        _smart_source_bucket,
-        _smart_source_file,
-        _smart_source_lineno,
-        _sdc_batched_at,
-        _sdc_received_at
+        -- metadata dlt. Les `_smart_source_*` de tap-spreadsheets-anywhere et
+        -- les `_sdc_*` de Singer n'existent plus ; `_fichier_modifie_le` porte
+        -- la date du classeur d'où vient la ligne.
+        _extracted_at,
+        _fichier_modifie_le
 
     from deduped
     where rn = 1


### PR DESCRIPTION
Remplace le projet Meltano `elt_sftp` — **le dernier du parc** — par le pipeline dlt `sftp_evs`. Les tables raw gardent leur nom ; ce sont leurs colonnes techniques et quelques colonnes métier qui changent.

## Renommages, mesurés colonne par colonne

Deux surprises du normaliseur dlt : un `_` final devient `x`, et un chiffre suivi d'une lettre gagne un `_`.

| Modèle | Renommages |
|---|---|
| `stg_gac__sinistres` | **3** — `immat_`→`immatx`, `cl_tur_`→`cl_turx`, `resp_`→`respx` |
| `stg_gac__vehicule` | **0** — les 12 colonnes métier sont identiques |
| `stg_nesp_co__client` | **9** — `ns_n1`→`ns_n_1`, `caps_b2b`→`caps_b2_b`, `caps_b2c_ytd_`→`caps_b2_c_ytd`, `_caps_n_ytd`→`caps_n_ytd`… |

## `snapshot_date` n'est plus dérivée ici

Le pipeline dlt la **fournit** : c'est sa clé de merge, tirée du nom du fichier daté. Le `regexp_extract` sur `_sdc_source_file` a simplement descendu d'un étage, là où il sert de clé.

Conséquence : un fichier relu **réécrit sa journée** au lieu de s'empiler. Sous Meltano, en `append` sans protection, 95 des 133 fichiers avaient été rechargés — 63 337 lignes en base pour 32 021 couples (fichier, ligne) réellement distincts. La dédup du staging l'absorbait, donc personne ne l'a vu.

## Le classeur Nespresso atterrit en texte

D'où 4 `safe_cast` supplémentaires sur `ns`, `ns_n1`, `ns_n_ytd`, `ns_n1_ytd`.

Laisser dlt inférer les types d'un Excel lui fait créer des **colonnes variantes selon l'ordre des lignes** du fichier : 61 % des valeurs non nulles de `ns_n_1_ytd` étaient parties dans `ns_n_1_ytd__v_double` au premier essai, et un `select` sur la colonne les aurait perdues en silence.

## Les deux freshness sont réparées

`_sdc_extracted_at` et `_sdc_deleted_at` étaient **NULL sur 100 % des lignes des trois tables**. La première portait la freshness de `nespresso_base_client` : le test n'a donc **jamais** pu se déclencher, et quatre mois de retard sont passés inaperçus.

> ⚠️ Au premier run, le seuil 90 j de `nespresso_base_client` va se déclencher — la donnée date de mars. C'est le but.

L'ordre de dédup de `stg_nesp_co__client` passe à `_fichier_modifie_le`, la date du classeur d'où vient la ligne : plusieurs dépôts arrivent souvent dans un même run (le pipeline est manuel) et **8 916 clients différaient** entre (47) et (48).

## Parité vérifiée, ligne à ligne

| Modèle | dev | prod | Écart |
|---|---|---|---|
| `stg_gac__sinistres` | 258 | 258 | **0** |
| `stg_gac__vehicule` | 430 | 430 | **0** |
| `fct_services_generaux__sinistre` | 258 | 258 | **0** |
| `stg_nesp_co__client` | 21 904 | 21 262 | +643 clients, −1 |

Le premier chiffre est le plus parlant : le raw est passé de **63 337 à 32 021 lignes** et la sortie du staging est **identique**. Les 31 316 lignes supprimées n'apportaient rien.

Les 643 clients qui arrivent viennent des deux classeurs restés en attente depuis mars. Le client perdu est `CLINIQUE CONVERT` (`third` 9963312), que Nespresso a retiré de sa base entre mars et juillet : l'ancienne table le gardait parce qu'un upsert ne supprime jamais.

Build de la lignée en dev : `PASS=35 WARN=0 ERROR=0`.

## ⚠️ Contexte de déploiement

Le raw de prod a **déjà** basculé : les trois tables Meltano ont été supprimées et rechargées par dlt depuis la VM. Le scheduler `pipeline-sftp-evs` est **suspendu**.

Mais `pipeline-nesp-co` tourne **demain à 8h** et construit `source:nesp_co+` : son étape dbt échouera si cette PR n'est pas mergée d'ici là.

Reste ensuite, côté `ingestion` et `infra` : image, job `elt-sftp-evs`, `gha_ingestion_jobs`, arguments des deux workflows, réactivation du scheduler, puis suppression du projet Meltano — la fin de Meltano.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH3ApGby8jMzB1rZ8BF1WU