### PR TITLE
refactor(zoho_desk): aligner le staging sur le raw produit par dlt

### DIFF
--- a/models/staging/zoho_desk/_zoho_desk__sources.yml
+++ b/models/staging/zoho_desk/_zoho_desk__sources.yml
@@ -19,7 +19,10 @@ sources:
       Données brutes extraites de l'API Zoho Desk (EU region) via dlt (data load tool).
       Dataset BigQuery : evs-datastack-prod.prod_raw.
     database: "{{ var('raw_project') }}"
-    schema: prod_raw
+    # Paramétré comme sur oracle_lcdp : permet de pointer dbt sur le raw dlt
+    # en dev (--vars raw_schema: dev_raw) AVANT la bascule de production.
+    # Le défaut prod_raw laisse la prod inchangée.
+    schema: "{{ var('raw_schema', 'prod_raw') }}"
     config:
       tags: ['zoho_desk', 'source']
 

--- a/models/staging/zoho_desk/_zoho_desk__sources.yml
+++ b/models/staging/zoho_desk/_zoho_desk__sources.yml
@@ -343,16 +343,24 @@ sources:
 
       - name: zoho_desk_ticket_details
         description: >
-          Enrichissement 1:1 par ticket (20 678 lignes) : flags SLA, champs custom (cf_*),
-          texte de résolution, layout utilisé.
-          Jointure : _zoho_desk_tickets_id = zoho_desk_associated_tickets.id
-          NOTE : la colonne FK est nommée _zoho_desk_tickets_id et non
-          _zoho_desk_associated_tickets_id car le transformer dlt était défini
-          avec data_from=tickets (nom de la ressource dlt, pas du endpoint).
+          La réponse COMPLÈTE de /tickets/{id}, un appel par ticket : flags SLA,
+          61 champs personnalisés (cf__*), résolution, description, layout,
+          compteurs. Superset de zoho_desk_associated_tickets, qui n'est que la
+          vue de liste.
+          Jointure : _zoho_desk_associated_tickets_id = zoho_desk_associated_tickets.id
+          (`id` porte la même valeur — dlt réplique la clé du parent sous les deux noms).
+          NOTE : la FK s'appelait _zoho_desk_tickets_id jusqu'au passage du
+          pipeline sur dlt.sources.rest_api. dlt dérive désormais ce nom de la
+          ressource PARENTE, ce qui supprime l'incohérence.
+          Les champs personnalisés sont préfixés cf__ : l'API rend un objet `cf`
+          que dlt aplatit. L'objet jumeau `customFields`, indexé par LIBELLÉ
+          d'affichage, est écarté à l'ingestion — ses noms de colonne
+          dépendraient d'un texte modifiable dans l'interface Zoho.
         columns:
-          - name: _zoho_desk_tickets_id
+          - name: _zoho_desk_associated_tickets_id
             description: >
-              PK et FK — identifiant du ticket associé.
+              PK et FK — identifiant du ticket associé, injecté par dlt depuis la
+              ressource parente.
               Jointure : = zoho_desk_associated_tickets.id
               Renommé ticket_id dans le staging.
             tests: [unique, not_null]
@@ -368,7 +376,7 @@ sources:
             description: "Texte de résolution saisi par l'agent à la fermeture du ticket"
           - name: layout_id
             description: "ID du layout de formulaire Zoho"
-          - name: layout_name
+          - name: layout_details__layout_name
             description: "Nom lisible du layout (ex : Default Layout, Formulaire Facturation)"
           - name: contract_id
             description: "ID du contrat de service associé au ticket"
@@ -392,97 +400,97 @@ sources:
           # Tous les champs custom Zoho sont de type STRING quelle que soit leur
           # nature réelle (date, booléen, liste) — cast à faire dans le staging
           # si nécessaire.
-          - name: cf_statut_client
+          - name: cf__cf_statut_client
             description: "Custom field : statut du client (ex : VIP, Standard)"
-          - name: cf_nature_des_demandes
+          - name: cf__cf_nature_des_demandes
             description: "Custom field : nature de la demande (classification interne)"
-          - name: cf_previous_status
+          - name: cf__cf_previous_status
             description: "Custom field : statut Zoho précédent (avant l'état courant)"
