### PR TITLE
feat(nesp_co): lire les tables dlt au lieu des tables externes GCS

### DIFF
--- a/models/staging/nesp_co/_nesp_co__sources.yml
+++ b/models/staging/nesp_co/_nesp_co__sources.yml
@@ -9,8 +9,8 @@ sources:
     config:
       tags: ['nesp_co', 'source']
     tables:
-      - name: nespresso_commerce_activite
-        description: "External table (GCS-backed CSV) — activités commerciales Nespresso, remplace l'ancienne table native"
+      - name: nesp_co_activite
+        description: "Activités commerciales Nespresso. Chargée par le pipeline dlt `nesp_co` (dépôt ingestion) depuis les classeurs du SFTP. Remplace la table externe `nespresso_commerce_activite`, adossée à des CSV dans GCS, le 2026-08-06."
         columns:
           - name: employee_responsible
             description: "Identifiant de l'employé responsable"
@@ -66,15 +66,15 @@ sources:
             description: "Date de la tâche"
           - name: notes
             description: "Notes supplémentaires sur l'activité commerciale"
-          - name: extracted_at
+          - name: _extracted_at
             description: "Date et heure d'extraction des données"
-          - name: source_file
+          - name: _fichier
             description: "Nom du fichier source d'où proviennent les données"
-          - name: file_date
+          - name: snapshot_date
             description: "Date du fichier source"
           
-      - name: nespresso_commerce_opportunite
-        description: "External table (GCS-backed CSV) — opportunités commerciales Nespresso, remplace l'ancienne table native"
+      - name: nesp_co_opportunite
+        description: "Opportunités commerciales Nespresso. Chargée par le pipeline dlt `nesp_co` (dépôt ingestion) depuis les classeurs du SFTP. Remplace la table externe `nespresso_commerce_opportunite` le 2026-08-06."
         columns:
           - name: opportunity
             description: "Identifiant de l'opportunité commerciale"
@@ -116,7 +116,7 @@ sources:
             description: "Identifiant Nessoft du compte"
           - name: sales_unit
             description: "Unité de vente associée à l'opportunité"
-          - name: role_account_
+          - name: role_account
             description: "Rôle du compte (Prospect / Client)"
           - name: lifecycle_status
             description: "Statut du cycle de vie de l'opportunité"
@@ -124,7 +124,7 @@ sources:
             description: "Nombre de capsules de la première commande de café"
           - name: expected_value
             description: "Valeur attendue de l'opportunité"
-          - name: _zeq_zenius_equivalent_
+          - name: zeq_zenius_equivalent
             description: "Équivalent Zenius de l'opportunité"
           - name: chance_of_success
             description: "Chance de succès de l'opportunité en pourcentage"
@@ -134,11 +134,11 @@ sources:
             description: "Nombre d'opp"
           - name: machines
             description: "Nombre de machines associées à l'opportunité"
-          - name: extracted_at
+          - name: _extracted_at
             description: "Date et heure d'extraction des données"
-          - name: source_file
+          - name: _fichier
             description: "Nom du fichier source d'où proviennent les données"
-          - name: file_date
+          - name: snapshot_date
             description: "Date du fichier source"
 
       - name: nespresso_base_client

--- a/models/staging/nesp_co/stg_nesp_co__activite.sql
+++ b/models/staging/nesp_co/stg_nesp_co__activite.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        partition_by={'field': 'file_date', 'data_type': 'timestamp'},
+        partition_by={'field': 'file_date', 'data_type': 'date'},
         description='Table des activités Nespresso Commercial nettoyée et filtrée sur les colonnes utiles.'
     )
 }}
@@ -9,7 +9,7 @@
 with source_data as (
 
     select *
-    from {{ source('nesp_co', 'nespresso_commerce_activite') }}
+    from {{ source('nesp_co', 'nesp_co_activite') }}
 
 ),
 
