### PR TITLE
feat(nesp_tech): versionner la grille tarifaire Nespresso dans le temps

### DIFF
--- a/data/reference_data/nesp_tech/_nesp_tech__seeds.yml
+++ b/data/reference_data/nesp_tech/_nesp_tech__seeds.yml
@@ -84,7 +84,22 @@ seeds:
           - not_null
 
   - name: ref_nesp_tech__key_facturation
-    description: "Clé de facturation des interventions techniques"
+    description: >
+      Clé de facturation des interventions techniques Nespresso, avec le tarif et
+      le code produit associés — **versionnée dans le temps** par
+      `valid_from`/`valid_to` (même patron que `ref_yuman__tarification_clean`).
+      Grain : 1 ligne par (`key_ref_inter`, `valid_from`), et non par
+      `key_ref_inter` seule.
+      Pourquoi : la grille Nespresso a déjà changé au moins une fois (générations
+      2021 et 2024, cf. onglet Paramètres du classeur de facturation du manager)
+      et le tarif Enlèvement s'est ajouté plus tard. Un tarif unique par clé
+      interdisait de recalculer une facture d'un mois passé avec le tarif qui
+      était alors en vigueur.
+      État actuel : une seule génération chargée, plancher `2000-01-01` →
+      `9999-12-31`, donc aucun changement de comportement par rapport à la
+      version non versionnée. Les générations réelles (bascule 2021 → 2024, date
+      de création du tarif Enlèvement) restent à récupérer auprès du manager : ne
+      pas les inventer, une date fausse déplacerait des montants facturés.
     config:
       column_types:
         type_code: STRING
@@ -95,6 +110,12 @@ seeds:
         key_factu: STRING
         prod_factu: INT64
         tarif_factu: FLOAT64
+        valid_from: DATE
+        valid_to: DATE
+    tests:
+      - dbt_utils.unique_combination_of_columns:
+          arguments:
+            combination_of_columns: ['key_ref_inter', 'valid_from']
     columns:
       - name: type_code
         description: "Code intervention"
@@ -111,12 +132,15 @@ seeds:
       - name: type_montagne
         description: "Suffixe potentiel selon montagne"
       - name: key_ref_inter
-        description: "Clé de facturation lisible"
+        description: >
+          Clé de facturation lisible, suffixe ' - Montagne' inclus : c'est elle
+          que la clé calculée par `int_nesp_tech__facturation_interventions`
+          rejoint. Plus unique à elle seule depuis le versionnement — unique par
+          (`key_ref_inter`, `valid_from`), cf. test au niveau du seed.
         tests:
           - not_null
-          - unique
       - name: key_factu
-        description: "Clé de facturation lisible"
+        description: "Clé de facturation lisible, sans le suffixe Montagne"
         tests:
           - not_null
       - name: prod_factu
@@ -124,7 +148,21 @@ seeds:
         tests:
           - not_null
       - name: tarif_factu
-        description: "Tarif de l'intervention"
+        description: "Tarif de l'intervention, en vigueur sur la fenêtre valid_from → valid_to"
+        tests:
+          - not_null
+      - name: valid_from
+        description: >
+          Premier jour d'application du tarif (inclus). `2000-01-01` = plancher
+          conventionnel de la génération initiale, aligné sur
+          `ref_yuman__tarification_clean` : signifie « depuis toujours, faute de
+          date de bascule connue », pas une date réelle de contrat.
+        tests:
+          - not_null
+      - name: valid_to
+        description: >
+          Dernier jour d'application du tarif (inclus). `9999-12-31` = tarif
+          courant, sans fin connue.
         tests:
           - not_null
 