-          - name: cf_demande_intervention
+          - name: cf__cf_demande_intervention
             description: "Custom field : demande d'intervention terrain"
-          - name: cf_technique
+          - name: cf__cf_technique
             description: "Custom field : indicateur de demande technique"
-          - name: cf_type
+          - name: cf__cf_type
             description: "Custom field : type de demande"
-          - name: cf_type_de_remboursement
+          - name: cf__cf_type_de_remboursement
             description: "Custom field : type de remboursement demandé"
-          - name: cf_contrat_avenant
+          - name: cf__cf_contrat_avenant
             description: "Custom field : contrat ou avenant concerné"
-          - name: cf_suivi_intervention
+          - name: cf__cf_suivi_intervention
             description: "Custom field : lien ou référence de suivi d'intervention"
-          - name: cf_votre_demande_concerne
+          - name: cf__cf_votre_demande_concerne
             description: "Custom field : objet de la demande (formulaire portail client)"
-          - name: cf_correction
+          - name: cf__cf_correction
             description: "Custom field : correction demandée"
-          - name: cf_close_ticket_notification_sent
+          - name: cf__cf_close_ticket_notification_sent
             description: "Custom field : notification de fermeture envoyée (oui/non)"
-          - name: cf_civilite
+          - name: cf__cf_civilite
             description: "Custom field : civilité du demandeur (M., Mme) — formulaire web"
-          - name: cf_nom
+          - name: cf__cf_nom
             description: "Custom field : nom du demandeur — formulaire web"
-          - name: cf_prenom
+          - name: cf__cf_prenom
             description: "Custom field : prénom du demandeur — formulaire web"
-          - name: cf_numero_de_telephone
+          - name: cf__cf_numero_de_telephone
             description: "Custom field : téléphone — formulaire web"
-          - name: cf_nom_de_l_entreprise
+          - name: cf__cf_nom_de_l_entreprise
             description: "Custom field : nom de l'entreprise — formulaire web"
-          - name: cf_secteur_d_activite
+          - name: cf__cf_secteur_d_activite
             description: "Custom field : secteur d'activité — formulaire web"
-          - name: cf_tranche_effectiv
+          - name: cf__cf_tranche_effectiv
             description: "Custom field : tranche d'effectif de l'entreprise"
-          - name: cf_fiche_de_renseignement
+          - name: cf__cf_fiche_de_renseignement
             description: "Custom field : fiche de renseignement (pièce jointe ou référence)"
-          - name: cf_inscription
+          - name: cf__cf_inscription
             description: "Custom field : inscription"
-          - name: cf_creation_d_un_site
+          - name: cf__cf_creation_d_un_site
             description: "Custom field : demande de création d'un site"
-          - name: cf_modification_d_un_site
+          - name: cf__cf_modification_d_un_site
             description: "Custom field : demande de modification d'un site"
-          - name: cf_badges
+          - name: cf__cf_badges
             description: "Custom field : badges concernés"
-          - name: cf_rupture
+          - name: cf__cf_rupture
             description: "Custom field : rupture de stock signalée"
-          - name: cf_boisson_chaude
+          - name: cf__cf_boisson_chaude
             description: "Custom field : boissons chaudes (ancienne colonne, remplacée par cf_boissons_chaudes)"
-          - name: cf_boissons_chaudes
+          - name: cf__cf_boissons_chaudes
             description: "Custom field : boissons chaudes"
-          - name: cf_snack
+          - name: cf__cf_snack
             description: "Custom field : snacks"
-          - name: cf_consommables
+          - name: cf__cf_consommables
             description: "Custom field : consommables"
-          - name: cf_s_reappro
+          - name: cf__cf_s_reappro
             description: "Custom field : réapprovisionnement"
-          - name: cf_s_facturation
+          - name: cf__cf_s_facturation
             description: "Custom field : facturation"
-          - name: cf_s_remboursement
+          - name: cf__cf_s_remboursement
             description: "Custom field : remboursement"
-          - name: cf_s_commercial
+          - name: cf__cf_s_commercial
             description: "Custom field : commercial"
-          - name: cf_s_commande_directes
+          - name: cf__cf_s_commande_directes
             description: "Custom field : commandes directes"
-          - name: cf_s_gestion_des_cartes_privatives
+          - name: cf__cf_s_gestion_des_cartes_privatives
             description: "Custom field : gestion des cartes privatives"
