### PR TITLE
feat(stock_theorique): lire les tables dlt au lieu des tables externes GCS

### DIFF
--- a/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__sources.yml
+++ b/models/staging/oracle_lcdp_gcs/_oracle_lcdp_gcs__sources.yml
@@ -5,5 +5,19 @@ sources:
     database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     tables:
-      - name: ext_gcs_oracle_lcdp__stock_theorique
-        description: "External table pointing to nightly CSV extracts from Oracle LCDP"
+      - name: oracle_lcdp_stock_theorique
+        description: >
+          Stock théorique LCDP, chargé par le pipeline dlt `oracle_lcdp_stock`
+          (dépôt ingestion) directement depuis Oracle. Remplace la table externe
+          `ext_gcs_oracle_lcdp__stock_theorique`, adossée à des CSV dans GCS, le
+          2026-08-06. Les colonnes portent désormais leurs VRAIS types : les huit
+          NUMBER Oracle arrivent en NUMERIC(38,9) et non plus en STRING.
+        columns:
+          - name: snapshot_date
+            description: "Date métier du snapshot. Clé de merge du pipeline — à ne pas confondre avec date_system, qui porte l'heure du run."
+          - name: date_system
+            description: "SYSDATE Oracle au moment du calcul, HEURE COMPRISE. Vaut minuit sur une journée rejouée."
+          - name: date_inventaire
+            description: "VARCHAR2 côté Oracle, donc STRING ici : le staging le parse avec safe.parse_timestamp."
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne."

--- a/models/staging/oracle_lcdp_gcs/stg_oracle_lcdp_gcs__stock_theorique.sql
+++ b/models/staging/oracle_lcdp_gcs/stg_oracle_lcdp_gcs__stock_theorique.sql
@@ -22,6 +22,6 @@ select
     cast(dpa as numeric) as dpa,
     cast(pump as numeric) as pump,
     cast(purchase_price as numeric) as purchase_price,
-    cast(extracted_at as timestamp) as extracted_at,
-    row_count
-from {{ source('oracle_lcdp_gcs', 'ext_gcs_oracle_lcdp__stock_theorique') }}
+    _extracted_at as extracted_at,
+    snapshot_date
+from {{ source('oracle_lcdp_gcs', 'oracle_lcdp_stock_theorique') }}

--- a/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__sources.yml
+++ b/models/staging/oracle_neshu_gcs/_oracle_neshu_gcs__sources.yml
@@ -5,5 +5,19 @@ sources:
     database: "{{ var('raw_project') }}"
     schema: "prod_raw"
     tables:
-      - name: ext_gcs_oracle_neshu__stock_theorique
-        description: "External table pointing to nightly CSV extracts from Oracle Neshu"
+      - name: oracle_neshu_stock_theorique
+        description: >
+          Stock théorique NESHU, chargé par le pipeline dlt `oracle_neshu_stock`
+          (dépôt ingestion) directement depuis Oracle. Remplace la table externe
+          `ext_gcs_oracle_neshu__stock_theorique`, adossée à des CSV dans GCS, le
+          2026-08-06. Les colonnes portent désormais leurs VRAIS types : les huit
+          NUMBER Oracle arrivent en NUMERIC(38,9) et non plus en STRING.
+        columns:
+          - name: snapshot_date
+            description: "Date métier du snapshot. Clé de merge du pipeline — à ne pas confondre avec date_system, qui porte l'heure du run."
+          - name: date_system
+            description: "SYSDATE Oracle au moment du calcul, HEURE COMPRISE. Vaut minuit sur une journée rejouée."
+          - name: date_inventaire
+            description: "VARCHAR2 côté Oracle, donc STRING ici : le staging le parse avec safe.parse_timestamp."
+          - name: _extracted_at
+            description: "Horodatage du run dlt qui a chargé la ligne."

--- a/models/staging/oracle_neshu_gcs/stg_oracle_neshu_gcs__stock_theorique.sql
+++ b/models/staging/oracle_neshu_gcs/stg_oracle_neshu_gcs__stock_theorique.sql
@@ -22,6 +22,6 @@ select
     cast(dpa as numeric) as dpa,
     cast(pump as numeric) as pump,
     cast(purchase_price as numeric) as purchase_price,