--- a/data/reference_data/nesp_tech/ref_nesp_tech__key_facturation.csv
+++ b/data/reference_data/nesp_tech/ref_nesp_tech__key_facturation.csv
@@ -1,137 +1,139 @@
-type_code,type_inter,machine_clean,type_montagne,key_ref_inter,key_factu,prod_factu,tarif_factu,alias_obj_type_inter,alias_obj_type_machine,alias_obj_grp_machine
-1,Curative,Aguila 2,,1 - Curative - Aguila 2,1 - Curative - Aguila 2,3,546,CURATIVE NIVEAU 1,AGUILA,AGUILA
-1,Curative,Aguila 2,Montagne,1 - Curative - Aguila 2 - Montagne,1 - Curative - Aguila 2 - Montagne,3,726,CURATIVE NIVEAU 1,AGUILA,AGUILA
-5,Curative,Aguila 2,,5 - Curative - Aguila 2,5 - Curative - Aguila 2,2,185,CURATIVE NIVEAU 2,AGUILA,AGUILA
-5,Curative,Aguila 2,Montagne,5 - Curative - Aguila 2 - Montagne,5 - Curative - Aguila 2 - Montagne,2,248,CURATIVE NIVEAU 2,AGUILA,AGUILA
-7,Curative,Aguila 2,Montagne,7 - Curative - Aguila 2 - Montagne,7 - Curative - Aguila 2 - Montagne,2,248,CURATIVE NIVEAU 3,AGUILA,AGUILA
-7,Curative,Aguila 2,,7 - Curative - Aguila 2,7 - Curative - Aguila 2,2,185,CURATIVE NIVEAU 3,AGUILA,AGUILA
-7,Desinstallation,Aguila 2,,7 - Desinstallation - Aguila 2,7 - Desinstallation - Aguila 2,1,185,INSTALLATION,AGUILA,AGUILA
-7,Desinstallation,Aguila 2,Montagne,7 - Desinstallation - Aguila 2 - Montagne,7 - Desinstallation - Aguila 2 - Montagne,1,248,INSTALLATION,AGUILA,AGUILA
-7,Installation,Aguila 2,,7 - Installation - Aguila 2,7 - Installation - Aguila 2,3,382,INSTALLATION,AGUILA,AGUILA
-7,Installation,Aguila 2,Montagne,7 - Installation - Aguila 2 - Montagne,7 - Installation - Aguila 2 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA
-8,Installation,Aguila 2,,8 - Installation - Aguila 2,8 - Installation - Aguila 2,3,382,INSTALLATION,AGUILA,AGUILA
-8,Installation,Aguila 2,Montagne,8 - Installation - Aguila 2 - Montagne,8 - Installation - Aguila 2 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA
-2,Mini preventive,Aguila 2,,2 - Mini preventive - Aguila 2,2 - Mini preventive - Aguila 2,2,246,PREVENTIVE,AGUILA,AGUILA
-2,Mini preventive,Aguila 2,Montagne,2 - Mini preventive - Aguila 2 - Montagne,2 - Mini preventive - Aguila 2 - Montagne,2,328,PREVENTIVE,AGUILA,AGUILA
-7,Mini preventive,Aguila 2,,7 - Mini preventive - Aguila 2,7 - Mini preventive - Aguila 2,2,246,PREVENTIVE,AGUILA,AGUILA
-2,Preventive,Aguila 2,,2 - Preventive - Aguila 2,2 - Preventive - Aguila 2,4,491,PREVENTIVE,AGUILA,AGUILA
-2,Preventive,Aguila 2,Montagne,2 - Preventive - Aguila 2 - Montagne,2 - Preventive - Aguila 2 - Montagne,4,655,PREVENTIVE,AGUILA,AGUILA
-7,Preventive,Aguila 2,,7 - Preventive - Aguila 2,7 - Preventive - Aguila 2,4,491,PREVENTIVE,AGUILA,AGUILA
-7,Preventive,Aguila 2,Montagne,7 - Preventive - Aguila 2 - Montagne,7 - Preventive - Aguila 2 - Montagne,4,655,PREVENTIVE,AGUILA,AGUILA
-1,Curative,Aguila 4,,1 - Curative - Aguila 4,1 - Curative - Aguila 4,3,546,CURATIVE NIVEAU 1,AGUILA,AGUILA
-1,Curative,Aguila 4,Montagne,1 - Curative - Aguila 4 - Montagne,1 - Curative - Aguila 4 - Montagne,3,726,CURATIVE NIVEAU 1,AGUILA,AGUILA
-5,Curative,Aguila 4,,5 - Curative - Aguila 4,5 - Curative - Aguila 4,2,185,CURATIVE NIVEAU 2,AGUILA,AGUILA
-5,Curative,Aguila 4,Montagne,5 - Curative - Aguila 4 - Montagne,5 - Curative - Aguila 4 - Montagne,2,248,CURATIVE NIVEAU 2,AGUILA,AGUILA
-7,Curative,Aguila 4,Montagne,7 - Curative - Aguila 4 - Montagne,7 - Curative - Aguila 4 - Montagne,2,248,CURATIVE NIVEAU 3,AGUILA,AGUILA
-7,Curative,Aguila 4,,7 - Curative - Aguila 4,7 - Curative - Aguila 4,2,185,CURATIVE NIVEAU 3,AGUILA,AGUILA
-7,Desinstallation,Aguila 4,Montagne,7 - Desinstallation - Aguila 4 - Montagne,7 - Desinstallation - Aguila 4 - Montagne,1,248,INSTALLATION,AGUILA,AGUILA
-7,Desinstallation,Aguila 4,,7 - Desinstallation - Aguila 4,7 - Desinstallation - Aguila 4,1,185,INSTALLATION,AGUILA,AGUILA
-7,Installation,Aguila 4,,7 - Installation - Aguila 4,7 - Installation - Aguila 4,3,382,INSTALLATION,AGUILA,AGUILA
-7,Installation,Aguila 4,Montagne,7 - Installation - Aguila 4 - Montagne,7 - Installation - Aguila 4 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA
-8,Installation,Aguila 4,,8 - Installation - Aguila 4,8 - Installation - Aguila 4,3,382,INSTALLATION,AGUILA,AGUILA
-8,Installation,Aguila 4,Montagne,8 - Installation - Aguila 4 - Montagne,8 - Installation - Aguila 4 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA
-2,Mini preventive,Aguila 4,,2 - Mini preventive - Aguila 4,2 - Mini preventive - Aguila 4,3,410,PREVENTIVE,AGUILA,AGUILA
-2,Mini preventive,Aguila 4,Montagne,2 - Mini preventive - Aguila 4 - Montagne,2 - Mini preventive - Aguila 4 - Montagne,3,546,PREVENTIVE,AGUILA,AGUILA
-2,Preventive,Aguila 4,,2 - Preventive - Aguila 4,2 - Preventive - Aguila 4,6,655,PREVENTIVE,AGUILA,AGUILA
-2,Preventive,Aguila 4,Montagne,2 - Preventive - Aguila 4 - Montagne,2 - Preventive - Aguila 4 - Montagne,6,871,PREVENTIVE,AGUILA,AGUILA
-7,Preventive,Aguila 4,,7 - Preventive - Aguila 4,7 - Preventive - Aguila 4,6,655,PREVENTIVE,AGUILA,AGUILA
-7,Preventive,Aguila 4,Montagne,7 - Preventive - Aguila 4 - Montagne,7 - Preventive - Aguila 4 - Montagne,6,871,PREVENTIVE,AGUILA,AGUILA
-5,Curative,Dispenser Mini Tower,,5 - Curative - Dispenser Mini Tower,5 - Curative - Dispenser Mini Tower,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-5,Curative,Dispenser Mini Tower,Montagne,5 - Curative - Dispenser Mini Tower - Montagne,5 - Curative - Dispenser mini Tower,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-7,Desinstallation,Dispenser Mini Tower,,7 - Desinstallation - Dispenser Mini Tower,7 - Desinstallation - Dispenser Mini Tower,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Desinstallation,Dispenser Mini Tower,Montagne,7 - Desinstallation - Dispenser Mini Tower - Montagne,7 - Desinstallation - Dispenser Mini Tower,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Installation,Dispenser Mini Tower,,7 - Installation - Dispenser Mini Tower,7 - Installation - Dispenser Mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Installation,Dispenser Mini Tower,Montagne,7 - Installation - Dispenser Mini Tower - Montagne,7 - Installation - Dispenser Mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,Dispenser Mini Tower,,8 - Installation - Dispenser Mini Tower,8 - Installation - Dispenser Mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,Dispenser Mini Tower,Montagne,8 - Installation - Dispenser Mini Tower - Montagne,8 - Installation - Dispenser mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Preventive,Dispenser Mini Tower,,7 - Preventive - Dispenser Mini Tower,7 - Preventive - Dispenser Mini Tower,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-5,Curative,Dispenser Side By Side,,5 - Curative - Dispenser Side By Side,5 - Curative - Dispenser Side By Side,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-7,Desinstallation,Dispenser Side By Side,,7 - Desinstallation - Dispenser Side By Side,7 - Desinstallation - Dispenser Side By Side,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,Dispenser Side By Side,,8 - Installation - Dispenser Side By Side,8 - Installation - Dispenser Side By Side,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,Dispenser Side By Side,Montagne,8 - Installation - Dispenser Side By Side - Montagne,8 - Installation - Dispenser Side By Side,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Preventive,Dispenser Side By Side,,7 - Preventive - Dispenser Side By Side,7 - Preventive - Dispenser Side By Side,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-5,Curative,Gemini,,5 - Curative - Gemini,5 - Curative - Gemini,1,121,CURATIVE,GEMINI,TRANSPORTABLE
-5,Curative,Gemini,Montagne,5 - Curative - Gemini - Montagne,5 - Curative - Gemini,1,121,CURATIVE,GEMINI,TRANSPORTABLE
-7,Desinstallation,Gemini,,7 - Desinstallation - Gemini,7 - Desinstallation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE
-7,Desinstallation,Gemini,Montagne,7 - Desinstallation - Gemini - Montagne,7 - Desinstallation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE
-7,Enlevement,Gemini,,7 - Enlevement - Gemini,7 - Enlevement - Gemini,1,40,ENLEVEMENT,GEMINI,TRANSPORTABLE
-7,Installation,Gemini,,7 - Installation - Gemini,7 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE
-7,Installation,Gemini,Montagne,7 - Installation - Gemini - Montagne,7 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE
-8,Installation,Gemini,,8 - Installation - Gemini,8 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE
-8,Installation,Gemini,Montagne,8 - Installation - Gemini - Montagne,8 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE
-2,Preventive,Gemini,,2 - Preventive - Gemini,2 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE
-2,Preventive,Gemini,Montagne,2 - Preventive - Gemini - Montagne,2 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE
-7,Preventive,Gemini,,7 - Preventive - Gemini,7 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE
-7,Preventive,Gemini,Montagne,7 - Preventive - Gemini - Montagne,7 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE
-5,Curative,MOMENTO 100,,5 - Curative - MOMENTO 100,5 - Curative - MOMENTO 100,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-5,Curative,MOMENTO 100,Montagne,5 - Curative - MOMENTO 100 - Montagne,5 - Curative - MOMENTO 100,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-7,Desinstallation,MOMENTO 100,,7 - Desinstallation - MOMENTO 100,7 - Desinstallation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Desinstallation,MOMENTO 100,Montagne,7 - Desinstallation - MOMENTO 100 - Montagne,7 - Desinstallation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Enlevement,MOMENTO 100,,7 - Enlevement - MOMENTO 100,7 - Enlevement - MOMENTO 100,1,40,ENLEVEMENT,MOMENTO,TRANSPORTABLE
-7,Installation,MOMENTO 100,,7 - Installation - MOMENTO 100,7 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Installation,MOMENTO 100,Montagne,7 - Installation - MOMENTO 100 - Montagne,7 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,MOMENTO 100,,8 - Installation - MOMENTO 100,8 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,MOMENTO 100,Montagne,8 - Installation - MOMENTO 100 - Montagne,8 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-3,Mise a jour,MOMENTO 100,,3 - Mise a jour - MOMENTO 100,3 - Mise à jour - MOMENTO 100,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE
-3,Mise a jour,MOMENTO 100,Montagne,3 - Mise a jour - MOMENTO 100 - Montagne,3 - Mise à jour - MOMENTO 100,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE
-2,Preventive,MOMENTO 100,,2 - Preventive - MOMENTO 100,2 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-2,Preventive,MOMENTO 100,Montagne,2 - Preventive - MOMENTO 100 - Montagne,2 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-7,Preventive,MOMENTO 100,,7 - Preventive - MOMENTO 100,7 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-7,Preventive,MOMENTO 100,Montagne,7 - Preventive - MOMENTO 100 - Montagne,7 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-5,Curative,MOMENTO 120,,5 - Curative - MOMENTO 120,5 - Curative - MOMENTO 120,2,121,CURATIVE,MOMENTO MILK,TRANSPORTABLE
-5,Curative,MOMENTO 120,Montagne,5 - Curative - MOMENTO 120 - Montagne,5 - Curative - MOMENTO 120,2,121,CURATIVE,MOMENTO MILK,TRANSPORTABLE
-7,Desinstallation,MOMENTO 120,,7 - Desinstallation - MOMENTO 120,7 - Desinstallation - MOMENTO 120,1,90,INSTALLATION,MOMENTO MILK,TRANSPORTABLE
-7,Desinstallation,MOMENTO 120,Montagne,7 - Desinstallation - MOMENTO 120 - Montagne,7 - Desinstallation - MOMENTO 120,1,90,INSTALLATION,MOMENTO MILK,TRANSPORTABLE
-7,Enlevement,MOMENTO 120,Montagne,7 - Enlevement - MOMENTO 120 - Montagne,7 - Enlevement - MOMENTO 120,1,50,ENLEVEMENT,MOMENTO MILK,TRANSPORTABLE
-7,Enlevement,MOMENTO 120,,7 - Enlevement - MOMENTO 120,7 - Enlevement - MOMENTO 120,1,50,ENLEVEMENT,MOMENTO MILK,TRANSPORTABLE
-8,Installation,MOMENTO 120,,8 - Installation - MOMENTO 120,8 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE
-8,Installation,MOMENTO 120,Montagne,8 - Installation - MOMENTO 120 - Montagne,8 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE
-7,Installation,MOMENTO 120,Montagne,7 - Installation - MOMENTO 120 - Montagne,7 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE
-7,Installation,MOMENTO 120,,7 - Installation - MOMENTO 120,7 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE
-3,Mise a jour,MOMENTO 120,,3 - Mise a jour - MOMENTO 120,3 - Mise à jour - MOMENTO 120,1,273,MISE A JOUR,MOMENTO MILK,TRANSPORTABLE
-3,Mise a jour,MOMENTO 120,Montagne,3 - Mise a jour - MOMENTO 120 - Montagne,3 - Mise à jour - MOMENTO 120,1,273,MISE A JOUR,MOMENTO MILK,TRANSPORTABLE
-2,Preventive,MOMENTO 120,,2 - Preventive - MOMENTO 120,2 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE
-2,Preventive,MOMENTO 120,Montagne,2 - Preventive - MOMENTO 120 - Montagne,2 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE
-7,Preventive,MOMENTO 120,,7 - Preventive - MOMENTO 120,7 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE
-7,Preventive,MOMENTO 120,Montagne,7 - Preventive - MOMENTO 120 - Montagne,7 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE
-5,Curative,MOMENTO 200,,5 - Curative - MOMENTO 200,5 - Curative - MOMENTO 200,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-5,Curative,MOMENTO 200,Montagne,5 - Curative - MOMENTO 200 - Montagne,5 - Curative - MOMENTO 200,1,121,CURATIVE,MOMENTO,TRANSPORTABLE
-7,Desinstallation,MOMENTO 200,,7 - Desinstallation - MOMENTO 200,7 - Desinstallation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Desinstallation,MOMENTO 200,Montagne,7 - Desinstallation - MOMENTO 200 - Montagne,7 - Desinstallation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Enlevement,MOMENTO 200,Montagne,7 - Enlevement - MOMENTO 200 - Montagne,7 - Enlevement - MOMENTO 200,1,50,ENLEVEMENT,MOMENTO,TRANSPORTABLE
-7,Enlevement,MOMENTO 200,,7 - Enlevement - MOMENTO 200,7 - Enlevement - MOMENTO 200,1,50,ENLEVEMENT,MOMENTO,TRANSPORTABLE
-7,Installation,MOMENTO 200,,7 - Installation - MOMENTO 200,7 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-7,Installation,MOMENTO 200,Montagne,7 - Installation - MOMENTO 200 - Montagne,7 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,MOMENTO 200,,8 - Installation - MOMENTO 200,8 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-8,Installation,MOMENTO 200,Montagne,8 - Installation - MOMENTO 200 - Montagne,8 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE
-3,Mise a jour,MOMENTO 200,,3 - Mise a jour - MOMENTO 200,3 - Mise à jour - MOMENTO 200,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE
-3,Mise a jour,MOMENTO 200,Montagne,3 - Mise a jour - MOMENTO 200 - Montagne,3 - Mise à jour - MOMENTO 200,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE
-2,Preventive,MOMENTO 200,,2 - Preventive - MOMENTO 200,2 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-2,Preventive,MOMENTO 200,Montagne,2 - Preventive - MOMENTO 200 - Montagne,2 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-7,Preventive,MOMENTO 200,,7 - Preventive - MOMENTO 200,7 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-7,Preventive,MOMENTO 200,Montagne,7 - Preventive - MOMENTO 200 - Montagne,7 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE
-5,Curative,MOMENTO BLACK,,5 - Curative - MOMENTO BLACK,5 - Curative - MOMENTO BLACK,1,121,CURATIVE,MOMENTO BLACK,TRANSPORTABLE
-5,Curative,MOMENTO BLACK,Montagne,5 - Curative - MOMENTO BLACK - Montagne,5 - Curative - MOMENTO BLACK,1,121,CURATIVE,MOMENTO BLACK,TRANSPORTABLE
-7,Desinstallation,MOMENTO BLACK,,7 - Desinstallation - MOMENTO BLACK,7 - Desinstallation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE
-7,Desinstallation,MOMENTO BLACK,Montagne,7 - Desinstallation - MOMENTO BLACK - Montagne,7 - Desinstallation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE
-7,Enlevement,MOMENTO BLACK,,7 - Enlevement - MOMENTO BLACK,7 - Enlevement - MOMENTO BLACK,1,40,ENLEVEMENT,MOMENTO BLACK,TRANSPORTABLE
-7,Installation,MOMENTO BLACK,,7 - Installation - MOMENTO BLACK,7 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE
-7,Installation,MOMENTO BLACK,Montagne,7 - Installation - MOMENTO BLACK - Montagne,7 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE
-8,Installation,MOMENTO BLACK,,8 - Installation - MOMENTO BLACK,8 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE
-8,Installation,MOMENTO BLACK,Montagne,8 - Installation - MOMENTO BLACK - Montagne,8 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE
-3,Mise a jour,MOMENTO BLACK,,3 - Mise a jour - MOMENTO BLACK,3 - Mise à jour - MOMENTO BLACK,1,273,MISE A JOUR,MOMENTO BLACK,TRANSPORTABLE
-3,Mise a jour,MOMENTO BLACK,Montagne,3 - Mise a jour - MOMENTO BLACK - Montagne,3 - Mise à jour - MOMENTO BLACK,1,273,MISE A JOUR,MOMENTO BLACK,TRANSPORTABLE
-2,Preventive,MOMENTO BLACK,,2 - Preventive - MOMENTO BLACK,2 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE
-2,Preventive,MOMENTO BLACK,Montagne,2 - Preventive - MOMENTO BLACK - Montagne,2 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE
-7,Preventive,MOMENTO BLACK,,7 - Preventive - MOMENTO BLACK,7 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE
-7,Preventive,MOMENTO BLACK,Montagne,7 - Preventive - MOMENTO BLACK - Montagne,7 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE
-5,Curative,Zenius,,5 - Curative - Zenius,5 - Curative - Zenius,1,121,CURATIVE,ZENIUS,TRANSPORTABLE
-5,Curative,Zenius,Montagne,5 - Curative - Zenius - Montagne,5 - Curative - Zenius,1,121,CURATIVE,ZENIUS,TRANSPORTABLE
-7,Desinstallation,Zenius,,7 - Desinstallation - Zenius,7 - Desinstallation - Zenius,1,90,INSTALLATION,ZENIUS,TRANSPORTABLE
-7,Desinstallation,Zenius,Montagne,7 - Desinstallation - Zenius - Montagne,7 - Desinstallation - Zenius,1,90,INSTALLATION,ZENIUS,TRANSPORTABLE
-7,Enlevement,Zenius,,7 - Enlevement - Zenius,7 - Enlevement - Zenius,1,40,ENLEVEMENT,ZENIUS,TRANSPORTABLE
-7,Installation,Zenius,,7 - Installation - Zenius,7 - Installation - Zenius,1,90,INSTALLATION,ZENIUS,TRANSPORTABLE
-2,Preventive,Zenius,,2 - Preventive - Zenius,2 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE
-2,Preventive,Zenius,Montagne,2 - Preventive - Zenius - Montagne,2 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE
-7,Preventive,Zenius,,7 - Preventive - Zenius,7 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE
-7,Preventive,Zenius,Montagne,7 - Preventive - Zenius - Montagne,7 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE
+type_code,type_inter,machine_clean,type_montagne,key_ref_inter,key_factu,prod_factu,tarif_factu,alias_obj_type_inter,alias_obj_type_machine,alias_obj_grp_machine,valid_from,valid_to
+1,Curative,Aguila 2,,1 - Curative - Aguila 2,1 - Curative - Aguila 2,3,546,CURATIVE NIVEAU 1,AGUILA,AGUILA,2000-01-01,9999-12-31
+1,Curative,Aguila 2,Montagne,1 - Curative - Aguila 2 - Montagne,1 - Curative - Aguila 2 - Montagne,3,726,CURATIVE NIVEAU 1,AGUILA,AGUILA,2000-01-01,9999-12-31
+5,Curative,Aguila 2,,5 - Curative - Aguila 2,5 - Curative - Aguila 2,2,185,CURATIVE NIVEAU 2,AGUILA,AGUILA,2000-01-01,9999-12-31
+5,Curative,Aguila 2,Montagne,5 - Curative - Aguila 2 - Montagne,5 - Curative - Aguila 2 - Montagne,2,248,CURATIVE NIVEAU 2,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Curative,Aguila 2,Montagne,7 - Curative - Aguila 2 - Montagne,7 - Curative - Aguila 2 - Montagne,2,248,CURATIVE NIVEAU 3,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Curative,Aguila 2,,7 - Curative - Aguila 2,7 - Curative - Aguila 2,2,185,CURATIVE NIVEAU 3,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Desinstallation,Aguila 2,,7 - Desinstallation - Aguila 2,7 - Desinstallation - Aguila 2,1,185,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Desinstallation,Aguila 2,Montagne,7 - Desinstallation - Aguila 2 - Montagne,7 - Desinstallation - Aguila 2 - Montagne,1,248,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Installation,Aguila 2,,7 - Installation - Aguila 2,7 - Installation - Aguila 2,3,382,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Installation,Aguila 2,Montagne,7 - Installation - Aguila 2 - Montagne,7 - Installation - Aguila 2 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+8,Installation,Aguila 2,,8 - Installation - Aguila 2,8 - Installation - Aguila 2,3,382,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+8,Installation,Aguila 2,Montagne,8 - Installation - Aguila 2 - Montagne,8 - Installation - Aguila 2 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Mini preventive,Aguila 2,,2 - Mini preventive - Aguila 2,2 - Mini preventive - Aguila 2,2,246,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Mini preventive,Aguila 2,Montagne,2 - Mini preventive - Aguila 2 - Montagne,2 - Mini preventive - Aguila 2 - Montagne,2,328,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Mini preventive,Aguila 2,,7 - Mini preventive - Aguila 2,7 - Mini preventive - Aguila 2,2,246,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Preventive,Aguila 2,,2 - Preventive - Aguila 2,2 - Preventive - Aguila 2,4,491,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Preventive,Aguila 2,Montagne,2 - Preventive - Aguila 2 - Montagne,2 - Preventive - Aguila 2 - Montagne,4,655,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Preventive,Aguila 2,,7 - Preventive - Aguila 2,7 - Preventive - Aguila 2,4,491,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Preventive,Aguila 2,Montagne,7 - Preventive - Aguila 2 - Montagne,7 - Preventive - Aguila 2 - Montagne,4,655,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+1,Curative,Aguila 4,,1 - Curative - Aguila 4,1 - Curative - Aguila 4,3,546,CURATIVE NIVEAU 1,AGUILA,AGUILA,2000-01-01,9999-12-31
+1,Curative,Aguila 4,Montagne,1 - Curative - Aguila 4 - Montagne,1 - Curative - Aguila 4 - Montagne,3,726,CURATIVE NIVEAU 1,AGUILA,AGUILA,2000-01-01,9999-12-31
+5,Curative,Aguila 4,,5 - Curative - Aguila 4,5 - Curative - Aguila 4,2,185,CURATIVE NIVEAU 2,AGUILA,AGUILA,2000-01-01,9999-12-31
+5,Curative,Aguila 4,Montagne,5 - Curative - Aguila 4 - Montagne,5 - Curative - Aguila 4 - Montagne,2,248,CURATIVE NIVEAU 2,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Curative,Aguila 4,Montagne,7 - Curative - Aguila 4 - Montagne,7 - Curative - Aguila 4 - Montagne,2,248,CURATIVE NIVEAU 3,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Curative,Aguila 4,,7 - Curative - Aguila 4,7 - Curative - Aguila 4,2,185,CURATIVE NIVEAU 3,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Desinstallation,Aguila 4,Montagne,7 - Desinstallation - Aguila 4 - Montagne,7 - Desinstallation - Aguila 4 - Montagne,1,248,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Desinstallation,Aguila 4,,7 - Desinstallation - Aguila 4,7 - Desinstallation - Aguila 4,1,185,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Installation,Aguila 4,,7 - Installation - Aguila 4,7 - Installation - Aguila 4,3,382,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Installation,Aguila 4,Montagne,7 - Installation - Aguila 4 - Montagne,7 - Installation - Aguila 4 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+8,Installation,Aguila 4,,8 - Installation - Aguila 4,8 - Installation - Aguila 4,3,382,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+8,Installation,Aguila 4,Montagne,8 - Installation - Aguila 4 - Montagne,8 - Installation - Aguila 4 - Montagne,3,508,INSTALLATION,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Mini preventive,Aguila 4,,2 - Mini preventive - Aguila 4,2 - Mini preventive - Aguila 4,3,410,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Mini preventive,Aguila 4,Montagne,2 - Mini preventive - Aguila 4 - Montagne,2 - Mini preventive - Aguila 4 - Montagne,3,546,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Preventive,Aguila 4,,2 - Preventive - Aguila 4,2 - Preventive - Aguila 4,6,655,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+2,Preventive,Aguila 4,Montagne,2 - Preventive - Aguila 4 - Montagne,2 - Preventive - Aguila 4 - Montagne,6,871,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Preventive,Aguila 4,,7 - Preventive - Aguila 4,7 - Preventive - Aguila 4,6,655,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+7,Preventive,Aguila 4,Montagne,7 - Preventive - Aguila 4 - Montagne,7 - Preventive - Aguila 4 - Montagne,6,871,PREVENTIVE,AGUILA,AGUILA,2000-01-01,9999-12-31
+5,Curative,Dispenser Mini Tower,,5 - Curative - Dispenser Mini Tower,5 - Curative - Dispenser Mini Tower,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,Dispenser Mini Tower,Montagne,5 - Curative - Dispenser Mini Tower - Montagne,5 - Curative - Dispenser mini Tower,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Dispenser Mini Tower,,7 - Desinstallation - Dispenser Mini Tower,7 - Desinstallation - Dispenser Mini Tower,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Dispenser Mini Tower,Montagne,7 - Desinstallation - Dispenser Mini Tower - Montagne,7 - Desinstallation - Dispenser Mini Tower,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,Dispenser Mini Tower,,7 - Installation - Dispenser Mini Tower,7 - Installation - Dispenser Mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,Dispenser Mini Tower,Montagne,7 - Installation - Dispenser Mini Tower - Montagne,7 - Installation - Dispenser Mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,Dispenser Mini Tower,,8 - Installation - Dispenser Mini Tower,8 - Installation - Dispenser Mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,Dispenser Mini Tower,Montagne,8 - Installation - Dispenser Mini Tower - Montagne,8 - Installation - Dispenser mini Tower,2,301,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,Dispenser Mini Tower,,7 - Preventive - Dispenser Mini Tower,7 - Preventive - Dispenser Mini Tower,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,Dispenser Side By Side,,5 - Curative - Dispenser Side By Side,5 - Curative - Dispenser Side By Side,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Dispenser Side By Side,,7 - Desinstallation - Dispenser Side By Side,7 - Desinstallation - Dispenser Side By Side,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,Dispenser Side By Side,,8 - Installation - Dispenser Side By Side,8 - Installation - Dispenser Side By Side,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,Dispenser Side By Side,Montagne,8 - Installation - Dispenser Side By Side - Montagne,8 - Installation - Dispenser Side By Side,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,Dispenser Side By Side,,7 - Preventive - Dispenser Side By Side,7 - Preventive - Dispenser Side By Side,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,Gemini,,5 - Curative - Gemini,5 - Curative - Gemini,1,121,CURATIVE,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,Gemini,Montagne,5 - Curative - Gemini - Montagne,5 - Curative - Gemini,1,121,CURATIVE,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Gemini,,7 - Desinstallation - Gemini,7 - Desinstallation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Gemini,Montagne,7 - Desinstallation - Gemini - Montagne,7 - Desinstallation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,Gemini,,7 - Enlevement - Gemini,7 - Enlevement - Gemini,1,40,ENLEVEMENT,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,Gemini,,7 - Installation - Gemini,7 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,Gemini,Montagne,7 - Installation - Gemini - Montagne,7 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,Gemini,,8 - Installation - Gemini,8 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,Gemini,Montagne,8 - Installation - Gemini - Montagne,8 - Installation - Gemini,1,90,INSTALLATION,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,Gemini,,2 - Preventive - Gemini,2 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,Gemini,Montagne,2 - Preventive - Gemini - Montagne,2 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,Gemini,,7 - Preventive - Gemini,7 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,Gemini,Montagne,7 - Preventive - Gemini - Montagne,7 - Preventive - Gemini,1,90,PREVENTIVE,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO 100,,5 - Curative - MOMENTO 100,5 - Curative - MOMENTO 100,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO 100,Montagne,5 - Curative - MOMENTO 100 - Montagne,5 - Curative - MOMENTO 100,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO 100,,7 - Desinstallation - MOMENTO 100,7 - Desinstallation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO 100,Montagne,7 - Desinstallation - MOMENTO 100 - Montagne,7 - Desinstallation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,MOMENTO 100,,7 - Enlevement - MOMENTO 100,7 - Enlevement - MOMENTO 100,1,40,ENLEVEMENT,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO 100,,7 - Installation - MOMENTO 100,7 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO 100,Montagne,7 - Installation - MOMENTO 100 - Montagne,7 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO 100,,8 - Installation - MOMENTO 100,8 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO 100,Montagne,8 - Installation - MOMENTO 100 - Montagne,8 - Installation - MOMENTO 100,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO 100,,3 - Mise a jour - MOMENTO 100,3 - Mise à jour - MOMENTO 100,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO 100,Montagne,3 - Mise a jour - MOMENTO 100 - Montagne,3 - Mise à jour - MOMENTO 100,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO 100,,2 - Preventive - MOMENTO 100,2 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO 100,Montagne,2 - Preventive - MOMENTO 100 - Montagne,2 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO 100,,7 - Preventive - MOMENTO 100,7 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO 100,Montagne,7 - Preventive - MOMENTO 100 - Montagne,7 - Preventive - MOMENTO 100,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO 120,,5 - Curative - MOMENTO 120,5 - Curative - MOMENTO 120,2,121,CURATIVE,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO 120,Montagne,5 - Curative - MOMENTO 120 - Montagne,5 - Curative - MOMENTO 120,2,121,CURATIVE,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO 120,,7 - Desinstallation - MOMENTO 120,7 - Desinstallation - MOMENTO 120,1,90,INSTALLATION,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO 120,Montagne,7 - Desinstallation - MOMENTO 120 - Montagne,7 - Desinstallation - MOMENTO 120,1,90,INSTALLATION,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,MOMENTO 120,Montagne,7 - Enlevement - MOMENTO 120 - Montagne,7 - Enlevement - MOMENTO 120,1,50,ENLEVEMENT,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,MOMENTO 120,,7 - Enlevement - MOMENTO 120,7 - Enlevement - MOMENTO 120,1,50,ENLEVEMENT,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO 120,,8 - Installation - MOMENTO 120,8 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO 120,Montagne,8 - Installation - MOMENTO 120 - Montagne,8 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO 120,Montagne,7 - Installation - MOMENTO 120 - Montagne,7 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO 120,,7 - Installation - MOMENTO 120,7 - Installation - MOMENTO 120,2,179,INSTALLATION,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO 120,,3 - Mise a jour - MOMENTO 120,3 - Mise à jour - MOMENTO 120,1,273,MISE A JOUR,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO 120,Montagne,3 - Mise a jour - MOMENTO 120 - Montagne,3 - Mise à jour - MOMENTO 120,1,273,MISE A JOUR,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO 120,,2 - Preventive - MOMENTO 120,2 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO 120,Montagne,2 - Preventive - MOMENTO 120 - Montagne,2 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO 120,,7 - Preventive - MOMENTO 120,7 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO 120,Montagne,7 - Preventive - MOMENTO 120 - Montagne,7 - Preventive - MOMENTO 120,4,491,PREVENTIVE,MOMENTO MILK,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO 200,,5 - Curative - MOMENTO 200,5 - Curative - MOMENTO 200,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO 200,Montagne,5 - Curative - MOMENTO 200 - Montagne,5 - Curative - MOMENTO 200,1,121,CURATIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO 200,,7 - Desinstallation - MOMENTO 200,7 - Desinstallation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO 200,Montagne,7 - Desinstallation - MOMENTO 200 - Montagne,7 - Desinstallation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,MOMENTO 200,Montagne,7 - Enlevement - MOMENTO 200 - Montagne,7 - Enlevement - MOMENTO 200,1,50,ENLEVEMENT,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,MOMENTO 200,,7 - Enlevement - MOMENTO 200,7 - Enlevement - MOMENTO 200,1,50,ENLEVEMENT,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO 200,,7 - Installation - MOMENTO 200,7 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO 200,Montagne,7 - Installation - MOMENTO 200 - Montagne,7 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO 200,,8 - Installation - MOMENTO 200,8 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO 200,Montagne,8 - Installation - MOMENTO 200 - Montagne,8 - Installation - MOMENTO 200,1,90,INSTALLATION,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO 200,,3 - Mise a jour - MOMENTO 200,3 - Mise à jour - MOMENTO 200,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO 200,Montagne,3 - Mise a jour - MOMENTO 200 - Montagne,3 - Mise à jour - MOMENTO 200,1,273,MISE A JOUR,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO 200,,2 - Preventive - MOMENTO 200,2 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO 200,Montagne,2 - Preventive - MOMENTO 200 - Montagne,2 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO 200,,7 - Preventive - MOMENTO 200,7 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO 200,Montagne,7 - Preventive - MOMENTO 200 - Montagne,7 - Preventive - MOMENTO 200,1,90,PREVENTIVE,MOMENTO,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO BLACK,,5 - Curative - MOMENTO BLACK,5 - Curative - MOMENTO BLACK,1,121,CURATIVE,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,MOMENTO BLACK,Montagne,5 - Curative - MOMENTO BLACK - Montagne,5 - Curative - MOMENTO BLACK,1,121,CURATIVE,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO BLACK,,7 - Desinstallation - MOMENTO BLACK,7 - Desinstallation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,MOMENTO BLACK,Montagne,7 - Desinstallation - MOMENTO BLACK - Montagne,7 - Desinstallation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,MOMENTO BLACK,,7 - Enlevement - MOMENTO BLACK,7 - Enlevement - MOMENTO BLACK,1,40,ENLEVEMENT,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO BLACK,,7 - Installation - MOMENTO BLACK,7 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,MOMENTO BLACK,Montagne,7 - Installation - MOMENTO BLACK - Montagne,7 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO BLACK,,8 - Installation - MOMENTO BLACK,8 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+8,Installation,MOMENTO BLACK,Montagne,8 - Installation - MOMENTO BLACK - Montagne,8 - Installation - MOMENTO BLACK,1,90,INSTALLATION,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO BLACK,,3 - Mise a jour - MOMENTO BLACK,3 - Mise à jour - MOMENTO BLACK,1,273,MISE A JOUR,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+3,Mise a jour,MOMENTO BLACK,Montagne,3 - Mise a jour - MOMENTO BLACK - Montagne,3 - Mise à jour - MOMENTO BLACK,1,273,MISE A JOUR,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO BLACK,,2 - Preventive - MOMENTO BLACK,2 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,MOMENTO BLACK,Montagne,2 - Preventive - MOMENTO BLACK - Montagne,2 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO BLACK,,7 - Preventive - MOMENTO BLACK,7 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,MOMENTO BLACK,Montagne,7 - Preventive - MOMENTO BLACK - Montagne,7 - Preventive - MOMENTO BLACK,1,90,PREVENTIVE,MOMENTO BLACK,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,Zenius,,5 - Curative - Zenius,5 - Curative - Zenius,1,121,CURATIVE,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+5,Curative,Zenius,Montagne,5 - Curative - Zenius - Montagne,5 - Curative - Zenius,1,121,CURATIVE,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Zenius,,7 - Desinstallation - Zenius,7 - Desinstallation - Zenius,1,90,INSTALLATION,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Desinstallation,Zenius,Montagne,7 - Desinstallation - Zenius - Montagne,7 - Desinstallation - Zenius,1,90,INSTALLATION,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,Zenius,,7 - Enlevement - Zenius,7 - Enlevement - Zenius,1,40,ENLEVEMENT,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Installation,Zenius,,7 - Installation - Zenius,7 - Installation - Zenius,1,90,INSTALLATION,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,Zenius,,2 - Preventive - Zenius,2 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+2,Preventive,Zenius,Montagne,2 - Preventive - Zenius - Montagne,2 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,Zenius,,7 - Preventive - Zenius,7 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Preventive,Zenius,Montagne,7 - Preventive - Zenius - Montagne,7 - Preventive - Zenius,1,90,PREVENTIVE,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,Zenius,Montagne,7 - Enlevement - Zenius - Montagne,7 - Enlevement - Zenius,1,40,ENLEVEMENT,ZENIUS,TRANSPORTABLE,2000-01-01,9999-12-31
+7,Enlevement,Gemini,Montagne,7 - Enlevement - Gemini - Montagne,7 - Enlevement - Gemini,1,40,ENLEVEMENT,GEMINI,TRANSPORTABLE,2000-01-01,9999-12-31