-          - name: cf_s_gestion_des_planogrammes
+          - name: cf__cf_s_gestion_des_planogrammes
             description: "Custom field : gestion des planogrammes"
-          - name: cf_s_recyclage
+          - name: cf__cf_s_recyclage
             description: "Custom field : recyclage"
-          - name: cf_s_remontees_personnel_neshu
+          - name: cf__cf_s_remontees_personnel_neshu
             description: "Custom field : remontées personnel NESHU"
-          - name: cf_s_systeme_de_paiement
+          - name: cf__cf_s_systeme_de_paiement
             description: "Custom field : système de paiement"
-          - name: cf_collecte
+          - name: cf__cf_collecte
             description: "Custom field : collecte"
-          - name: cf_modification
+          - name: cf__cf_modification
             description: "Custom field : modification demandée"
-          - name: cf_modifications
+          - name: cf__cf_modifications
             description: "Custom field : modifications (variante colonne, coexiste avec cf_modification)"
-          - name: cf_date_de_l_animation
+          - name: cf__cf_date_de_l_animation
             description: "Custom field : date de l'animation"
-          - name: cf_champ_machine_formulaire
+          - name: cf__cf_champ_machine_formulaire
             description: "Custom field : référence machine saisie dans le formulaire web"
-          - name: cf_s_equipements
+          - name: cf__cf_s_equipements
             description: "Custom field : équipements concernés"
