### PR TITLE
feat(apptech): mart fct_technique__intervention_retraitee (facturation retraitée)

### DIFF
--- a/models/marts/technique/_technique__marts_models.yml
+++ b/models/marts/technique/_technique__marts_models.yml
@@ -1534,3 +1534,201 @@ models:
             max_value: 100000
           config:
             severity: warn
+
+  - name: fct_technique__intervention_retraitee
+    description: |
+      [QUOI MÉTIER]
+      Facturation retraitée (modèle « live ») : chaque intervention de
+      `fct_technique__intervention` enrichie des décisions de retraitement
+      saisies par les managers dans l'app Suivi Tech (facturation forcée,
+      technicien réel, délais forcés, doublement de prime, conversion code 5).
+      Base des marts Primes (prod nette et délais retenus post-retraitement) et
+      de la facturation partenaire corrigée.
+
+      [COMMENT CONSTRUITE]
+      `fct_technique__intervention` LEFT JOIN une version pivotée de
+      `int_apptech__retraitements` (les 6 flux de retraitement compilés) sur
+      `key_inter`. Le pivot produit 1 ligne par `key_inter` avec une colonne par
+      (type_retraitement, champ). Fusion colonne par colonne : `a_facturer_retraite`
+      ← mee OU modif_intervention (domaines normalisés en OUI/NON avant fusion) ;
+      `tech_id_reel_retraite` ← astreinte OU modif_intervention. Les colonnes
+      « effectives » (`statut_facturation_effectif`, `tech_id_effectif`,
+      `tech_yuman_id_effectif`, `delai_tech_effectif`, `delai_partenaire_effectif`)
+      appliquent le retraitement sur la valeur du fait (COALESCE retraité → base).
+
+      [GRAIN]
+      1 ligne par intervention. PK = `key_inter` (extension 1:1 du fait, pas de
+      fan-out).
+
+      [NOTES]
+      - Les interventions sans retraitement (majorité) ont `has_retraitement` =
+        false et toutes les colonnes retraitées à NULL ; leurs colonnes
+        effectives valent la valeur du fait.
+      - Lignes de `int_apptech__retraitements` à `key_inter` NULL (src_inter non
+        émis par l'app) exclues : non joignables.
+      - Deux colonnes ont plusieurs types contributeurs ; un test de collision
+        (`error`) échoue si les contributeurs divergent pour une même
+        intervention (cf. contrat identité DA, collision réputée très rare).
+      - Décision de facturation : `mee` émet OUI/NON, `modif_intervention` émet
+        'NOT VALIDATED' ou rien — normalisés en OUI/NON. ⚠️ Mapping à confirmer
+        avec le DA sur données réelles (période bêta, échantillon test réduit).
+      - Colonnes brutes par type (`*_mee`, `*_modif`, `*_astreinte`) conservées
+        pour audit.
+      - Rafraîchissement : hérite de `fct_technique__intervention` (pas de
+        scheduler dédié, refacto Option C via `source:<source>+`).
+
+    columns:
+      - name: key_inter
+        description: PK — identifiant unique de l'intervention (cf. `fct_technique__intervention`).
+        tests:
+          - not_null
+          - unique
+          - relationships:
+              arguments:
+                to: ref('fct_technique__intervention')
+                field: key_inter
+
+      - name: has_retraitement
+        description: >
+          Booléen — l'intervention a fait l'objet d'au moins un retraitement
+          (au moins une ligne dans `int_apptech__retraitements`).
+        tests:
+          - not_null
+
+      - name: types_retraitement
+        description: >
+          Liste (string, séparée par ', ') des types de retraitement ayant touché
+          l'intervention (astreinte, mee, curative, aguila, pause,
+          modif_intervention). NULL si aucun.
+
+      - name: statut_facturation_effectif
+        description: >
+          Statut de facturation après application du retraitement : VALIDATED si
+          `a_facturer_retraite` = OUI, NOT VALIDATED si NON, sinon le
+          `statut_facturation` du fait.
+        tests:
+          - not_null
+          - accepted_values:
+              arguments:
+                values: ['VALIDATED', 'NOT VALIDATED', 'NOT DEFINED']
+
+      - name: tech_id_effectif
+        description: >
+          Technicien retenu après retraitement, dans l'espace d'ID NATIF de la
+          source : nomad (`tec-xxxx`) côté NESP, id Yuman numérique côté YUMAN.
+          = technicien réel saisi si présent, sinon `tech_id` du fait.
+
+      - name: tech_yuman_id_effectif
+        description: Id Yuman du technicien effectif (pendant de `tech_id_effectif`).
+
+      - name: delai_tech_effectif
+        description: >
+          Délai côté technicien après retraitement : `delai_tech_force` (curative)
+          si saisi, sinon `delai_tech` du fait.
+
+      - name: delai_partenaire_effectif
+        description: >
+          Délai côté partenaire après retraitement : `delai_partenaire_force`
+          (curative) si saisi, sinon `delai_partenaire` du fait.
+
+      - name: tech_nom_effectif
+        description: >
+          Nom du technicien effectif (re-mappé sur `tech_id_effectif` via
+          `stg_yuman__users`). Cohérent avec `tech_id_effectif` — à utiliser pour
+          l'attribution des primes, contrairement à `tech_nom` (planifié).
+
+      - name: tech_secteur_effectif
+        description: >
+          Secteur du technicien effectif (pendant de `tech_nom_effectif`). À
+          utiliser pour les agrégats primes par secteur.
+
+      - name: tech_nomad_id_effectif
+        description: Identifiant Nomad du technicien effectif.
+
+      - name: flag_hors_delai_tech_effectif
+        description: >
+          Flag hors-délai technicien recalculé sur `delai_tech_effectif` (même
+          règle que `flag_hors_delai_tech` du fait : délai J++/J+3 sur une
+          curative). 1 = hors délai, 0 sinon.
+        tests:
+          - not_null
+
+      - name: key_factu_effectif
+        description: >
+          Clé de facturation effective : si `convertir_code_5` = OUI, le code de
+          tête passe de `1 -` à `5 -` (conversion code 5 Aguila), sinon =
+          `key_factu` du fait. Détermine `prod_effectif` / `montant_effectif`.
+
+      - name: prod_effectif
+        description: >
+          Production facturable effective : re-lookée sur `key_factu_effectif`
+          si conversion code 5, sinon = `prod` du fait.
+
+      - name: montant_effectif
+        description: >
+          Montant facturé effectif : re-looké sur `key_factu_effectif` si
+          conversion code 5 (tarif du code 5, différent du code 1), sinon =
+          `montant` du fait.
+
+      - name: a_facturer_retraite
+        description: >
+          Décision de facturation retraitée normalisée (OUI / NON / NULL),
+          fusionnée depuis `mee` et `modif_intervention`.
+        tests:
+          - accepted_values:
+              arguments:
+                values: ['OUI', 'NON']
+
+      - name: tech_id_reel_retraite
+        description: Technicien réel saisi (astreinte ou modif), avant COALESCE avec le fait. NULL si aucun.
+
+      - name: tech_yuman_id_reel_retraite
+        description: Id Yuman du technicien réel saisi. NULL si aucun.
+
+      - name: delai_tech_force
+        description: Délai technicien forcé (retraitement curative). NULL si aucun.
+
+      - name: delai_partenaire_force
+        description: Délai partenaire forcé (retraitement curative). NULL si aucun.
+
+      - name: doubler_prime
+        description: >
+          Décision « doubler la prime » (OUI/NON) du retraitement pause.
+          Consommé par les marts Primes. NULL si aucun.
+
+      - name: convertir_code_5
+        description: >
+          Décision « convertir le code 5 » (OUI/NON) du retraitement aguila.
+          NULL si aucun.
+
+      - name: type_modif
+        description: >
+          Type de modification d'intervention (Annulation / Réattribution /
+          Annulation + Réattribution / Autre). NULL hors modif_intervention.
+
+      - name: commentaire_retraitement
+        description: >
+          Commentaires managers agrégés, préfixés par type
+          (`<type>: <commentaire>`, séparés par ' | '). NULL si aucun.
+
+      - name: retraite_extracted_at
+        description: Timestamp d'extraction le plus récent parmi les retraitements de l'intervention.
+
+    tests:
+      # Collision a_facturer : mee dit OUI (facturer) ET modif dit NOT VALIDATED (ne pas facturer)
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: "not (a_facturer_mee = 'OUI' and a_facturer_modif = 'NOT VALIDATED')"
+          config:
+            severity: error
+      # Collision technicien réel : astreinte et modif divergent
+      - dbt_utils.expression_is_true:
+          arguments:
+            expression: >
+              not (
+                tech_id_reel_astreinte is not null
+                and tech_id_reel_modif is not null
+                and tech_id_reel_astreinte != tech_id_reel_modif
+              )
+          config:
+            severity: error