--- a/docs/apptech_etat_du_chantier.md
+++ b/docs/apptech_etat_du_chantier.md
@@ -8,7 +8,8 @@ Périmètre couvert : app Suivi Tech (`evs-suivi-tech`) → flux NDJSON GCS →
 staging/intermediate apptech → marts technique (facturation retraitée, primes,
 facturation NESPRESSO).
 
-Dernière mise à jour : 2026-08-07 (DE).
+Dernière mise à jour : 2026-08-07 (DE) — étapes 1 et 2 du chantier facturation
+NESPRESSO livrées, cf. § 3.
 
 ---
 
@@ -44,8 +45,9 @@ Validation prod du 2026-08-04 : 93 897 lignes, 118 retraitées, 0 orphelin,
 |---|---|---|---|
 | Rebuild auto de la chaîne apptech (Cloud Run Job du bouton « Build », ou build planifié `tag:apptech`) | DE | — | à faire — **bloque la fraîcheur prod** |
 | Snapshot daté du mart retraitée (append + `build_ts`) | DE | — | décidé, non codé |
-| Propager `agency` (Nomad) dans `int_nesp_tech__facturation_interventions` → fait → mart, et filtrer `nespresso sud` au dédup | DE | — | **PR #201 ouverte** 2026-08-07 |
-| Seed `ref_nesp_tech__key_facturation` versionné `valid_from`/`valid_to` (patron `ref_yuman__tarification_clean`) + 2 variantes Montagne manquantes (`Enlevement` Zenius/Gemini) | DE | — | à faire |
+| ~~Propager `agency` (Nomad) jusqu'aux marts, et filtrer `nespresso sud` au dédup~~ | DE | — | ✅ **PR #201 mergée** 2026-08-07 (`5d4835ad`), `cd` vert, prod vérifiée (4 agences, sous-traitant absent) |
+| ~~Seed `ref_nesp_tech__key_facturation` versionné `valid_from`/`valid_to` + 2 variantes Montagne manquantes~~ | DE | — | ✅ fait 2026-08-07, branche `feature/tarifs-nesp-versionnes` (`9f58127c`), PR à ouvrir |
+| Récupérer les **générations tarifaires réelles** auprès du manager (bascule 2021 → 2024, date contractuelle du tarif Enlèvement) et les charger dans le seed | DE + métier | réponse métier | à faire — le mécanisme est en place, seules les dates manquent |
 | `int_nesp_tech__facturation_rw_credits` (crédit négatif) | DE | — | **débloqué** (cf. § 4, contrat RW vérifié) |
 | Test dbt sur le contrat RW (le flux ne contient que des décisions confirmées, par convention app et non par colonne — un test garde-fou vaut mieux qu'une hypothèse tacite) | DE | — | à faire avec le crédit RW |
 | Coupe-circuit bonus par agence (modèle intermediate dédié pour le taux RW, sinon cycle dbt) — **filet de sécurité, jamais déclenché à ce jour** (max mesuré 1,11 % vs seuil 2,5 %) | DE | — | priorité basse |
@@ -77,6 +79,8 @@ Ne pas rouvrir sans raison nouvelle. Source = document de décision d'origine.
 | **Le bonus dbt et le bonus « règle Excel » désignent la même population** — pas d'écart à corriger. `delai_jours_fin <= 2` vaut `type_delai_fin IN ('J+0','J+1')` (le libellé est décalé d'un cran : `<= 1` → J+0), et `code_machine not like 'ag%'` ne laisse en pratique que `Transportable` + `Momento`. Mesuré sur tout 2026 : 6 852 interventions, populations identiques cellule par cellule. Seul le coupe-circuit agence manque | 2026-08-07 | mesuré, remplace facturation § 5.1 |
 | **Le flux `/rw` ne contient que des décisions confirmées** : `app/domain/rw.py:80` écarte tout `pole_expertise_RW != 'OUI'`, et `submit_rw` n'écrit que les lignes retrouvées en BigQuery. Volume conforme (12 lignes pour 2026-05 = les 12 confirmées de la facture de juillet). Contrat **par convention, pas par colonne** → à couvrir par un test dbt | 2026-08-07 | code app + données |
 | **Agence de facturation = `agency` (Nomad)**, pas `tech_secteur`. Les 4 valeurs (`evs`, `evs idf`, `evs paris`, `evs paris 2`) correspondent aux 4 libellés Excel — le TCD Excel est bâti sur l'export Nomad, c'est la même donnée. `tech_secteur` (5 valeurs, dont `evs est` absent de la grille) recouvre plusieurs agences et ne peut pas servir de dimension de facturation | 2026-08-07 | mesuré sur juillet 2026, 1 956 interventions |