-          - name: cf_machines
+          - name: cf__cf_machines
             description: "Custom field : machines concernées"
           - name: _dlt_load_id
             description: "ID interne du run dlt (STRING)"

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_details.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_details.sql
@@ -12,9 +12,11 @@ with source as (
 renamed as (
     select
         -- primary key + foreign key to stg_zoho_desk__tickets
-        -- (colonne source nommée _zoho_desk_tickets_id car le transformer dlt
-        --  utilisait la ressource `tickets` comme parent)
-        _zoho_desk_tickets_id as ticket_id,
+        -- La FK est nommée par dlt d'après la ressource PARENTE
+        -- (`zoho_desk_associated_tickets`). Elle s'appelait _zoho_desk_tickets_id
+        -- jusqu'au passage du pipeline sur dlt.sources.rest_api : le transformer
+        -- était alors défini sur une ressource nommée `tickets`.
+        _zoho_desk_associated_tickets_id as ticket_id,
 
         -- sla (indicateurs et flags regroupés par domaine)
         sla_id,
@@ -24,7 +26,7 @@ renamed as (
 
         -- layout
         layout_id,
-        layout_name,
+        layout_details__layout_name as layout_name,
 
         -- resolution
         resolution,
@@ -38,52 +40,57 @@ renamed as (
         safe_cast(task_count as int64) as task_count,
 
         -- custom fields (tous STRING — caster dans les marts si nécessaire)
-        cf_statut_client,
-        cf_nature_des_demandes,
-        cf_type,
-        cf_type_de_remboursement,
-        cf_votre_demande_concerne,
-        cf_demande_intervention,
-        cf_technique,
-        cf_s_equipements,
-        cf_machines,
-        cf_suivi_intervention,
-        cf_s_facturation,
-        cf_s_remboursement,
-        cf_s_commercial,
-        cf_s_reappro,
-        cf_rupture,
-        cf_boissons_chaudes,
-        cf_snack,
-        cf_consommables,
-        cf_s_gestion_des_cartes_privatives,
-        cf_s_gestion_des_planogrammes,
-        cf_s_recyclage,
-        cf_s_systeme_de_paiement,
-        cf_collecte,
-        cf_badges,
-        cf_inscription,
-        cf_creation_d_un_site,
-        cf_modification_d_un_site,
-        cf_nom_de_l_entreprise,
-        cf_secteur_d_activite,
-        cf_civilite,
-        cf_nom,
-        cf_prenom,
-        cf_numero_de_telephone,
-        cf_date_de_l_animation,
-        cf_champ_machine_formulaire,
-        cf_previous_status,
-        cf_close_ticket_notification_sent,
-        cf_contrat_avenant,
-        cf_correction,
-        cf_modification,
-        cf_s_remontees_personnel_neshu,
-        cf_s_commande_directes,
-        cf_tranche_effectiv,
-        cf_fiche_de_renseignement,
-        cf_boisson_chaude,
-        cf_modifications,
+        -- Colonnes source préfixées cf__ : l'API rend un OBJET `cf`, que dlt
+        -- aplatit en cf__<nom d'API>. L'ancien pipeline remontait ces clés à la
+        -- racine à la main — de la logique dans l'extracteur, que les conventions
+        -- d'ingestion interdisent. Les noms de SORTIE ne bougent pas : les couches
+        -- intermediate et marts sont intactes.
+        cf__cf_statut_client as cf_statut_client,
+        cf__cf_nature_des_demandes as cf_nature_des_demandes,
+        cf__cf_type as cf_type,
+        cf__cf_type_de_remboursement as cf_type_de_remboursement,
+        cf__cf_votre_demande_concerne as cf_votre_demande_concerne,
+        cf__cf_demande_intervention as cf_demande_intervention,
+        cf__cf_technique as cf_technique,
+        cf__cf_s_equipements as cf_s_equipements,
+        cf__cf_machines as cf_machines,
+        cf__cf_suivi_intervention as cf_suivi_intervention,
+        cf__cf_s_facturation as cf_s_facturation,
+        cf__cf_s_remboursement as cf_s_remboursement,
+        cf__cf_s_commercial as cf_s_commercial,
+        cf__cf_s_reappro as cf_s_reappro,
+        cf__cf_rupture as cf_rupture,
+        cf__cf_boissons_chaudes as cf_boissons_chaudes,
+        cf__cf_snack as cf_snack,
+        cf__cf_consommables as cf_consommables,
+        cf__cf_s_gestion_des_cartes_privatives as cf_s_gestion_des_cartes_privatives,
+        cf__cf_s_gestion_des_planogrammes as cf_s_gestion_des_planogrammes,
+        cf__cf_s_recyclage as cf_s_recyclage,
+        cf__cf_s_systeme_de_paiement as cf_s_systeme_de_paiement,
+        cf__cf_collecte as cf_collecte,
+        cf__cf_badges as cf_badges,
+        cf__cf_inscription as cf_inscription,
+        cf__cf_creation_d_un_site as cf_creation_d_un_site,
+        cf__cf_modification_d_un_site as cf_modification_d_un_site,
+        cf__cf_nom_de_l_entreprise as cf_nom_de_l_entreprise,
+        cf__cf_secteur_d_activite as cf_secteur_d_activite,
+        cf__cf_civilite as cf_civilite,
+        cf__cf_nom as cf_nom,
+        cf__cf_prenom as cf_prenom,
+        cf__cf_numero_de_telephone as cf_numero_de_telephone,
+        cf__cf_date_de_l_animation as cf_date_de_l_animation,
+        cf__cf_champ_machine_formulaire as cf_champ_machine_formulaire,
+        cf__cf_previous_status as cf_previous_status,
+        cf__cf_close_ticket_notification_sent as cf_close_ticket_notification_sent,
+        cf__cf_contrat_avenant as cf_contrat_avenant,
+        cf__cf_correction as cf_correction,
+        cf__cf_modification as cf_modification,
+        cf__cf_s_remontees_personnel_neshu as cf_s_remontees_personnel_neshu,
+        cf__cf_s_commande_directes as cf_s_commande_directes,
+        cf__cf_tranche_effectiv as cf_tranche_effectiv,
+        cf__cf_fiche_de_renseignement as cf_fiche_de_renseignement,
+        cf__cf_boisson_chaude as cf_boisson_chaude,
+        cf__cf_modifications as cf_modifications,
 
         -- metadata
         created_by,

--- a/models/staging/zoho_desk/stg_zoho_desk__ticket_history_event_info.sql
+++ b/models/staging/zoho_desk/stg_zoho_desk__ticket_history_event_info.sql
@@ -22,8 +22,15 @@ renamed as (
         property_type,
         system_property,
 
+        -- Les TROIS valeurs scalaires ci-dessous sont POLYMORPHES : l'API rend
+        -- tantôt du texte ('Closed'), tantôt un horodatage (property_name
+        -- 'Due Date'), tantôt un booléen. Le cast explicite en string rend ce
+        -- modèle indépendant du type inféré au raw — sans lui, une inférence à
+        -- `timestamp` casse les modèles d'intermediate qui les coalescent
+        -- (COALESCE(TIMESTAMP, STRING)), comme mesuré le 2026-08-05.
+
         -- scalar value (quand la valeur n'est pas un before/after — ex : première assignation)
-        property_value,
+        cast(property_value as string) as property_value,
         property_value__id,
         property_value__name,
         property_value__type,
@@ -31,7 +38,7 @@ renamed as (
         -- valeur AVANT modification
         -- scalaire : property_value__previous_value (ex : 'Open')
         -- objet    : property_value__previous_value__id / __name / __type (ex : agent précédent)
-        property_value__previous_value,
+        cast(property_value__previous_value as string) as property_value__previous_value,
         property_value__previous_value__id,
         property_value__previous_value__name,
         property_value__previous_value__type,
@@ -39,7 +46,7 @@ renamed as (
         -- valeur APRÈS modification
         -- scalaire : property_value__updated_value (ex : 'Closed')
         -- objet    : property_value__updated_value__id / __name / __type (ex : nouvel agent)
-        property_value__updated_value,
+        cast(property_value__updated_value as string) as property_value__updated_value,
         property_value__updated_value__id,
         property_value__updated_value__name,
         property_value__updated_value__type,


### PR DESCRIPTION
Aligne la couche staging Zoho Desk sur le `prod_raw` produit par le pipeline
`dlt.sources.rest_api` (`ingestion@1645719`). Sans ce PR, les 13 modèles de
staging lisent des colonnes qui n'existent plus.

## Contenu

| Commit | Objet |
|---|---|
| `refactor` | **renommage des colonnes** — dlt aplatit autrement que l'ancien extracteur : `cf_statut_client` → `cf__cf_statut_client`, `layout_name` → `layout_details__layout_name`. 123 lignes de `_zoho_desk__sources.yml`, 107 de `stg_zoho_desk__ticket_details.sql`. |
| `refactor` | **schéma source paramétrable** : `schema: "{{ var('raw_schema', 'prod_raw') }}"`, comme `oracle_lcdp`. Le défaut laisse la production inchangée. C'est ce qui rend la validation possible AVANT bascule. |
| `fix` | **cast des 3 valeurs polymorphes** de `ticket_history__event_info`. |

## Validation

Le paramétrage du schéma a payé immédiatement. Première passe contre le `dev_raw`
du nouveau pipeline : 89 PASS / 3 ERROR — `language` que l'API ne renseigne plus,
et `property_value__updated_value` inféré en TIMESTAMP avec 87 % des valeurs
rangées en colonnes variantes. Les trois corrigés côté ingestion.

Deux passes complètes après correction, `dbt build -s source:zoho_desk+` :

| Cible du raw | Résultat |
|---|---|
| `evs-datastack-dev.dev_raw` | **PASS=129 WARN=1 ERROR=0** |
| `evs-datastack-prod.prod_raw` (chemin de production) | **PASS=129 WARN=1 ERROR=0** |

L'unique warning est un `accepted_values` sur `int_zoho_desk__ticket_enriched.status_type` :
3 tickets sur 23 217 (0,01 %) ont un statut vide, vraisemblablement des valeurs
non couvertes par le seed `status_mapping`. Severity `warn`, préexistant au
chantier, à traiter séparément.

## État de la bascule

`ingestion` et `infra` sont livrés. Le premier run de production a échoué sur le
budget d'API Zoho — le nocturne de 3 h avait déjà consommé les 81 % du jour, il
n'y avait pas de marge pour un rattrapage manuel (documenté dans
`pipelines/zoho_desk/CLAUDE.md` § Quotas). L'échec est survenu en **extraction**,
donc sans chargement partiel ni curseur avancé.

`prod_raw` a été repeuplé depuis `dev_raw` pour débloquer ce PR : 19 tables,
compteurs vérifiés un à un. `ticket_history` et ses 3 tables filles y sont à
~3,6 % de leur volume, l'échantillon dev ayant été extrait en `--limit`. Le run
complet de demain les remettra d'aplomb — `ticket_history` est en `replace`, les
autres en `merge`.

Sauvegarde de l'état antérieur : `evs-datastack-prod.prod_raw_backup_zoho_20260805`,
23 tables, 1 770 241 lignes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)