@@ -45,9 +45,9 @@ base_activite as (
         nullif(calendar_month, '#') as calendar_month,
 
         -- metadata
-        timestamp(extracted_at) as extracted_at,
-        timestamp(file_date) as file_date,
-        source_file
+        _extracted_at as extracted_at,
+        snapshot_date as file_date,
+        _fichier as source_file
 
     from source_data
 

--- a/models/staging/nesp_co/stg_nesp_co__opportunite.sql
+++ b/models/staging/nesp_co/stg_nesp_co__opportunite.sql
@@ -1,7 +1,7 @@
 {{
     config(
         materialized='table',
-        partition_by={'field': 'file_date', 'data_type': 'timestamp'},
+        partition_by={'field': 'file_date', 'data_type': 'date'},
         description='Table des opportunites Nespresso Commercial nettoyée et filtrée sur les colonnes utiles.'
     )
 }}
@@ -9,7 +9,7 @@
 with source_data as (
 
     select *
-    from {{ source('nesp_co', 'nespresso_commerce_opportunite') }}
+    from {{ source('nesp_co', 'nesp_co_opportunite') }}
 
 ),
 
@@ -56,9 +56,9 @@ base_opportunite as (
         timestamp(nullif(close_date, '#')) as close_date,
 
         -- metadata
-        timestamp(extracted_at) as extracted_at,
-        timestamp(file_date) as file_date,
-        source_file
+        _extracted_at as extracted_at,
+        snapshot_date as file_date,
+        _fichier as source_file
 
     from source_data
     where opportunity != 'Result' or opportunity is null


### PR DESCRIPTION
Bascule de la source des deux modèles `stg_nesp_co__*` : les tables externes
`nespresso_commerce_*`, adossées à des CSV dans GCS, laissent place aux tables
`nesp_co_*` chargées directement par le pipeline dlt `nesp_co` (dépôt
`ingestion`, commit `98768f1`).

**C'est le dernier maillon de la migration.** Le pipeline tourne déjà en prod et
les tables sont chargées ; rien ne change pour les utilisateurs tant que cette PR
n'est pas mergée.

## Parité vérifiée en production, avant bascule

Comparaison par empreinte commutative par journée (`sum(farm_fingerprint(...))`
sur toutes les colonnes concaténées, NULL distingué du vide) :

| | Journées communes | Comptes | Empreinte |
|---|---|---|---|
| `activite` | 235 | **235/235** | **235/235** hors `notes` |
| `opportunite` | 250 | **250/250** | **250/250** hors lignes `Result` |

**Aucune journée présente en externe et absente en dlt.**

## Ce que ça change réellement

**Un seul mart bouge :** `fct_commerce__activite` passe de 147 572 à **147 673**
lignes (+101). `fct_commerce__opportunite`, `dim_commerce__client` et
`fct_commerce__machine_intervention` sont **inchangés à la ligne près**.

Ces 101 lignes viennent des **31 journées** que GCS n'a jamais reçues : l'ancien
script ne publiait que le dernier fichier vu à 8h, et les dépôts du vendredi
restaient sur le SFTP sans jamais être archivés.

**`act_note` portera `'NA'` là où il y avait NULL.** `pandas.read_excel`
convertissait les « NA » réellement saisis en NaN via ses `na_values` par défaut,
**même avec `dtype=str`** — environ 1 119 valeurs par jour. Si c'est du bruit de
saisie plutôt qu'une réponse, c'est un `nullif(notes, 'NA')` à ajouter ici : le
raw doit rester fidèle à la source, la décision est métier.

## Métadonnées

Les noms de dlt remplacent ceux de Singer, mais les colonnes de **sortie** gardent
leurs noms — donc aucun impact au-delà de ces deux modèles (vérifié : `file_date`
n'apparaît nulle part ailleurs dans `models/`).

| Avant | Après |
|---|---|
| `extracted_at` | `_extracted_at` |
| `file_date` (timestamp) | `snapshot_date` (**date**) |
| `source_file` | `_fichier` |

Corrige au passage deux noms de colonnes **faux depuis l'origine** dans la
déclaration de source : `role_account_` et `_zeq_zenius_equivalent_`. Terraform et
les modèles utilisent ces noms sans souligné — la doc mentait, sans conséquence.

## Validation

`dbt build --select stg_nesp_co__activite+ stg_nesp_co__opportunite+ --defer` sur
`dev`, soit les **9 modèles avals** (3 intermediate, 4 marts) et leurs tests :

```
Completed successfully
Done. PASS=45 WARN=0 ERROR=0 SKIP=0 NO-OP=2 TOTAL=47
```

## Après le merge

1. Repointer le workflow `pipeline-nesp-co` vers `elt-nesp-co` (dépôt `infra`) ;
2. supprimer le job `ingest-nespresso-commerce-gcs` et les 2 tables externes ;
3. supprimer `elt-sftp-evs`, gardé dormant comme filet de retour arrière.

**Rollback** : revert de ce commit. Les tables externes et le job legacy restent
en place et continuent de tourner jusqu'à l'étape 2 ci-dessus.

## À signaler, sans rapport avec cette PR

Le `manifest.json` du bucket d'état GCS **n'est plus lisible** par dbt 1.11.11
(`InvalidFieldValue` sur le champ `macros`). La slim CI tombe donc
silencieusement en repli sur un build complet. À regarder séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XehQWkhe9tcXTrzf2xho9U