+| **La grille tarifaire NESP est versionnée dans le temps** (`valid_from`/`valid_to` sur `ref_nesp_tech__key_facturation`, jointure sur `date(date_heure_fin, 'Europe/Paris')`, patron `ref_yuman__tarification_clean`), avec un garde-fou anti-chevauchement. Une seule génération chargée, plancher `2000-01-01` : le mécanisme existe, le comportement ne change pas. **Les dates réelles ne sont pas inventées** — le point DA situe la création du tarif Enlèvement « courant 2026 », or il se résout dans les données depuis **juillet 2025** (1 en Q3 2025, 41 en Q4, puis 45/54/25) : le dater de 2026 aurait retiré son tarif à 42 interventions de 2025 | 2026-08-07 | mesuré, corrige facturation § 5.9 |
+| **Variantes Montagne de la clé Enlèvement (Zenius, Gemini) au même tarif que la ligne non-montagne (40 €)** — seul précédent du seed : pour l'Enlèvement la Montagne est tarifairement neutre (MOMENTO 120 et 200 à 50 € dans les deux variantes). Répare 4 interventions qui n'avaient aucun tarif. Hypothèse tarifaire, à confirmer par le métier | 2026-08-07 | branche `feature/tarifs-nesp-versionnes` |
 | **`nespresso sud` est exclu de toute la chaîne NESP, filtré au dédup** (point unique). C'est un sous-traitant, pas une agence EVS : ses 643 interventions (27/10 → 27/12/2025, flux éteint) sont faites par 7 techniciens dont **aucun** n'existe au référentiel EVS, là où les 4 agences EVS en résolvent 100 %. Avant, la divergence des filtres entre modèles laissait ces lignes à moitié enrichies dans le fait (montant renseigné, délais/bonus/technicien NULL). Impact : le fait perd 643 lignes, l'alerting Aguila 8, le mart commerce 0 | 2026-08-07 | décision user, PR #201 |
 | Mini-prev et Enlèvement : tarifs **déjà corrects**, rien à construire | 2026-08-06 | facturation § 5.3 / 5.8 |
 | Hors périmètre : majoration T3 Dispenser, barème de primes de l'onglet Excel `Paramètres` | 2026-08-05/06 | facturation § 5.4 / 5.10 |