--- a/models/marts/technique/fct_technique__intervention_retraitee.sql
+++ b/models/marts/technique/fct_technique__intervention_retraitee.sql
@@ -1,0 +1,241 @@
+{{ config(materialized='table') }}
+
+-- Facturation retraitée (modèle « live », toujours à jour) : chaque intervention
+-- de fct_technique__intervention, enrichie des décisions de retraitement saisies
+-- par les managers dans l'app Suivi Tech (int_apptech__retraitements).
+--
+-- Grain : 1 ligne par key_inter (extension 1:1 du fait, pas de fan-out).
+-- Les retraitements sont pivotés à 1 ligne / key_inter (une colonne par
+-- (type, champ)), fusionnés colonne par colonne, puis appliqués au fait pour
+-- produire des colonnes « effectives » (statut / technicien / délai post-
+-- retraitement) que les marts Primes consomment directement.
+--
+-- Convention de nommage des colonnes de sortie :
+--   - sans suffixe  = état BRUT du fait (avant retraitement, pour audit)
+--   - suffixe _effectif = vérité POST-retraitement (consommée par les Primes)
+--   - colonnes *_retraite / *_mee / *_modif / *_astreinte = valeurs de
+--     retraitement fusionnées ou brutes par type (audit / débogage)
+--
+-- Deux colonnes logiques ont plus d'un type contributeur (cf. contrat DA) :
+--   a_facturer_retraite  ← mee OU modif_intervention
+--   tech_id_reel_retraite ← astreinte OU modif_intervention
+-- Un test de collision (error) échoue si les deux contributeurs divergent.
+
+with retraitements as (
+
+    select * from {{ ref('int_apptech__retraitements') }}
+    -- key_inter NULL = src_inter non émis par l'app : jointure impossible, on écarte.
+    where key_inter is not null
+
+),
+
+-- Pivot : 1 ligne par key_inter, une colonne par (type_retraitement, champ).
+pivoted as (
+
+    select
+        key_inter,
+
+        -- Décision de facturation (domaines source distincts, normalisés plus bas)
+        max(case when type_retraitement = 'mee' then a_facturer end) as a_facturer_mee,
+        max(case when type_retraitement = 'modif_intervention' then a_facturer end) as a_facturer_modif,
+
+        -- Technicien réel (astreinte ou modif_intervention)
+        max(case when type_retraitement = 'astreinte' then tech_id_reel end) as tech_id_reel_astreinte,
+        max(case when type_retraitement = 'astreinte' then tech_yuman_id_reel end) as tech_yuman_id_reel_astreinte,
+        max(case when type_retraitement = 'modif_intervention' then tech_id_reel end) as tech_id_reel_modif,
+        max(case when type_retraitement = 'modif_intervention' then tech_yuman_id_reel end) as tech_yuman_id_reel_modif,
+
+        -- Délais forcés (curative uniquement)
+        max(case when type_retraitement = 'curative' then delai_tech_force end) as delai_tech_force,
+        max(case when type_retraitement = 'curative' then delai_partenaire_force end) as delai_partenaire_force,
+
+        -- Flags consommés par les Primes (pause / aguila)
+        max(case when type_retraitement = 'pause' then doubler_prime end) as doubler_prime,
+        max(case when type_retraitement = 'aguila' then convertir_code_5 end) as convertir_code_5,
+
+        -- Type de modification (modif_intervention)
+        max(case when type_retraitement = 'modif_intervention' then type_modif end) as type_modif,
+
+        -- Traçabilité
+        string_agg(distinct type_retraitement order by type_retraitement) as types_retraitement,
+        string_agg(
+            case when commentaire is not null then concat(type_retraitement, ': ', commentaire) end
+            order by type_retraitement
+        ) as commentaire_retraitement,
+        max(extracted_at) as retraite_extracted_at
+
+    from retraitements
+    group by key_inter
+
+),
+
+-- Fusion colonne par colonne + normalisation de la décision de facturation.
+-- mee : OUI/NON tel quel. modif : 'NOT VALIDATED' => 'NON', sinon pas d'avis.
+merged as (
+
+    select
+        key_inter,
+
+        coalesce(
+            case a_facturer_mee when 'OUI' then 'OUI' when 'NON' then 'NON' end,
+            case when a_facturer_modif = 'NOT VALIDATED' then 'NON' end
+        ) as a_facturer_retraite,
+        coalesce(tech_id_reel_astreinte, tech_id_reel_modif) as tech_id_reel_retraite,
+        coalesce(tech_yuman_id_reel_astreinte, tech_yuman_id_reel_modif) as tech_yuman_id_reel_retraite,
+        delai_tech_force,
+        delai_partenaire_force,
+        doubler_prime,
+        convertir_code_5,
+        type_modif,
+
+        -- Brut par type (audit / débogage)
+        a_facturer_mee,
+        a_facturer_modif,
+        tech_id_reel_astreinte,
+        tech_yuman_id_reel_astreinte,
+        tech_id_reel_modif,
+        tech_yuman_id_reel_modif,
+
+        types_retraitement,
+        commentaire_retraitement,
+        retraite_extracted_at
+
+    from pivoted
+
+),
+
+-- Application des retraitements au fait : colonnes brutes (fait) + colonnes
+-- effectives (post-retraitement). Le technicien effectif n'est ici qu'un ID ;
+-- son nom/secteur/nomad_id sont re-mappés dans le SELECT final.
+effective as (
+
+    select
+        -- Grain + identité (repris du fait)
+        f.key_inter,
+        f.src_inter,
+        f.partenaire,
+        f.intervention_id,
+        f.numero_pu,
+
+        -- Attributs intervention (fait)
+        f.intervention_statut,
+        f.statut_facturation,
+        f.categorie_machine,
+        f.machine_clean,
+        f.type_intervention,
+        f.num_serie_machine,
+        f.tech_id,
+        f.client_id,
+        f.client_nom,
+        f.date_creation,
+        f.date_debut,
+        f.date_fin,
+        f.duree_inter_minutes,
+        f.key_factu,
+        f.code_postal,
+        f.consignes,
+        f.commentaire_tech,
+        f.prod,
+        f.montant,
+        f.bonus_bool,
+        f.montant_avec_bonus,
+        f.delai_heures_debut,
+        f.delai_heures_fin,
+        f.delai_tech,
+        f.delai_partenaire,
+        f.flag_montagne_prime,
+        f.flag_paris_intramuros,
+        f.flag_hors_delai_tech,
+        f.tech_yuman_id,
+        f.tech_nomad_id,
+        f.tech_nom,
+        f.tech_secteur,
+        f.alias_obj_type_inter,
+        f.alias_obj_type_machine,
+        f.alias_obj_grp_machine,
+
+        -- Colonnes effectives (fait après application des retraitements)
+        case
+            when m.a_facturer_retraite = 'OUI' then 'VALIDATED'
+            when m.a_facturer_retraite = 'NON' then 'NOT VALIDATED'
+            else f.statut_facturation
+        end as statut_facturation_effectif,
+        -- tech_id_effectif reste dans l'espace d'ID NATIF de la source :
+        -- nomad (tec-xxxx) côté NESP, id Yuman numérique côté YUMAN. L'app écrit
+        -- le technicien réel en nomad (tech_id_reel) ET en id Yuman
+        -- (tech_yuman_id_reel), donc on prend le bon selon src_inter.
+        case
+            when f.src_inter = 'NESP' then coalesce(m.tech_id_reel_retraite, f.tech_id)
+            when f.src_inter = 'YUMAN' then coalesce(cast(m.tech_yuman_id_reel_retraite as string), f.tech_id)
+        end as tech_id_effectif,
+        coalesce(m.tech_yuman_id_reel_retraite, f.tech_yuman_id) as tech_yuman_id_effectif,
+        coalesce(m.delai_tech_force, f.delai_tech) as delai_tech_effectif,
+        coalesce(m.delai_partenaire_force, f.delai_partenaire) as delai_partenaire_effectif,
+        -- Conversion code 5 (aguila) : force le code de tête de key_factu de 1
+        -- à 5, ce qui change la clé de facturation (donc tarif + prod, re-lookés
+        -- dans le SELECT final). Côté app, convertir_code_5='OUI' n'est proposé
+        -- que sur des interventions key_factu '1 - ... Aguila', donc le swap est sûr.
+        case
+            when m.convertir_code_5 = 'OUI' then regexp_replace(f.key_factu, r'^1 ', '5 ')
+            else f.key_factu
+        end as key_factu_effectif,
+
+        -- Décisions de retraitement fusionnées
+        m.a_facturer_retraite,
+        m.tech_id_reel_retraite,
+        m.tech_yuman_id_reel_retraite,
+        m.delai_tech_force,
+        m.delai_partenaire_force,
+        m.doubler_prime,
+        m.convertir_code_5,
+        m.type_modif,
+
+        -- Traçabilité
+        coalesce(m.types_retraitement is not null, false) as has_retraitement,
+        m.types_retraitement,
+        m.commentaire_retraitement,
+
+        -- Brut par type (audit)
+        m.a_facturer_mee,
+        m.a_facturer_modif,
+        m.tech_id_reel_astreinte,
+        m.tech_yuman_id_reel_astreinte,
+        m.tech_id_reel_modif,
+        m.tech_yuman_id_reel_modif,
+
+        -- Métadonnées
+        m.retraite_extracted_at
+
+    from {{ ref('fct_technique__intervention') }} as f
+    left join merged as m on f.key_inter = m.key_inter
+
+)
+
+select
+    e.*,
+
+    -- Technicien effectif complet : re-mapping nom/secteur/nomad_id sur l'id
+    -- Yuman effectif (tech_yuman_id_effectif), clé universelle NESP+YUMAN
+    -- (l'app résout toujours l'id Yuman du technicien réel). Les colonnes
+    -- tech_nom/tech_secteur/tech_nomad_id ci-dessus restent le PLANIFIÉ (audit).
+    tech_eff.user_name as tech_nom_effectif,
+    tech_eff.user_secteur as tech_secteur_effectif,
+    tech_eff.nomad_id as tech_nomad_id_effectif,
+
+    -- Flag hors-délai recalculé sur le délai effectif (même règle que le fait).
+    case
+        when e.delai_tech_effectif in ('J++', 'J+3') and lower(e.key_factu) like '%curative%'
+            then 1
+        else 0
+    end as flag_hors_delai_tech_effectif,
+
+    -- Facturation effective : si conversion code 5, tarif/prod re-lookés sur la
+    -- clé effective ; sinon valeurs du fait. (kf_eff ne résout que les clés
+    -- NESP ; le case garde le montant du fait pour tout le reste, dont YUMAN.)
+    case when e.convertir_code_5 = 'OUI' then kf_eff.prod_factu else e.prod end as prod_effectif,
+    case when e.convertir_code_5 = 'OUI' then kf_eff.tarif_factu else e.montant end as montant_effectif
+from effective as e
+left join {{ ref('stg_yuman__users') }} as tech_eff
+    on e.tech_yuman_id_effectif = tech_eff.user_id
+left join {{ ref('ref_nesp_tech__key_facturation') }} as kf_eff
+    on e.key_factu_effectif = kf_eff.key_ref_inter