-    cast(extracted_at as timestamp) as extracted_at,
-    row_count
-from {{ source('oracle_neshu_gcs', 'ext_gcs_oracle_neshu__stock_theorique') }}
+    _extracted_at as extracted_at,
+    snapshot_date
+from {{ source('oracle_neshu_gcs', 'oracle_neshu_stock_theorique') }}


### PR DESCRIPTION
Dernier maillon de la migration du stock théorique : les modèles de staging
passent des tables externes `ext_gcs_oracle_*__stock_theorique` — adossées à des
CSV dans GCS — aux tables natives chargées par les pipelines dlt
`oracle_neshu_stock` et `oracle_lcdp_stock` (dépôt `ingestion`, `6a4c711`).

**Les pipelines tournent déjà en prod et les tables sont chargées.** Rien ne
change pour les utilisateurs tant que cette PR n'est pas mergée.

## Parité vérifiée en production, avant bascule

| Couche | Résultat |
|---|---|
| **raw** | **278/278** journées NESHU et **62/62** LCDP — comptes ET empreintes identiques, **aucune journée manquante** |
| **staging** | **865 705** et **120 257** lignes identiques à la ligne près, sur les 16 colonnes communes |
| **marts** | `stock_neshu` (574 485) et `stock_lcdp` (120 257) **IDENTIQUES** |
| **marts mensuels** | identiques hors mois courant — 3 957 / 15 819 / 2 184 |

L'égalité au niveau staging est le point qui compte : **les 6 décimales de `dpa`
et `purchase_price` sont préservées**, alors qu'elles transitaient jusqu'ici par
du texte. Un écart d'un millionième aurait cassé l'empreinte.

## Ce qui diffère, et pourquoi ce n'est pas la migration

`couverture_stock_neshu`, `point_commande_neshu` et `flux_neshu` se calculent sur
le **dernier snapshot** (`max(date(date_system))`). Les tables dlt portent déjà le
2026-08-06 ; les tables externes ne l'auront qu'à 23h, quand les jobs legacy
tourneront. Ces trois marts voient donc **un jour de plus** — un écart de
fraîcheur, pas de contenu.

Leurs comptes de lignes sont identiques (272, 300, 21), et les marts mensuels le
confirment : identiques partout **sauf sur le mois qui gagne ce jour**.

## Ce qui ne change pas dans le SQL

Les casts survivent tels quels. La table externe était **tout-STRING** (17
colonnes) et le staging recastait tout ; les colonnes portent désormais leurs
vrais types Oracle, donc `cast(x as numeric)` sur un NUMERIC est un no-op.

**`date_inventaire` reste STRING** — c'est un `VARCHAR2` côté Oracle, vérifié —
donc `safe.parse_timestamp('%d/%m/%Y %H:%M', …)` continue de fonctionner.

## Ce qui change

`row_count` disparaît, remplacé par `snapshot_date`. C'était la sentinelle de
complétude que le script Python répétait sur chaque ligne ; elle n'était lue
nulle part en aval. `snapshot_date` est la date **métier** du snapshot, à ne pas
confondre avec `date_system`, qui porte l'**heure** du run (`23:00:02`) et vaut
minuit sur une journée rejouée.

## Validation

`dbt build --select stg_oracle_neshu_gcs__stock_theorique+
stg_oracle_lcdp_gcs__stock_theorique+ --defer` — les **10 modèles** (2 staging,
8 marts `fct_supply_chain__*`) et leurs tests :

```
Completed successfully
Done. PASS=90 WARN=0 ERROR=0 SKIP=0 NO-OP=4 TOTAL=94
```

## Après le merge

1. Couper les schedulers `pipeline_oracle_stock_theorique` et
   `pipeline_oracle_lcdp_stock_theorique`, repointer les workflows vers les jobs
   `elt-oracle-*-stock` (dépôt `infra`) ;
2. supprimer les 2 jobs legacy et les 2 tables externes.

**Rollback** : revert de ce commit. Les tables externes et les jobs legacy
restent en place et continuent de tourner jusqu'à l'étape 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XehQWkhe9tcXTrzf2xho9U