@@ -95,6 +99,8 @@ dans un paragraphe.
 |---|---|---|
 | Le libellé « **EVS AURA** » de la grille Excel correspond-il bien à `agency = 'evs'`, qui contient aussi l'activité du secteur **EST** (juillet 2026 : 297 interventions, 50 234 €) ? Si le métier veut un jour EST en ligne séparée, la donnée le permet (`tech_secteur`), la grille Excel non | métier | ouverte — n'empêche pas de coder |
 | La compta / Sage attend-elle l'imputation du crédit RW au mois d'**origine** ? Et l'écart de méthode est-il acceptable : recalculé au tarif courant, le crédit de mai 2026 vaut **2 429 €** contre **2 158 €** facturés dans l'Excel, soit **+271 € (+12,6 %)** sur 12 lignes | métier | ouverte — chiffrée |
+| **Générations tarifaires** : à quelle date la grille est-elle passée de 2021 à 2024, et depuis quand le tarif Enlèvement est-il contractuel ? Sans ces dates, tout mois passé est recalculé au tarif courant. Ne pas deviner : une date fausse déplacerait des montants facturés sans que personne ne le voie | métier | ouverte |
+| **Tarif Montagne de l'Enlèvement** (Zenius, Gemini) : 40 € comme la variante non-montagne, par analogie avec MOMENTO ? | métier | ouverte |
 | Les 2 techniciens fictifs d'astreinte (`ASTREINTE Aura`/`ASTREINTE IDF`, `is_active = false`) portent bien des interventions VALIDATED (4 en juillet 2026) : le transfert symétrique de prod est donc nécessaire, comme prévu. Reste à confirmer s'ils doivent apparaître comme lignes du mart Primes ou en être exclus | DA / métier | ouverte |
 | Mapping MEE / modif_intervention → OUI/NON : à valider sur un mois réel complet (échantillon bêta jusqu'ici) avant facturation réelle | DA | ouverte |
 | `rw_neshu` : libellés et options de décision à figer avant ingestion | DA | ouverte |

--- a/models/intermediate/nesp_tech/int_nesp_tech__facturation_interventions.sql
+++ b/models/intermediate/nesp_tech/int_nesp_tech__facturation_interventions.sql
@@ -111,9 +111,23 @@ final as (
         kf.prod_factu,
         kf.tarif_factu
     from joined as j
+    -- Tarif en vigueur À LA DATE DE L'INTERVENTION, et non tarif courant : la
+    -- grille Nespresso a déjà changé au moins une fois (générations 2021 / 2024,
+    -- cf. onglet Paramètres du classeur de facturation), et un tarif unique par
+    -- clé interdisait de recalculer une facture d'un mois passé. Même patron que
+    -- `ref_yuman__tarification_clean` / `int_yuman__interventions`.
     left join {{ ref('ref_nesp_tech__key_facturation') }} as kf
-        on j.key_factu = kf.key_ref_inter
+        on
+            j.key_factu = kf.key_ref_inter
+            and date(j.date_heure_fin, 'Europe/Paris') between kf.valid_from and kf.valid_to
     where j.rn = 1
+    -- Garde-fou : deux générations qui se chevaucheraient dupliqueraient
+    -- l'intervention et casseraient le grain (1 ligne par n_planning) jusque
+    -- dans le fait. On garde la génération la plus récente qui couvre la date.
+    qualify row_number() over (
+        partition by j.n_planning
+        order by kf.valid_from desc nulls last
+    ) = 1
 )
 
 select


### PR DESCRIPTION
## Pourquoi

`ref_nesp_tech__key_facturation` ne portait qu'**un tarif courant par clé**, ce qui interdit
de recalculer une facture d'un mois passé : la grille Nespresso a déjà changé au moins une
fois (générations 2021 et 2024, cf. onglet `Paramètres` du classeur de facturation du
manager technique) et le tarif Enlèvement s'est ajouté plus tard. Sans versionnement, un
recalcul de juillet 2024 utiliserait la grille d'aujourd'hui.

Étape 2 du chantier facturation mensuelle NESPRESSO (suite de #201). Contexte et suivi :
`docs/apptech_etat_du_chantier.md`.

## Ce que fait la PR

Le patron **déjà en place dans ce repo** pour Yuman (`ref_yuman__tarification_clean` /
`int_yuman__interventions`), transposé à la grille Nespresso :

- seed : colonnes `valid_from` / `valid_to` (typées `DATE`) sur les 138 lignes ;
- `int_nesp_tech__facturation_interventions` : jointure du tarif sur
  `date(date_heure_fin, 'Europe/Paris') between kf.valid_from and kf.valid_to` ;
- **garde-fou anti-fan-out** : `qualify row_number() over (partition by n_planning order by
  valid_from desc)` — deux générations qui se chevaucheraient dupliqueraient l'intervention
  et casseraient le grain (1 ligne par `n_planning`) jusque dans le fait ;
- `key_ref_inter` perd son test `unique` au profit d'une clé composite
  (`key_ref_inter`, `valid_from`) : le test serait devenu faux dès la 2e génération.

**Une seule génération chargée**, plancher `2000-01-01` → `9999-12-31` : le mécanisme
existe, le comportement ne change pas.

## Les dates réelles ne sont pas inventées

Le point de cadrage du DA situe la création du tarif Enlèvement « courant 2026 » et demande
qu'il ne s'applique pas rétroactivement. Les données disent autre chose : ce type se résout
**depuis juillet 2025** — 1 en Q3 2025, 41 en Q4 2025, puis 45, 54, 25. Le dater de 2026
aurait retiré son tarif à **42 interventions de 2025**.

Un plancher conventionnel est donc plus honnête qu'une date plausible : une date fausse
déplacerait des montants facturés sans que personne ne le voie. Les générations réelles
(bascule 2021 → 2024, date contractuelle de l'Enlèvement) restent à obtenir du manager —
c'est une évolution du seed, pas du code.

## Correction annexe

Les 2 variantes Montagne manquantes de la clé Enlèvement (`Zenius`, `Gemini`), au **même
tarif que leur ligne non-montagne (40 €)**, conformément au seul précédent du seed : pour
l'Enlèvement, la Montagne est tarifairement neutre (MOMENTO 120 et 200 sont à 50 € dans les
deux variantes). ⚠️ Hypothèse tarifaire, à confirmer par le métier.

## Non-régression

Sur les **74 389 interventions communes** dev / prod :

| Contrôle | Résultat |
|---|---|
| Tarifs perdus | **0** |
| Clés de facturation modifiées | **0** |
| Tarifs réparés | **4** — 3 `Enlevement Zenius Montagne` + 1 `Enlevement Gemini Montagne`, de NULL à 40 € |

Vérifié aussi qu'**aucune intervention facturable n'a de `date_heure_fin` NULL** (0 sur
74 836) : la nouvelle jointure sur date ne peut donc pas perdre de ligne.

Build dev vert : 36 PASS, 0 warning, 0 erreur. SQLFluff propre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