--- a/models/staging/apptech/_apptech__models.yml
+++ b/models/staging/apptech/_apptech__models.yml
@@ -304,13 +304,13 @@ models:
       - name: numero_pu
         description: "Numéro d'intervention visible (n° PU), pour recherche/audit. NULL en phase de bascule."
       - name: a_facturer
-        description: "Décision de facturation (normalisé en majuscules, NULL si non renseignée)"
+        description: "Décision de facturation de la modif : 'NOT VALIDATED' (= annulation, seule valeur émise par l'app) ou NULL si non renseignée. À ne pas confondre avec le OUI/NON de la MEE."
         tests:
           - accepted_values:
               arguments:
-                values: ['OUI', 'NON']
+                values: ['NOT VALIDATED']
       - name: tech_id_reel
-        description: "Identifiant interne du technicien réel (normalisé en minuscules, ex. 'tec-01003')"
+        description: "Identifiant du technicien réel : nomad ('tec-xxxx') pour un technicien qui en a un, ou id Yuman brut sinon (23/66 techniciens n'ont pas de nomad — cf. app evs-suivi-tech). Normalisé en minuscules."
       - name: tech_yuman_id_reel
         description: "Identifiant Yuman du technicien réel"
       - name: type_modif

--- a/models/staging/apptech/stg_apptech__suivi_tech_astreinte.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_astreinte.sql
@@ -25,7 +25,7 @@ cleaned_data as (
         intervention_id,
         upper(trim(src_inter)) as src_inter,
         nullif(trim(numero_pu), '') as numero_pu,
-        lower(trim(tech_id_reel)) as tech_id_reel,
+        nullif(lower(trim(tech_id_reel)), '') as tech_id_reel,
         tech_yuman_id_reel,
         nullif(trim(commentaire), '') as commentaire,
 

--- a/models/staging/apptech/stg_apptech__suivi_tech_modif_intervention.sql
+++ b/models/staging/apptech/stg_apptech__suivi_tech_modif_intervention.sql
@@ -29,7 +29,7 @@ cleaned_data as (
         nullif(trim(numero_pu), '') as numero_pu,
         -- a_facturer peut être vide dans la source (modif sans décision de facturation)
         upper(nullif(trim(a_facturer), '')) as a_facturer,
-        lower(trim(tech_id_reel)) as tech_id_reel,
+        nullif(lower(trim(tech_id_reel)), '') as tech_id_reel,
         tech_yuman_id_reel,
         nullif(trim(type_modif), '') as type_modif,
         nullif(trim(commentaire), '') as commentaire,


### PR DESCRIPTION
## Quoi
Étape 2 du chantier facturation retraitée : mart live `fct_technique__intervention_retraitee` (1 ligne/intervention, extension 1:1 de `fct_technique__intervention` sur `key_inter`), qui applique les décisions de retraitement saisies dans l'app Suivi Tech (`int_apptech__retraitements`). Servira de base aux marts Primes.

## Convention de colonnes
- sans suffixe = état **brut** du fait (audit)
- `_effectif` = vérité **post-retraitement** (consommée par les Primes)

## Règles (confirmées DA)
- **Q1** MEE `a_facturer=OUI` → VALIDATED
- **Q4** `convertir_code_5=OUI` : force le code de tête `key_factu` 1→5 (conversion code 5 Aguila) → re-lookup tarif+prod (ex. 726€→248€)
- **Q5** `flag_hors_delai_tech_effectif` sur `delai_tech`
- **Q6** technicien effectif re-mappé sur l'id Yuman (universel NESP+YUMAN), compatible avec le fix app de réaffectation Yuman (evs-suivi-tech PR #7)

## Aussi
- fix staging : `nullif` sur `tech_id_reel` (astreinte + modif) — la source émettait des chaînes vides → faux overrides/collisions
- tests : `unique`/`not_null`/`relationships` sur `key_inter`, `accepted_values`, + 2 tests de collision (`error`) sur `a_facturer` / `tech_id_reel`

## Validation
Build dev vert (92,6k lignes, sans fan-out), tous tests PASS, recompute code 5 vérifié en base.

## Reporté
`montant_avec_bonus` effectif → chantier Primes (dépend du calcul bonus amont).

🤖 Generated with [Claude Code](https://claude.com/claude-code)